### PR TITLE
Use the OS independent "rimraf" to remove dist folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "del": "^5.1.0",
         "mocha": "^7.2.0",
         "nodemon": "^2.0.4",
+        "rimraf": "^3.0.2",
         "source-map-support": "^0.5.19",
         "ts-loader": "^6.2.2",
         "ts-node": "^8.10.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
-    "clean": "rm -rf ./dist",
+    "clean": "rimraf dist/",
     "build": "webpack",
     "test": "mocha --opts mocha.opts",
     "test:watch": "mocha --opts mocha.opts --watch",
@@ -39,6 +39,7 @@
     "del": "^5.1.0",
     "mocha": "^7.2.0",
     "nodemon": "^2.0.4",
+    "rimraf": "^3.0.2",
     "source-map-support": "^0.5.19",
     "ts-loader": "^6.2.2",
     "ts-node": "^8.10.2",


### PR DESCRIPTION
The current technique ("clean": "rm -rf ./dist") does not work on Windows