### PR TITLE
Serialize Authorization Rules

### DIFF
--- a/src/authorization/authorizationRules.ts
+++ b/src/authorization/authorizationRules.ts
@@ -399,8 +399,12 @@ export class AuthorizationRules {
         }
 
         const graph = new FactGraph(factRecords);
-        const results = await mapAsync(rules, async r =>
-            await r.isAuthorized(userFact, fact, graph, store));
-        return results.some(b => b);
+        for (const rule of rules) {
+            const authorized = await rule.isAuthorized(userFact, fact, graph, store);
+            if (authorized) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/authorization/authorizationRules.ts
+++ b/src/authorization/authorizationRules.ts
@@ -444,3 +444,8 @@ export class AuthorizationRules {
         throw new Error('Not implemented.');
     }
 }
+
+export function describeAuthorizationRules(model: Model, authorization: (a: AuthorizationRules) => AuthorizationRules) {
+    const rules = authorization(new AuthorizationRules(model));
+    return rules.saveToDescription();
+}

--- a/src/authorization/authorizationRules.ts
+++ b/src/authorization/authorizationRules.ts
@@ -1,12 +1,13 @@
 import { getPredecessors } from '../memory/memory-store';
-import { User, Device } from '../model/user';
+import { Device, User } from '../model/user';
 import { Query } from '../query/query';
 import { Preposition } from '../query/query-parser';
 import { Direction, Join, PropertyCondition, Step } from '../query/steps';
+import { describeSpecification } from '../specification/description';
 import { FactConstructor, FactRepository, LabelOf, Model, Traversal, getPayload } from '../specification/model';
 import { Condition, Label, Match, PathCondition, Specification, splitBeforeFirstSuccessor } from '../specification/specification';
