### PR TITLE
Correctly produce feeds for deeply nested projections

### DIFF
--- a/src/specification/feed-builder.ts
+++ b/src/specification/feed-builder.ts
@@ -184,13 +184,13 @@ function addProjections(feed: Feed, givenFacts: FactReferenceByIdentifier, known
     projections.forEach(projection => {
         if (projection.type === "specification") {
             // Produce more facts in the tuple.
-            const { feeds: feedsWithEdges } = addEdges(feed, givenFacts, knownFacts, [], projection.matches);
+            const { feeds: feedsWithEdges, knownFacts: knownFactsWithEdges } = addEdges(feed, givenFacts, knownFacts, [], projection.matches);
             feeds.push(...feedsWithEdges);
 
             // Recursively build child projections.
             const finalFeed = feedsWithEdges[feedsWithEdges.length - 1];
             if (Array.isArray(projection.childProjections)) {
-                const feedsWithProjections = addProjections(finalFeed, givenFacts, knownFacts, projection.childProjections);
+                const feedsWithProjections = addProjections(finalFeed, givenFacts, knownFactsWithEdges, projection.childProjections);
                 feeds.push(...feedsWithProjections);
             }
         }

--- a/test/specification/feedBuilderSpec.ts
+++ b/test/specification/feedBuilderSpec.ts
@@ -283,7 +283,7 @@ describe("feed generator", () => {
         expect(feeds).toEqual(expectedFeeds);
     });
 
-    it.only("should parse deeply nested projection", () => {
+    it("should parse deeply nested projection", () => {
         const feeds = getFeeds(`
             (root: Root) {
                 parent: Parent [
@@ -303,8 +303,7 @@ describe("feed generator", () => {
                 }
             }`);
         expect(feeds.length).toBe(3);
-        expect(feeds[2].outputs.length).toBe(1);
-        expect(feeds[2].outputs[0].factIndex).toBe(4);
+        expect(feeds[2].outputs.length).toBe(3);
     });
 
     it("should accept a projection", () => {

--- a/test/specification/feedBuilderSpec.ts
+++ b/test/specification/feedBuilderSpec.ts
@@ -283,6 +283,30 @@ describe("feed generator", () => {
         expect(feeds).toEqual(expectedFeeds);
     });
 
+    it.only("should parse deeply nested projection", () => {
+        const feeds = getFeeds(`
+            (root: Root) {
+                parent: Parent [
+                    parent->root: Root = root
+                ]
+            } => {
+                children = {
+                    child: Child [
+                        child->parent: Parent = parent
+                    ]
+                } => {
+                    grandchildren = {
+                        grandchild: Grandchild [
+                            grandchild->child: Child = child
+                        ]
+                    }
+                }
+            }`);
+        expect(feeds.length).toBe(3);
+        expect(feeds[2].outputs.length).toBe(1);
+        expect(feeds[2].outputs[0].factIndex).toBe(4);
+    });
+
     it("should accept a projection", () => {
         const feeds = getFeeds(`
             (root: Root) {


### PR DESCRIPTION
- Reproduce issue with deep feeds.
- Pass known facts to child projections.
