### PR TITLE
Add predecessor function

### DIFF
--- a/documentation/predecessor.md
+++ b/documentation/predecessor.md
@@ -1,0 +1,112 @@
+# Querying for `predecessor`
+
+The `predecessor()` method allows you to navigate from a fact to its direct predecessor in a specification. This provides a convenient way to traverse relationships in the reverse direction.
+
+## Example of Using the `predecessor` Method
+
+In the context of a company model, you can use the `predecessor()` method to find the company that an office belongs to:
+
+```typescript
+const specification = model.given(Office).match(office =>
+    office.company.predecessor()
+);
+
+const result = await j.query(specification, office);
+```
+
+In this example, the `predecessor()` method is used to navigate from an office to its company.
+
+## Compared to the `join` Method
+
+The alternative to the `predecessor()` syntax in Jinaga is to use the `join` method with `facts.ofType()`:
+
+```typescript
+const specification = model.given(Office).match((office, facts) =>
+    facts.ofType(Company)
+        .join(company => company, office.company)
+);
+
+const result = await j.query(specification, office);
+```
+
+The `predecessor()` method provides a more concise and readable way to express the same query.
+
+## Using the `predecessor` Method with Projections
+
+You can use the `predecessor()` method with projections to select specific fields or create composite results:
+
+```typescript
+const specification = model.given(Office).match(office =>
+    office.company.predecessor()
+        .select(company => company.identifier)
+);
+
+const result = await j.query(specification, office);
+```
+
+For composite projections that include predecessor relationships, you need to properly label the predecessor facts:
+
+```typescript
+const specification = model.given(Office).match((office, facts) =>
+    office.company.predecessor()
+        .select(company => ({
+            identifier: company.identifier,
+            creator: facts.ofType(User)
+                .join(user => user, company.creator)
+        }))
+);
+
+const result = await j.query(specification, office);
+```
+
+## Chaining Predecessor Calls
+
+You can chain multiple `predecessor()` calls to navigate through multiple levels of relationships:
+
+```typescript
+const specification = model.given(President).match(president =>
+    president.office.company.predecessor()
+);
+
+const result = await j.query(specification, president);
+```
+
+This example navigates from a president to their office, and then to the company of that office.
+
+## Combining with Existential Conditions
+
+The `predecessor()` method can be used with existential conditions:
+
+```typescript
+const specification = model.given(OfficeClosed).match(officeClosed =>
+    officeClosed.office.predecessor()
+        .exists(office => office.company.predecessor())
+);
+
+const result = await j.query(specification, officeClosed);
+```
+
+## Combining with Successors
+
+You can combine `predecessor()` and `successors()` methods in the same query:
+
+```typescript
+const specification = model.given(Company).match(company =>
+    company.successors(Office, office => office.company)
+        .select(office => ({
+            identifier: office.identifier,
+            presidents: office.successors(President, president => president.office)
+                .selectMany(president => president.user.predecessor()
+                    .select(user => ({
+                        user: user,
+                        names: user.successors(UserName, userName => userName.user)
+                            .select(userName => userName.value)
+                    }))
+                )
+        }))
+);
+
+const result = await j.query(specification, company);
+```
+
+This example shows how to navigate from a company to its offices (using `successors`), then to the presidents of those offices (using `successors`), then to the users who are those presidents (using `predecessor`), and finally to the names of those users (using `successors`).