-import { FactRecord, FactReference, factReferenceEquals, ReferencesByName, Storage } from '../storage';
-import { findIndex, flatten, flattenAsync, mapAsync } from '../util/fn';
+import { FactRecord, FactReference, ReferencesByName, Storage, factReferenceEquals } from '../storage';
+import { findIndex, flatten, flattenAsync } from '../util/fn';
 import { Trace } from '../util/trace';
 
 class FactGraph {
@@ -157,16 +158,25 @@ function headStep(step: Step) {
 }
 
 interface AuthorizationRule {
+    describe(type: string): string;
     isAuthorized(userFact: FactReference | null, fact: FactRecord, graph: FactGraph, store: Storage): Promise<boolean>;
 }
 
 class AuthorizationRuleAny implements AuthorizationRule {
+    describe(type: string) {
+        return `    any ${type}\n`;
+    }
+
     isAuthorized(userFact: FactReference | null, fact: FactRecord, graph: FactGraph, store: Storage) {
         return Promise.resolve(true);
     }
 }
 
 class AuthorizationRuleNone implements AuthorizationRule {
+    describe(type: string) {
+        return `    no ${type}\n`;
+    }
+
     isAuthorized(userFact: FactReference | null, fact: FactRecord, graph: FactGraph, store: Storage): Promise<boolean> {
         Trace.warn(`No fact of type ${fact.type} is authorized.`);
         return Promise.resolve(false);
@@ -179,6 +189,10 @@ class AuthorizationRuleQuery implements AuthorizationRule {
         private tail: Query | null
     ) {
 
+    }
+
+    describe(type: string): string {
+        throw new Error("Authorization rules must be based on specifications, not template functions.");
     }
 
     async isAuthorized(userFact: FactReference | null, fact: FactRecord, graph: FactGraph, store: Storage) {
@@ -216,6 +230,11 @@ class AuthorizationRuleSpecification implements AuthorizationRule {
     constructor(
         private specification: Specification
     ) { }
+
+    describe(type: string): string {
+        const description = describeSpecification(this.specification, 1);
+        return description;
+    }
 
     async isAuthorized(userFact: FactReference | null, fact: FactRecord, graph: FactGraph, store: Storage): Promise<boolean> {
         if (!userFact) {
@@ -406,5 +425,22 @@ export class AuthorizationRules {
             }
         }
         return false;
+    }
+
+    saveToDescription(): string {
+        var description = 'authorization {\n';
+        for (const type in this.rulesByType) {
+            const rules = this.rulesByType[type];
+            for (const rule of rules) {
+                const ruleDescription = rule.describe(type);
+                description += ruleDescription;
+            }
+        }
+        description += '}\n';
+        return description;
+    }
+
+    static loadFromDescription(description: string): AuthorizationRules {
+        throw new Error('Not implemented.');
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { AuthenticationNoOp } from './authentication/authentication-noop';
 export { Authorization } from './authorization/authorization';
 export { AuthorizationEngine, Forbidden } from './authorization/authorization-engine';
 export { AuthorizationNoOp } from "./authorization/authorization-noop";
-export { AuthorizationRules } from "./authorization/authorizationRules";
+export { AuthorizationRules, describeAuthorizationRules } from "./authorization/authorizationRules";
 export { DistributionEngine } from './distribution/distribution-engine';
 export { DistributionRules } from './distribution/distribution-rules';
 export { canonicalPredecessors, canonicalizeFact, computeHash, computeObjectHash } from './fact/hash';

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -121,7 +121,6 @@ class LoadBatch {
             this.reject = reject;
         });
         this.timeout = setTimeout(() => {
-            Trace.info('Trigger batch on timeout');
             this.run();
             this.onRun();
         }, 100);
@@ -198,7 +197,6 @@ export class NetworkManager {
                 const { references: factReferences, bookmark: nextBookmark } = await this.network.fetchFeed(feed, bookmark);
 
                 if (factReferences.length === 0) {
-                    Trace.info('End of feed');
                     break;
                 }
 
@@ -208,7 +206,6 @@ export class NetworkManager {
                     let batch = this.currentBatch;
                     if (batch === null) {
                         // Begin a new batch.
-                        Trace.info('Begin batch');
                         batch = new LoadBatch(this.network, this.store, this.notifyFactsAdded, () => {
                             if (this.currentBatch === batch) {
                                 this.currentBatch = null;
@@ -222,7 +219,6 @@ export class NetworkManager {
                     decremented = true;
                     if (this.fectchCount === 0) {
                         // This is the last fetch, so trigger the batch.
-                        Trace.info('Trigger batch on last fetch');
                         batch.trigger();
                     }
                     await batch.completed;
@@ -237,7 +233,6 @@ export class NetworkManager {
                     Trace.metric('Fetch aborted', { fectchCount: this.fectchCount });
                     if (this.fectchCount === 0 && this.currentBatch !== null) {
                         // This is the last fetch, so trigger the batch.
-                        Trace.info('Trigger batch on last fetch');
                         this.currentBatch.trigger();
                     }
                 }

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -3,9 +3,8 @@ import { computeObjectHash } from "../fact/hash";
 import { FeedResponse } from "../http/messages";
 import { Feed } from "../specification/feed";
 import { buildFeeds } from "../specification/feed-builder";
-import { Specification } from "../specification/specification";
+import { reduceSpecification, Specification } from "../specification/specification";
 import { FactEnvelope, FactReference, factReferenceEquals, Storage } from "../storage";
-import { Trace } from "../util/trace";
 
 export interface Network {
     feeds(start: FactReference[], specification: Specification): Promise<string[]>;
@@ -170,7 +169,8 @@ export class NetworkManager {
     ) { }
 
     async fetch(start: FactReference[], specification: Specification) {
-        const feeds: string[] = await this.network.feeds(start, specification);
+        const reducedSpecification = reduceSpecification(specification);
+        const feeds: string[] = await this.network.feeds(start, reducedSpecification);
 
         // Fork to fetch from each feed.
         const promises = feeds.map(feed => {

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -191,7 +191,6 @@ export class NetworkManager {
 
         while (true) {
             this.fectchCount++;
-            Trace.metric('Fetch begin', { fectchCount: this.fectchCount });
             let decremented = false;
             try {
                 const { references: factReferences, bookmark: nextBookmark } = await this.network.fetchFeed(feed, bookmark);
@@ -215,7 +214,6 @@ export class NetworkManager {
                     }
                     batch.add(unknownFactReferences);
                     this.fectchCount--;
-                    Trace.metric('Fetch end', { fectchCount: this.fectchCount });
                     decremented = true;
                     if (this.fectchCount === 0) {
                         // This is the last fetch, so trigger the batch.
@@ -230,7 +228,6 @@ export class NetworkManager {
             finally {
                 if (!decremented) {
                     this.fectchCount--;
-                    Trace.metric('Fetch aborted', { fectchCount: this.fectchCount });
                     if (this.fectchCount === 0 && this.currentBatch !== null) {
                         // This is the last fetch, so trigger the batch.
                         this.currentBatch.trigger();

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -170,7 +170,6 @@ export class ObserverImpl<T> implements Observer<T> {
             // Don't call result added if we have already called it for this tuple.
             if (resultAdded && this.notifiedTuples.has(tupleHash) === false) {
                 const types = Object.values(pr.tuple).map(t => t.type).join(', ');
-                Trace.info(`Observer: Added ${types} ${path}`);
 
                 const promiseMaybe = resultAdded(result);
                 this.notifiedTuples.add(tupleHash);
@@ -209,7 +208,6 @@ export class ObserverImpl<T> implements Observer<T> {
             const removal = this.removalsByTuple[resultTupleHash];
             if (removal !== undefined) {
                 const types = Object.values(pr.tuple).map(t => t.type).join(', ');
-                Trace.info(`Observer: Removed ${types}`);
                 await removal();
                 delete this.removalsByTuple[resultTupleHash];
 

--- a/src/specification/specification.ts
+++ b/src/specification/specification.ts
@@ -356,4 +356,44 @@ export function specificationIsIdentity(specification: Specification) {
         )
     );
 }
-  
+
+export function reduceSpecification(specification: Specification): Specification {
+    // Remove all projections except for specification projections.
+    return {
+        given: specification.given,
+        matches: specification.matches,
+        projection: reduceProjection(specification.projection)
+    };
+}
+
+function reduceProjection(projection: Projection): Projection {
+    if (projection.type === "composite") {
+        const reducedComponents = projection.components
+            .map(reduceComponent)
+            .filter((component): component is NamedComponentProjection => component !== null);
+        return {
+            type: "composite",
+            components: reducedComponents
+        };
+    }
+    else {
+        return {
+            type: "composite",
+            components: []
+        };
+    }
+}
+
+function reduceComponent(component: NamedComponentProjection): NamedComponentProjection | null {
+    if (component.type === "specification") {
+        return {
+            type: "specification",
+            name: component.name,
+            matches: component.matches,
+            projection: reduceProjection(component.projection)
+        };
+    }
+    else {
+        return null;
+    }
+}

--- a/test/authorization/authorizationSpecificationSpec.ts
+++ b/test/authorization/authorizationSpecificationSpec.ts
@@ -1,4 +1,4 @@
-import { AuthorizationRules, buildModel, Jinaga, JinagaTest } from '../../src';
+import { AuthorizationRules, buildModel, Jinaga, JinagaTest, describeAuthorizationRules } from '../../src';
 
 describe("Feedback authorization from specification", () => {
   describe("as a user", () => {
@@ -139,14 +139,12 @@ describe("Feedback authorization from specification", () => {
 
 describe("Authorization rules description", () => {
   it("should be able to save authorization rules", () => {
-    const rules = authorization(new AuthorizationRules(model));
-    const description = rules.saveToDescription();
+    const description = describeAuthorizationRules(model, authorization);
     expect(description).not.toBeNull();
   });
 
   it.todo("should be able to load authorization rules", () => {
-    const rules = authorization(new AuthorizationRules(model));
-    const description = rules.saveToDescription();
+    const description = describeAuthorizationRules(model, authorization);
     const loaded = AuthorizationRules.loadFromDescription(description);
     expect(loaded.hasRule(Content.Type)).toBeTruthy();
   });

--- a/test/authorization/authorizationSpecificationSpec.ts
+++ b/test/authorization/authorizationSpecificationSpec.ts
@@ -143,7 +143,7 @@ describe("Authorization rules description", () => {
     expect(description).not.toBeNull();
   });
 
-  it.todo("should be able to load authorization rules", () => {
+  it.skip("should be able to load authorization rules", () => {
     const description = describeAuthorizationRules(model, authorization);
     const loaded = AuthorizationRules.loadFromDescription(description);
     expect(loaded.hasRule(Content.Type)).toBeTruthy();

--- a/test/authorization/authorizationSpecificationSpec.ts
+++ b/test/authorization/authorizationSpecificationSpec.ts
@@ -137,6 +137,21 @@ describe("Feedback authorization from specification", () => {
   });
 });
 
+describe("Authorization rules description", () => {
+  it("should be able to save authorization rules", () => {
+    const rules = authorization(new AuthorizationRules(model));
+    const description = rules.saveToDescription();
+    expect(description).not.toBeNull();
+  });
+
+  it.todo("should be able to load authorization rules", () => {
+    const rules = authorization(new AuthorizationRules(model));
+    const description = rules.saveToDescription();
+    const loaded = AuthorizationRules.loadFromDescription(description);
+    expect(loaded.hasRule(Content.Type)).toBeTruthy();
+  });
+});
+
 class User {
   static Type = "Jinaga.User" as const;
   type = User.Type;


### PR DESCRIPTION
Generate text form of authorization rules in preparation for uploading.

- Remove noisy traces
- Remove slightly chatty traces
- Reduce the specification before fetching feeds
- Cache feeds by specification
- Short circuit authorization rules as soon as authorized
- Describe authorization rules
- Export function to describe authorization rules
