### PR TITLE
Export TypeScript declarations for Jinaga.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ npm i jinaga
 This installs just the client side components.
 See [jinaga.com](https://jinaga.com) for details on how to use them.
 
+## TypeScript Support
+
+Jinaga.js includes TypeScript declarations and supports both ESM and CommonJS imports. The package uses the "exports" field in package.json to properly map type declarations, ensuring compatibility with TypeScript's module resolution.
+
 ## Running a Replicator
 
 A Jinaga front end connects to a device called a Replicator.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
Add TypeScript support by including type declarations and configuring the package.json to ensure compatibility with module resolution.