--- a/src/specification/model.ts
+++ b/src/specification/model.ts
@@ -329,7 +329,7 @@ function joinCondition(payloadLeft: LabelPayload, payloadRight: LabelPayload) {
     }
 
     if (payloadLeft.factType !== payloadRight.factType) {
-        throw new Error(`Cannot join ${payloadLeft.factType}" with "${payloadRight.factType}"`);
+        throw new Error(`Cannot join "${payloadLeft.factType}" with "${payloadRight.factType}"`);
     }
     const condition: PathCondition = {
         type: "path",
@@ -390,31 +390,31 @@ function createFactProxy(factTypeMap: FactTypeMap, root: string, path: Role[], f
             }
             else if (property === "join") {
                 return (left: (input: any) => any, right: any) => {
-                    const traversal = labelPredecessor(payload, factTypeMap, target);
+                    const traversal = labelPredecessor(factTypeMap, target);
                     return traversal.join(left, right);
                 };
             }
             else if (property === "notExists") {
                 return (tupleDefinition: (proxy: any) => any) => {
-                    const traversal = labelPredecessor(payload, factTypeMap, target);
+                    const traversal = labelPredecessor(factTypeMap, target);
                     return traversal.notExists(tupleDefinition);
                 };
             }
             else if (property === "exists") {
                 return (tupleDefinition: (proxy: any) => any) => {
-                    const traversal = labelPredecessor(payload, factTypeMap, target);
+                    const traversal = labelPredecessor(factTypeMap, target);
                     return traversal.exists(tupleDefinition);
                 };
             }
             else if (property === "select") {
                 return (selector: (input: any) => any) => {
-                    const traversal = labelPredecessor(payload, factTypeMap, target);
+                    const traversal = labelPredecessor(factTypeMap, target);
                     return traversal.select(selector);
                 };
             }
             else if (property === "selectMany") {
                 return (selector: (input: any) => any) => {
-                    const traversal = labelPredecessor(payload, factTypeMap, target);
+                    const traversal = labelPredecessor(factTypeMap, target);
                     return traversal.selectMany(selector);
                 };
             }
@@ -438,10 +438,10 @@ function createFactProxy(factTypeMap: FactTypeMap, root: string, path: Role[], f
     });
 }
 
-function labelPredecessor(payload: LabelPayloadFact, factTypeMap: FactTypeMap, target: LabelPayloadFact) {
-    const typeWithOnlyAlphaNumeric = payload.factType.replace(/[^a-zA-Z0-9]/g, '');
+function labelPredecessor(factTypeMap: FactTypeMap, target: LabelPayloadFact) {
+    const typeWithOnlyAlphaNumeric = target.factType.replace(/[^a-zA-Z0-9]/g, '');
     const name = `u${typeWithOnlyAlphaNumeric}`;
-    const unknown = createFactProxy(factTypeMap, name, [], payload.factType);
+    const unknown = createFactProxy(factTypeMap, name, [], target.factType);
     const condition: PathCondition = {
         type: "path",
         rolesLeft: [],
@@ -451,7 +451,7 @@ function labelPredecessor(payload: LabelPayloadFact, factTypeMap: FactTypeMap, t
     const match: Match = {
         unknown: {
             name: name,
-            type: payload.factType
+            type: target.factType
         },
         conditions: [
             condition

--- a/src/specification/model.ts
+++ b/src/specification/model.ts
@@ -211,6 +211,10 @@ export class Traversal<T> {
                 conditions
             }
         ];
+
+        // Verify that the matches collection contains no unknowns with the same name.
+        // Traverse existential conditions looking for names defined above.
+        verifyNoDuplicateNames(matches, []);
         return matches;
     }
 
@@ -579,5 +583,19 @@ function traversalFromDefinition<U>(definition: U, matches: Match[]): Traversal<
             components
         }
         return new Traversal<U>(definition, matches, compositeProjection);
+    }
+}
+
+function verifyNoDuplicateNames(matches: Match[], usedNames: string[]) {
+    for (const match of matches) {
+        if (usedNames.includes(match.unknown.name)) {
+            throw new Error(`The name "${match.unknown.name}" is already defined.`);
+        }
+        usedNames.push(match.unknown.name);
+        for (const condition of match.conditions) {
+            if (condition.type === "existential") {
+                verifyNoDuplicateNames(condition.matches, usedNames);
+            }
+        }
     }
 }

--- a/src/specification/model.ts
+++ b/src/specification/model.ts
@@ -193,11 +193,11 @@ export class Traversal<T> {
             exists,
             matches: result.matches
         };
-        const matches: Match[] = this.withCondition<U>(existentialCondition);
+        const matches: Match[] = this.withCondition(existentialCondition);
         return new Traversal<T>(this.input, matches, this.projection);
     }
 
-    private withCondition<U>(condition: Condition) {
+    private withCondition(condition: Condition) {
         if (this.matches.length === 0) {
             throw new Error("Cannot add a condition without declaring an unknown.");
         }
@@ -213,10 +213,6 @@ export class Traversal<T> {
                 conditions
             }
         ];
-
-        // Verify that the matches collection contains no unknowns with the same name.
-        // Traverse existential conditions looking for names defined above.
-        verifyNoDuplicateNames(matches, []);
         return matches;
     }
 
