### PR TITLE
Simplify join syntax

### DIFF
--- a/documentation/successors.md
+++ b/documentation/successors.md
@@ -1,0 +1,58 @@
+# Querying for `successors`
+
+As an alternative to the `join` method, you can use the `successors` method to query for facts that are successors of a given fact.
+Rather than joining to `facts.ofType(T)`, you can find `successors(T, ...)` directly.
+
+When using `successors`, it is often possible to remove the `facts` parameter from the match function.
+
+## Example of Using the `successors` Method
+
+In the context of a company model, you can use the `successors` method to find all offices of a company by specifying the relationship between the company and its offices. Here is an example:
+
+```typescript
+const specification = model.given(Company).match(company =>
+    company.successors(Office, office => office.company)
+);
+
+const result = await j.query(specification, company);
+```
+
+In this example, the `successors` method is used to find all offices of a company by specifying the relationship between the company and its offices.
+
+## Compared to the `join` Method
+
+The alternative to the `successors` syntax in Jinaga is to use the `join` method.
+Here is that same query expressed using the `join` method:
+
+```typescript
+const specification = model.given(Company).match((company, facts) =>
+    facts.ofType(Office)
+        .join(office => office.company, company)
+);
+
+const result = await j.query(specification, company);
+```
+
+Notice that we need to pass the `facts` parameter to the match function when using the `join` method.
+Then we use `facts.ofType(Office)` to find all offices of the company, and `join` to specify the relationship between the company and its offices.
+
+## Using the `successors` Method with Composite Projections
+
+Composite projections allow you to define a structure for the results of a query.
+You can define nested projections and collections.
+The `successors` method can be used within composite projections.
+Here is an example:
+
+```typescript
+const specification = model.given(Company).match(company =>
+    company.successors(Office, office => office.company)
+        .select(office => ({
+            identifier: office.identifier,
+            employees: office.successors(Employee, employee => employee.office)
+        }))
+);
+
+const result = await j.query(specification, company);
+```
+
+In this example, the `successors` method is used to find all offices of a company and include additional information about each office, such as its employees, in the projection.

--- a/src/specification/model.ts
+++ b/src/specification/model.ts
@@ -357,7 +357,8 @@ function createFactProxy(factTypeMap: FactTypeMap, root: string, path: Role[], f
             }
             if (property === "successors") {
                 return (type: FactConstructor<any>, selector: (successor: any) => any) => {
-                    const name = `u${type.Type}`;
+                    const typeWithOnlyAlphaNumeric = type.Type.replace(/[^a-zA-Z0-9]/g, '');
+                    const name = `u${typeWithOnlyAlphaNumeric}`;
                     const unknown = createFactProxy(factTypeMap, name, [], type.Type);
                     const ancestor = selector(unknown);
                     const payloadLeft = getPayload(ancestor);

--- a/test/specification/querySpec.ts
+++ b/test/specification/querySpec.ts
@@ -54,7 +54,7 @@ describe("specification query", () => {
     });
 
     it("should query for successors using successors", async () => {
-        const specification = model.given(Company).match((company, facts) =>
+        const specification = model.given(Company).match(company =>
             company.successors(Office, office => office.company)
         );
 
@@ -251,7 +251,7 @@ describe("specification query", () => {
     });
 
     it("should execute a field projection using successors", async () => {
-        const specification = model.given(Company).match((company, facts) =>
+        const specification = model.given(Company).match(company =>
             company.successors(Office, office => office.company)
                 .select(office => office.identifier)
         );
@@ -280,7 +280,7 @@ describe("specification query", () => {
     });
 
     it("should execute a composite projection using successors", async () => {
-        const specification = model.given(Company).match((company, facts) =>
+        const specification = model.given(Company).match(company =>
             company.successors(Office, office => office.company)
                 .select(office => ({
                     identifier: office.identifier,
@@ -315,7 +315,7 @@ describe("specification query", () => {
     });
 
     it("should execute a specification projection using successors", async () => {
-        const specification = model.given(Company).match((company, facts) =>
+        const specification = model.given(Company).match(company =>
             company.successors(Office, office => office.company)
                 .select(office => ({
                     identifier: office.identifier,
@@ -396,7 +396,7 @@ describe("specification query", () => {
     });
 
     it("should execute a hash projection using successors", async () => {
-        const specification = model.given(Company).match((company, facts) =>
+        const specification = model.given(Company).match(company =>
             company.successors(Office, office => office.company)
                 .select(office => j.hash(office))
         );


### PR DESCRIPTION
Fixes #99

Simplify join syntax by adding a `successors` method to the `LabelOf` type.