### PR TITLE
Don't retry when there is no persistent client-side storage

### DIFF
--- a/src/http/web-client.ts
+++ b/src/http/web-client.ts
@@ -66,23 +66,45 @@ export class WebClient {
     }
 
     async query(query: QueryMessage) {
+        return <QueryResponse> await this.post('/query', query);
+    }
+
+    async queryWithRetry(query: QueryMessage) {
         return <QueryResponse> await this.postWithLimitedRetry('/query', query);
     }
 
     async save(save: SaveMessage) {
+        await this.post('/save', save);
+    }
+
+    async saveWithRetry(save: SaveMessage) {
         await this.postWithInfiniteRetry('/save', save);
     }
 
     async load(load: LoadMessage) {
+        return <LoadResponse> await this.post('/load', load);
+    }
+
+    async loadWithRetry(load: LoadMessage) {
         return <LoadResponse> await this.postWithLimitedRetry('/load', load);
     }
 
     async feeds(request: string): Promise<FeedsResponse> {
-        return <FeedsResponse> await this.postWithLimitedRetry('/feeds', request);
+        return <FeedsResponse> await this.post('/feeds', request);
     }
 
     async feed(feed: string, bookmark: string): Promise<FeedResponse> {
         return <FeedResponse> await this.httpConnection.get(`/feeds/${feed}?b=${bookmark}`);
+    }
+
+    private async post(path: string, body: {} | string) {
+        const response = await this.httpConnection.post(path, body, this.config.timeoutSeconds);
+        if (response.result === 'success') {
+            return response.response;
+        }
+        else {
+            throw new Error(response.error);
+        }
     }
 
     private async postWithLimitedRetry(path: string, body: {} | string) {

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -32,7 +32,7 @@ export class JinagaBrowser {
         const observableSource = new ObservableSource(store);
         const syncStatusNotifier = new SyncStatusNotifier();
         const fork = createFork(config, store, syncStatusNotifier);
-        const authentication = createAuthentication(config, store, syncStatusNotifier);
+        const authentication = createAuthentication(config, syncStatusNotifier);
         const network = createNetwork(config, syncStatusNotifier);
         const factManager = new FactManager(authentication, fork, observableSource, store, network);
         return new Jinaga(factManager, syncStatusNotifier);
@@ -62,6 +62,7 @@ function createFork(
         if (config.indexedDb) {
             const queue = new IndexedDBQueue(config.indexedDb);
             const fork = new PersistentFork(store, queue, webClient);
+            fork.initialize();
             return fork;
         }
         else {
@@ -77,7 +78,6 @@ function createFork(
 
 function createAuthentication(
     config: JinagaBrowserConfig,
-    store: Storage,
     syncStatusNotifier: SyncStatusNotifier
 ): Authentication {
     if (config.httpEndpoint) {
@@ -87,11 +87,8 @@ function createAuthentication(
             timeoutSeconds: httpTimeoutSeconds
         });
         if (config.indexedDb) {
-            const queue = new IndexedDBQueue(config.indexedDb);
-            const fork = new PersistentFork(store, queue, webClient);
             const loginStore = new IndexedDBLoginStore(config.indexedDb);
             const authentication = new AuthenticationOffline(loginStore, webClient);
-            fork.initialize();
             return authentication;
         }
         else {


### PR DESCRIPTION
- Removed duplicate fork creation
- Remove the redundant WebClient construction
- Do not retry from transient fork