@@ -543,19 +539,5 @@ function traversalFromDefinition<U>(definition: U, matches: Match[]): Traversal<
             components
         }
         return new Traversal<U>(definition, matches, compositeProjection);
-    }
-}
-
-function verifyNoDuplicateNames(matches: Match[], usedNames: string[]) {
-    for (const match of matches) {
-        if (usedNames.includes(match.unknown.name)) {
-            throw new Error(`The name "${match.unknown.name}" is already defined.`);
-        }
-        usedNames.push(match.unknown.name);
-        for (const condition of match.conditions) {
-            if (condition.type === "existential") {
-                verifyNoDuplicateNames(condition.matches, usedNames);
-            }
-        }
     }
 }

--- a/src/specification/model.ts
+++ b/src/specification/model.ts
@@ -122,7 +122,7 @@ class Given<T extends any[]> {
             const name = `p${i + 1}`;
             return createFactProxy(factRepository, this.factTypeMap, name, [], factType);
         });
-        const result = (selector as any)(...labels, new FactRepository(this.factTypeMap));
+        const result = (selector as any)(...labels, factRepository);
         const matches: Match[] = [];
         const traversal = traversalFromDefinition(result, matches);
         const projection = traversal.projection;

--- a/test/specification/givenSpec.ts
+++ b/test/specification/givenSpec.ts
@@ -1,5 +1,5 @@
 import { SpecificationOf } from "../../src";
-import { Company, Office, OfficeClosed, President, User, UserName, model } from "../companyModel";
+import { Company, Office, OfficeClosed, OfficeReopened, President, User, UserName, model } from "../companyModel";
 
 describe("given", () => {
     it("should parse an identity specification", () => {
@@ -24,6 +24,19 @@ describe("given", () => {
             } => u1`);
     });
 
+    it("should parse a successor join using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                ]
+            } => uOffice`);
+    });
+
     it("should parse negative existential condition", () => {
         const specification = model.given(Company).match((company, facts) =>
             facts.ofType(Office)
@@ -46,6 +59,25 @@ describe("given", () => {
             } => u1`);
     });
 
+    it("should parse negative existential condition using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .notExists(office => office.successors(OfficeClosed, officeClosed => officeClosed.office))
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                    !E {
+                        uOfficeClosed: Office.Closed [
+                            uOfficeClosed->office: Office = uOffice
+                        ]
+                    }
+                ]
+            } => uOffice`);
+    });
+
     it("should parse positive existential condition", () => {
         const specification = model.given(Company).match((company, facts) =>
             facts.ofType(Office)
@@ -66,6 +98,25 @@ describe("given", () => {
                     }
                 ]
             } => u1`);
+    });
+
+    it("should parse positive existential condition using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .exists(office => office.successors(OfficeClosed, officeClosed => officeClosed.office))
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                    E {
+                        uOfficeClosed: Office.Closed [
+                            uOfficeClosed->office: Office = uOffice
+                        ]
+                    }
+                ]
+            } => uOffice`);
     });
 
     it("should parse nested negative existential condition", () => {
@@ -91,6 +142,32 @@ describe("given", () => {
             } => u1`);
     });
 
+    it("should parse nested negative existential condition using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .notExists(office => office.successors(OfficeClosed, officeClosed => officeClosed.office)
+                    .notExists(officeClosed => officeClosed.successors(OfficeReopened, officeReopened => officeReopened.officeClosed))
+                )
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                    !E {
+                        uOfficeClosed: Office.Closed [
+                            uOfficeClosed->office: Office = uOffice
+                            !E {
+                                uOfficeReopened: Office.Reopened [
+                                    uOfficeReopened->officeClosed: Office.Closed = uOfficeClosed
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            } => uOffice`);
+    });
+
     it("should parse a field projection", () => {
         const specification = model.given(Company).match((company, facts) =>
             facts.ofType(Office)
@@ -104,6 +181,20 @@ describe("given", () => {
                     u1->company: Company = p1
                 ]
             } => u1.identifier`);
+    });
+
+    it("should parse a field projection using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .select(office => office.identifier)
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                ]
+            } => uOffice.identifier`);
     });
 
     it("should parse a composite projection with a field", () => {
@@ -122,6 +213,24 @@ describe("given", () => {
                 ]
             } => {
                 identifier = u1.identifier
+            }`);
+    });
+
+    it("should parse a composite projection with a field using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .select(office => ({
+                    identifier: office.identifier
+                }))
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                ]
+            } => {
+                identifier = uOffice.identifier
             }`);
     });
 
@@ -148,6 +257,30 @@ describe("given", () => {
                         u2->office: Office = u1
                     ]
                 } => u2
+            }`);
+    });
+
+    it("should parse a composite projection with a collection using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .select(office => ({
+                    identifier: office.identifier,
+                    presidents: office.successors(President, president => president.office)
+                }))
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                ]
+            } => {
+                identifier = uOffice.identifier
+                presidents = {
+                    uPresident: President [
+                        uPresident->office: Office = uOffice
+                    ]
+                } => uPresident
             }`);
     });
 
