### PR TITLE
Implement single-use principal functionality with key pair generation and signing of facts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { Authentication } from './authentication/authentication';
 export { AuthenticationNoOp } from './authentication/authentication-noop';
+export { AuthenticationTest } from './authentication/authentication-test';
 export { Authorization } from './authorization/authorization';
 export { AuthorizationEngine, Forbidden } from './authorization/authorization-engine';
 export { AuthorizationNoOp } from "./authorization/authorization-noop";
@@ -58,4 +59,3 @@ export { ConsoleTracer, NoOpTracer, Trace, Tracer } from './util/trace';
 
 // Export the JinagaBrowser class using the alias JinagaClient
 export { JinagaBrowser as JinagaClient } from "./jinaga-browser";
-

--- a/test/single-use/singleUseForkSpec.ts
+++ b/test/single-use/singleUseForkSpec.ts
@@ -1,0 +1,93 @@
+import { AuthenticationTest, FactEnvelope, FactManager, FactReference, Fork, Jinaga, MemoryStore, ObservableSource, User } from '../../src';
+
+// Define a fake Fork implementation that captures saved facts
+class FakeFork implements Fork {
+    public savedEnvelopes: FactEnvelope[] = [];
+
+    async save(envelopes: FactEnvelope[]): Promise<void> {
+        this.savedEnvelopes = this.savedEnvelopes.concat(envelopes);
+        return Promise.resolve();
+    }
+
+    async load(references: FactReference[]): Promise<FactEnvelope[]> {
+        return Promise.resolve([]);
+    }
+
+    async close(): Promise<void> {
+        return Promise.resolve();
+    }
+}
+
+// Define an Environment fact type that will be owned by the single-use principal
+class Environment {
+    static Type = "Enterprise.Environment" as const;
+    type = Environment.Type;
+
+    constructor(
+        public creator: User,
+        public identifier: string
+    ) { }
+}
+
+describe('SingleUse with FakeFork', () => {
+    it('should create single-use principal', async () => {
+        // Arrange
+        const store = new MemoryStore();
+        const fakeFork = new FakeFork();
+        const observableSource = new ObservableSource(store);
+        const authentication = new AuthenticationTest(store, null, null, null);
+        const factManager = new FactManager(fakeFork, observableSource, store, {
+            feeds: async () => [],
+            fetchFeed: async () => ({ references: [], bookmark: '' }),
+            streamFeed: () => () => {},
+            load: async () => []
+        }, []);
+        const j = new Jinaga(authentication, factManager, null);
+        
+        // Act
+        await j.singleUse(async (principal: User) => {
+            // Assert
+            expect(principal).toBeDefined();
+            expect(principal.type).toBe('Jinaga.User');
+            expect(principal.publicKey).toContain('-----BEGIN PUBLIC KEY-----');
+            return 0;
+        });
+    });
+
+    it('should sign facts created by single-use principal', async () => {
+        // Arrange
+        const store = new MemoryStore();
+        const fakeFork = new FakeFork();
+        const observableSource = new ObservableSource(store);
+        const authentication = new AuthenticationTest(store, null, null, null);
+        const factManager = new FactManager(fakeFork, observableSource, store, {
+            feeds: async () => [],
+            fetchFeed: async () => ({ references: [], bookmark: '' }),
+            streamFeed: () => () => {},
+            load: async () => []
+        }, []);
+        const j = new Jinaga(authentication, factManager, null);
+        
+        // Act
+        const publicKey = await j.singleUse(async (principal: User) => {
+            await j.fact(new Environment(principal, "Production"));
+            return principal.publicKey;
+        });
+        
+        // Assert
+        // Find the Environment fact in the saved envelopes
+        const environmentFact = fakeFork.savedEnvelopes
+            .filter(envelope => envelope.fact.type === "Enterprise.Environment")
+            .map(envelope => envelope.fact);
+        expect(environmentFact.length).toBe(1);
+        
+        // Find the signature for the Environment fact
+        const environmentSignature = fakeFork.savedEnvelopes
+            .filter(envelope => envelope.fact.type === "Enterprise.Environment")
+            .flatMap(envelope => envelope.signatures);
+        expect(environmentSignature.length).toBe(1);
+        
+        // Verify the signature uses the principal's public key
+        expect(environmentSignature[0].publicKey).toBe(publicKey);
+    });
+});

--- a/test/single-use/singleUseStoreSpec.ts
+++ b/test/single-use/singleUseStoreSpec.ts
@@ -1,0 +1,69 @@
+import { AuthenticationTest, FactManager, Jinaga, MemoryStore, ObservableSource, PassThroughFork, User } from '../../src';
+
+// Define a test fact type that will be owned by the single-use principal
+class TestFact {
+  static Type = "TestFact" as const;
+  type = TestFact.Type;
+
+  constructor(
+    public owner: User,
+    public value: string
+  ) { }
+}
+
+describe('SingleUse with Store', () => {
+  it('should create and sign facts with a single-use principal', async () => {
+    // Arrange
+    const store = new MemoryStore();
+    const fork = new PassThroughFork(store);
+    const observableSource = new ObservableSource(store);
+    const authentication = new AuthenticationTest(store, null, null, null);
+    const factManager = new FactManager(fork, observableSource, store, {
+      feeds: async () => [],
+      fetchFeed: async () => ({ references: [], bookmark: '' }),
+      streamFeed: () => () => {},
+      load: async () => []
+    }, []);
+    const j = new Jinaga(authentication, factManager, null);
+    
+    // Act
+    const result = await j.singleUse(async (principal: User) => {
+      // Create a fact owned by the principal
+      const fact = await j.fact(new TestFact(principal, 'test value'));
+      return fact;
+    });
+    
+    // Assert
+    expect(result).toBeDefined();
+    expect(result.type).toBe('TestFact');
+    expect(result.owner.type).toBe('Jinaga.User');
+    expect(result.owner.publicKey).toBeDefined();
+    expect(result.value).toBe('test value');
+    
+    // Verify that the fact was saved to the store
+    const facts = await store.load([{
+      type: 'TestFact',
+      hash: Jinaga.hash(result)
+    }]);
+    
+    // Find the TestFact in the returned facts
+    const testFact = facts.find(f => f.fact.type === 'TestFact');
+    expect(testFact).toBeDefined();
+    expect(testFact!.fact.fields.value).toBe('test value');
+    
+    // Verify that the fact has a signature
+    expect(testFact!.signatures.length).toBeGreaterThan(0);
+    
+    // Verify that the user fact was saved to the store
+    const userFacts = await store.load([{
+      type: 'Jinaga.User',
+      hash: Jinaga.hash(result.owner)
+    }]);
+    expect(userFacts.length).toBe(1);
+    expect(userFacts[0].fact.type).toBe('Jinaga.User');
+    expect(userFacts[0].fact.fields.publicKey).toBeDefined();
+    
+    // Verify that the user fact has a signature
+    expect(userFacts[0].signatures.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Introduce a mechanism for creating single-use principals that generate key pairs to sign facts. This functionality includes methods for beginning and ending single-use sessions, ensuring that private keys are discarded after use. Additionally, tests validate the creation and signing of facts by these principals.