### PR TITLE
Add SingleUse method to JinagaClient

### DIFF
--- a/src/cryptography/key-pair.ts
+++ b/src/cryptography/key-pair.ts
@@ -6,6 +6,7 @@ import { Trace } from "../util/trace";
 export interface KeyPair {
     publicPem: string;
     privatePem: string;
+    singleUseKeyPair?: KeyPair | null;
 }
 
 export function generateKeyPair(): KeyPair {
@@ -41,4 +42,14 @@ function signFact(fact: FactRecord, publicPem: string, privateKey: pki.rsa.Priva
             publicKey: publicPem
         }]
     };
+}
+
+export function BeginSingleUse(): KeyPair {
+    const keyPair = generateKeyPair();
+    keyPair.singleUseKeyPair = keyPair;
+    return keyPair;
+}
+
+export function EndSingleUse(keyPair: KeyPair): void {
+    keyPair.singleUseKeyPair = null;
 }

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -248,6 +248,16 @@ export class Jinaga {
         return this.factManager.purge();
     }
 
+    async SingleUse<T>(callback: (jinaga: Jinaga) => Promise<T>): Promise<T> {
+        await this.factManager.BeginSingleUse();
+        try {
+            const result = await callback(this);
+            return result;
+        } finally {
+            await this.factManager.EndSingleUse();
+        }
+    }
+
     private validateFact(prototype: Fact) {
         const error = Jinaga.getFactError(prototype);
         if (error) {

--- a/test/specification/querySpec.ts
+++ b/test/specification/querySpec.ts
@@ -408,4 +408,15 @@ describe("specification query", () => {
             j.hash(reopenedOffice)
         ]);
     });
+
+    it("should create facts using a temporary user", async () => {
+        const result = await j.SingleUse(async (jinaga) => {
+            const tempUser = new User("--- TEMP USER PUBLIC KEY ---");
+            const tempCompany = new Company(tempUser, "TempCo");
+            await jinaga.fact(tempCompany);
+            return tempCompany;
+        });
+
+        expect(result.identifier).toBe("TempCo");
+    });
 });


### PR DESCRIPTION
Fixes #82

Add a `SingleUse` method to the `Jinaga` class to generate a temporary key pair and execute a callback function.

* Add `SingleUse` method to `Jinaga` class in `src/jinaga.ts`
* Call `factManager.BeginSingleUse()` at the beginning of the `SingleUse` method
* Call `factManager.EndSingleUse()` at the end of the `SingleUse` method

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jinaga/jinaga.js/pull/113?shareId=21642136-9568-4658-9c5f-72dcf9984d40).