@@ -186,6 +319,42 @@ describe("given", () => {
                         ]
                     } => u3.value
                     president = u2
+                }
+            }`);
+    });
+
+    it("should parse a nested collection using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .select(office => ({
+                    identifier: office.identifier,
+                    presidents: office.successors(President, president => president.office)
+                        .select(president => ({
+                            president: president,
+                            names: president.user.successors(UserName, userName => userName.user)
+                                .select(userName => userName.value)
+                        }))
+                }))
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                ]
+            } => {
+                identifier = uOffice.identifier
+                presidents = {
+                    uPresident: President [
+                        uPresident->office: Office = uOffice
+                    ]
+                } => {
+                    names = {
+                        uUserName: User.Name [
+                            uUserName->user: User = uPresident->user: User
+                        ]
+                    } => uUserName.value
+                    president = uPresident
                 }
             }`);
     });
@@ -239,6 +408,51 @@ describe("given", () => {
             }`);
     });
 
+    it("should parse multiple joins using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .select(office => ({
+                    identifier: office.identifier,
+                    presidents: office.successors(President, president => president.office)
+                        .select(president => ({
+                            president: president,
+                            names: president.user.successors(UserName, userName => userName.user)
+                                .notExists(userName => userName.successors(UserName, next => next.prior)
+                                    .join(next => next.user, president.user)
+                                )
+                                .select(userName => userName.value)
+                        }))
+                }))
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                ]
+            } => {
+                identifier = uOffice.identifier
+                presidents = {
+                    uPresident: President [
+                        uPresident->office: Office = uOffice
+                    ]
+                } => {
+                    names = {
+                        uUserName: User.Name [
+                            uUserName->user: User = uPresident->user: User
+                            !E {
+                                uUserName: User.Name [
+                                    uUserName->prior: User.Name = uUserName
+                                    uUserName->user: User = uPresident->user: User
+                                ]
+                            }
+                        ]
+                    } => uUserName.value
+                    president = uPresident
+                }
+            }`);
+    });
+
     it("should parse multiple joins in opposite order", () => {
         const specification = model.given(Company).match((company, facts) =>
             facts.ofType(Office)
@@ -288,6 +502,48 @@ describe("given", () => {
             }`);
     });
 
+    it("should parse multiple joins in opposite order using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .select(office => ({
+                    identifier: office.identifier,
+                    presidents: office.successors(President, president => president.office)
+                        .select(president => ({
+                            president: president,
+                            names: president.user.successors(UserName, userName => userName.user)
+                                .notExists(userName => userName.successors(UserName, next => next.prior))
+                                .select(userName => userName.value)
+                        }))
+                }))
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                ]
+            } => {
+                identifier = uOffice.identifier
+                presidents = {
+                    uPresident: President [
+                        uPresident->office: Office = uOffice
+                    ]
+                } => {
+                    names = {
+                        uUserName: User.Name [
+                            uUserName->user: User = uPresident->user: User
+                            !E {
+                                uUserName: User.Name [
+                                    uUserName->prior: User.Name = uUserName
+                                ]
+                            }
+                        ]
+                    } => uUserName.value
+                    president = uPresident
+                }
+            }`);
+    });
+
     it("should parse select many", () => {
         const specification = model.given(Company).match((company, facts) =>
             facts.ofType(Office)
@@ -333,6 +589,47 @@ describe("given", () => {
             }`);
     });
 
+    it("should parse select many using successors syntax", () => {
+        const specification = model.given(Company).match(company =>
+            company.successors(Office, office => office.company)
+                .select(office => ({
+                    identifier: office.identifier,
+                    presidents: office.successors(President, president => president.office)
+                        .selectMany(president => president.user
+                            .select(user => ({
+                                user: user,
+                                names: user.successors(UserName, userName => userName.user)
+                                    .select(userName => userName.value)
+                            }))
+                        )
+                }))
+        );
+
+        expectSpecification(specification, `
+            (p1: Company) {
+                uOffice: Office [
+                    uOffice->company: Company = p1
+                ]
+            } => {
+                identifier = uOffice.identifier
+                presidents = {
+                    uPresident: President [
+                        uPresident->office: Office = uOffice
+                    ]
+                    uUser: User [
+                        uUser = uPresident->user: User
+                    ]
+                } => {
+                    names = {
+                        uUserName: User.Name [
+                            uUserName->user: User = uUser
+                        ]
+                    } => uUserName.value
+                    user = uUser
+                }
+            }`);
+    });
+
     it("should parse multiple givens", () => {
         const specification = model.given(Company, User).match((company, user, facts) =>
             facts.ofType(President)
@@ -347,6 +644,21 @@ describe("given", () => {
                     u1->user: User = p2
                 ]
             } => u1`);
+    });
+
+    it("should parse multiple givens using successors syntax", () => {
+        const specification = model.given(Company, User).match((company, user) =>
+            company.successors(President, president => president.office.company)
+                .join(president => president.user, user)
+        );
+
+        expectSpecification(specification, `
+            (p1: Company, p2: User) {
+                uPresident: President [
+                    uPresident->office: Office->company: Company = p1
+                    uPresident->user: User = p2
+                ]
+            } => uPresident`);
     });
 });
 

