### PR TITLE
Optimize loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ To release a new version of Jinaga.JS, bump the version number, create and push 
 and create a release. The GitHub Actions workflow will build and publish the package.
 
 ```bash
+git c main
+git pull
 npm version patch
 git push --follow-tags
 gh release create v$(node -p "require('./package.json').version") --generate-notes --verify-tag

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# The parameter must be patch, minor or major
+if [ "$1" != "patch" ] && [ "$1" != "minor" ] && [ "$1" != "major" ]; then
+  echo "Usage: $0 [patch|minor|major]"
+  exit 1
+fi
+
+git c main
+git pull
+npm version $1
+git push --follow-tags
+gh release create v$(node -p "require('./package.json').version") --generate-notes --verify-tag

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -192,6 +192,7 @@ export class Jinaga {
             this.validateFact(fact);
             return dehydrateReference(fact);
         });
+        await this.factManager.fetch(references, innerSpecification);
         const projectedResults = await this.factManager.read(references, innerSpecification);
         return extractResults(projectedResults, innerSpecification.projection);
     }
@@ -285,9 +286,7 @@ export class Jinaga {
             return dehydrateReference(fact);
         });
 
-        const observer = new ObserverImpl<U>(this.factManager, references, innerSpecification, resultAdded);
-        observer.start();
-        return observer;
+        return this.factManager.startObserver<U>(references, innerSpecification, resultAdded);
     }
 
     /**

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -59,6 +59,9 @@ export class ObserverImpl<T> {
 
     public start() {
         this.initialQuery = this.runInitialQuery();
+    }
+
+    private addSpecificationListeners() {
         const inverses: SpecificationInverse[] = invertSpecification(this.specification);
         const listeners = inverses.map(inverse => this.factManager.addSpecificationListener(
             inverse.inverseSpecification,
@@ -83,6 +86,7 @@ export class ObserverImpl<T> {
 
     private async runInitialQuery() {
         const projectedResults = await this.factManager.read(this.given, this.specification);
+        this.addSpecificationListeners();
         const givenSubset = this.specification.given.map(g => g.name);
         await this.notifyAdded(projectedResults, this.specification.projection, "", givenSubset);
     }


### PR DESCRIPTION
- Release script
- Don't add listeners until the results are back.
- On subsequent watches, resolve before fetching