--- a/test/specification/givenSpec.ts
+++ b/test/specification/givenSpec.ts
@@ -595,7 +595,7 @@ describe("given", () => {
                 .select(office => ({
                     identifier: office.identifier,
                     presidents: office.successors(President, president => president.office)
-                        .selectMany(president => president.user
+                        .selectMany(president => president.user.predecessor()
                             .select(user => ({
                                 user: user,
                                 names: user.successors(UserName, userName => userName.user)

--- a/test/specification/givenSpec.ts
+++ b/test/specification/givenSpec.ts
@@ -31,10 +31,10 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                 ]
-            } => uOffice`);
+            } => u1`);
     });
 
     it("should parse negative existential condition", () => {
@@ -67,15 +67,15 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                     !E {
-                        uOfficeClosed: Office.Closed [
-                            uOfficeClosed->office: Office = uOffice
+                        u2: Office.Closed [
+                            u2->office: Office = u1
                         ]
                     }
                 ]
-            } => uOffice`);
+            } => u1`);
     });
 
     it("should parse positive existential condition", () => {
@@ -108,15 +108,15 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                     E {
-                        uOfficeClosed: Office.Closed [
-                            uOfficeClosed->office: Office = uOffice
+                        u2: Office.Closed [
+                            u2->office: Office = u1
                         ]
                     }
                 ]
-            } => uOffice`);
+            } => u1`);
     });
 
     it("should parse nested negative existential condition", () => {
@@ -152,20 +152,20 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                     !E {
-                        uOfficeClosed: Office.Closed [
-                            uOfficeClosed->office: Office = uOffice
+                        u2: Office.Closed [
+                            u2->office: Office = u1
                             !E {
-                                uOfficeReopened: Office.Reopened [
-                                    uOfficeReopened->officeClosed: Office.Closed = uOfficeClosed
+                                u3: Office.Reopened [
+                                    u3->officeClosed: Office.Closed = u2
                                 ]
                             }
                         ]
                     }
                 ]
-            } => uOffice`);
+            } => u1`);
     });
 
     it("should parse a field projection", () => {
@@ -191,10 +191,10 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                 ]
-            } => uOffice.identifier`);
+            } => u1.identifier`);
     });
 
     it("should parse a composite projection with a field", () => {
@@ -226,11 +226,11 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                 ]
             } => {
-                identifier = uOffice.identifier
+                identifier = u1.identifier
             }`);
     });
 
@@ -271,16 +271,16 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                 ]
             } => {
-                identifier = uOffice.identifier
+                identifier = u1.identifier
                 presidents = {
-                    uPresident: President [
-                        uPresident->office: Office = uOffice
+                    u2: President [
+                        u2->office: Office = u1
                     ]
-                } => uPresident
+                } => u2
             }`);
     });
 
@@ -339,22 +339,22 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                 ]
             } => {
-                identifier = uOffice.identifier
+                identifier = u1.identifier
                 presidents = {
-                    uPresident: President [
-                        uPresident->office: Office = uOffice
+                    u2: President [
+                        u2->office: Office = u1
                     ]
                 } => {
                     names = {
-                        uUserName: User.Name [
-                            uUserName->user: User = uPresident->user: User
+                        u3: User.Name [
+                            u3->user: User = u2->user: User
                         ]
-                    } => uUserName.value
-                    president = uPresident
+                    } => u3.value
+                    president = u2
                 }
             }`);
     });
@@ -427,28 +427,28 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                 ]
             } => {
-                identifier = uOffice.identifier
+                identifier = u1.identifier
                 presidents = {
-                    uPresident: President [
-                        uPresident->office: Office = uOffice
+                    u2: President [
+                        u2->office: Office = u1
                     ]
                 } => {
                     names = {
-                        uUserName: User.Name [
-                            uUserName->user: User = uPresident->user: User
+                        u3: User.Name [
+                            u3->user: User = u2->user: User
                             !E {
-                                uUserName: User.Name [
-                                    uUserName->prior: User.Name = uUserName
-                                    uUserName->user: User = uPresident->user: User
+                                u4: User.Name [
+                                    u4->prior: User.Name = u3
+                                    u4->user: User = u2->user: User
                                 ]
                             }
                         ]
-                    } => uUserName.value
-                    president = uPresident
+                    } => u3.value
+                    president = u2
                 }
             }`);
     });
@@ -519,27 +519,27 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                 ]
             } => {
-                identifier = uOffice.identifier
+                identifier = u1.identifier
                 presidents = {
-                    uPresident: President [
-                        uPresident->office: Office = uOffice
+                    u2: President [
+                        u2->office: Office = u1
                     ]
                 } => {
                     names = {
-                        uUserName: User.Name [
-                            uUserName->user: User = uPresident->user: User
+                        u3: User.Name [
+                            u3->user: User = u2->user: User
                             !E {
-                                uUserName: User.Name [
-                                    uUserName->prior: User.Name = uUserName
+                                u4: User.Name [
+                                    u4->prior: User.Name = u3
                                 ]
                             }
                         ]
-                    } => uUserName.value
-                    president = uPresident
+                    } => u3.value
+                    president = u2
                 }
             }`);
     });
@@ -607,25 +607,25 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company) {
-                uOffice: Office [
-                    uOffice->company: Company = p1
+                u1: Office [
+                    u1->company: Company = p1
                 ]
             } => {
-                identifier = uOffice.identifier
+                identifier = u1.identifier
                 presidents = {
-                    uPresident: President [
-                        uPresident->office: Office = uOffice
+                    u2: President [
+                        u2->office: Office = u1
                     ]
-                    uUser: User [
-                        uUser = uPresident->user: User
+                    u3: User [
+                        u3 = u2->user: User
                     ]
                 } => {
                     names = {
-                        uUserName: User.Name [
-                            uUserName->user: User = uUser
+                        u4: User.Name [
+                            u4->user: User = u3
                         ]
-                    } => uUserName.value
-                    user = uUser
+                    } => u4.value
+                    user = u3
                 }
             }`);
     });
@@ -654,11 +654,11 @@ describe("given", () => {
 
         expectSpecification(specification, `
             (p1: Company, p2: User) {
-                uPresident: President [
-                    uPresident->office: Office->company: Company = p1
-                    uPresident->user: User = p2
+                u1: President [
+                    u1->office: Office->company: Company = p1
+                    u1->user: User = p2
                 ]
-            } => uPresident`);
+            } => u1`);
     });
 });
 


### PR DESCRIPTION
Introduce a new predecessor function to streamline name generation and reduce reserved names. Refactor existing functions to utilize a fact repository for consistent name handling and ensure no duplicate names are generated during traversal. Update tests to align with the new naming conventions.