### PR TITLE
Analyze jinaga.js issue 136 and propose plans

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,5 @@ export { Invalid, SpecificationParser } from './specification/specification-pars
 export { computeTupleSubsetHash, FactEnvelope, factEnvelopeEquals, FactFeed, FactRecord, FactReference, factReferenceEquals, FactSignature, FactTuple, PredecessorCollection, ProjectedResult, Queue, ReferencesByName, Storage, validateGiven } from './storage';
 export { UserIdentity } from './user-identity';
 export { ConsoleTracer, NoOpTracer, Trace, Tracer } from './util/trace';
-
-// Export the JinagaBrowser class using the alias JinagaClient
 export { JinagaBrowser as JinagaClient } from "./jinaga-browser";
+export { validateSpecificationConnectivity, DisconnectedSpecificationError, setConnectivityValidationMode, enforceConnectivityValidation } from './specification/connectivity';

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -10,6 +10,7 @@ import { FactEnvelope, FactRecord, FactReference, ProjectedResult, Storage } fro
 import { Trace } from "../util/trace";
 import { Network, NetworkManager } from "./NetworkManager";
 import { PurgeManager } from "./PurgeManager";
+import { enforceConnectivityValidation } from "../specification/connectivity";
 
 export class FactManager {
     private networkManager: NetworkManager;
@@ -110,16 +111,19 @@ export class FactManager {
     }
 
     async read(start: FactReference[], specification: Specification): Promise<ProjectedResult[]> {
+        enforceConnectivityValidation(specification);
         this.purgeManager.checkCompliance(specification);
         return await this.store.read(start, specification);
     }
 
     async fetch(start: FactReference[], specification: Specification) {
+        enforceConnectivityValidation(specification);
         this.purgeManager.checkCompliance(specification);
         await this.networkManager.fetch(start, specification);
     }
 
     async subscribe(start: FactReference[], specification: Specification) {
+        enforceConnectivityValidation(specification);
         this.purgeManager.checkCompliance(specification);
         return await this.networkManager.subscribe(start, specification);
     }

--- a/src/specification/connectivity.ts
+++ b/src/specification/connectivity.ts
@@ -1,0 +1,213 @@
+import { ComponentProjection, Condition, Match, NamedComponentProjection, Projection, Specification } from "./specification";
+
+export class DisconnectedSpecificationError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, DisconnectedSpecificationError.prototype);
+    this.name = "DisconnectedSpecificationError";
+  }
+}
+
+export type ConnectivityValidationMode = "off" | "warn" | "error";
+let connectivityValidationMode: ConnectivityValidationMode = "off";
+
+export function setConnectivityValidationMode(mode: ConnectivityValidationMode) {
+  connectivityValidationMode = mode;
+}
+
+export function enforceConnectivityValidation(spec: Specification): void {
+  if (connectivityValidationMode === "off") return;
+  try {
+    validateSpecificationConnectivity(spec);
+  }
+  catch (e) {
+    if (connectivityValidationMode === "warn") {
+      // eslint-disable-next-line no-console
+      console.warn((e as Error).message);
+      return;
+    }
+    throw e;
+  }
+}
+
+export function validateSpecificationConnectivity(spec: Specification): void {
+  // Build undirected adjacency map of label names
+  const nodes = new Set<string>();
+  const adj = new Map<string, Set<string>>();
+
+  function addNode(label: string) {
+    nodes.add(label);
+    if (!adj.has(label)) adj.set(label, new Set());
+  }
+  function addEdge(a: string, b: string) {
+    if (a === b) return;
+    addNode(a); addNode(b);
+    adj.get(a)!.add(b);
+    adj.get(b)!.add(a);
+  }
+
+  // Collect all nodes and edges from the entire spec tree
+  for (const g of spec.given) {
+    addNode(g.name);
+  }
+  collectFromMatches(spec.matches);
+  collectFromProjection(spec.projection);
+
+  function collectFromMatches(matches: Match[]) {
+    for (const m of matches) {
+      addNode(m.unknown.name);
+      for (const c of m.conditions) {
+        collectFromCondition(m.unknown.name, c);
+      }
+    }
+  }
+
+  function collectFromCondition(unknownLabel: string, c: Condition) {
+    if (c.type === "path") {
+      // Path condition connects the match unknown to the referenced label
+      addNode(c.labelRight);
+      addEdge(unknownLabel, c.labelRight);
+    }
+    else if (c.type === "existential") {
+      collectFromMatches(c.matches);
+    }
+    else {
+      const _exhaustive: never = c;
+      throw new Error(`Unexpected condition type: ${( _exhaustive as any).type}`);
+    }
+  }
+
+  function collectFromProjection(p: Projection) {
+    if (p.type === "composite") {
+      for (const comp of p.components) {
+        collectFromComponent(comp);
+      }
+    }
+    else {
+      // Singular projections reference a label directly
+      addNode(p.label);
+    }
+  }
+
+  function collectFromComponent(comp: NamedComponentProjection) {
+    if (comp.type === "specification") {
+      collectFromMatches(comp.matches);
+      collectFromProjection(comp.projection);
+    }
+    else {
+      // fact/field/hash reference a label
+      addNode(comp.label);
+    }
+  }
+
+  // Compute degrees for isolated detection
+  const degreeByNode = new Map<string, number>();
+  for (const n of nodes) {
+    degreeByNode.set(n, (adj.get(n)?.size ?? 0));
+  }
+  const isolated = Array.from(nodes).filter(n => (degreeByNode.get(n) ?? 0) === 0);
+  // Allow identity specifications that neither match nor project any labels
+  const isIdentity = isolated.length > 0 && nodes.size === spec.given.length &&
+    spec.matches.length === 0 &&
+    (spec.projection.type === "composite" && spec.projection.components.length === 0);
+  if (!isIdentity && isolated.length > 0) {
+    throw new DisconnectedSpecificationError(
+      `Specification is disconnected. Isolated labels: ${isolated.sort().join(", ")}.`
+    );
+  }
+
+  // Compute connected components over nodes present in adj
+  const nodeList = Array.from(nodes);
+  const componentIdByNode = new Map<string, number>();
+  let currentId = 0;
+  for (const n of nodeList) {
+    if (!componentIdByNode.has(n)) {
+      // BFS/DFS
+      const stack = [n];
+      componentIdByNode.set(n, currentId);
+      while (stack.length) {
+        const v = stack.pop()!;
+        const neighbors = adj.get(v) ?? new Set<string>();
+        for (const w of neighbors) {
+          if (!componentIdByNode.has(w)) {
+            componentIdByNode.set(w, currentId);
+            stack.push(w);
+          }
+        }
+      }
+      currentId++;
+    }
+  }
+
+  // Gather labels referenced by the projection tree (including nested specs)
+  const projectionLabels = new Set<string>();
+  collectProjectionLabels(spec.projection, projectionLabels);
+
+  function collectProjectionLabels(p: Projection, acc: Set<string>) {
+    if (p.type === "composite") {
+      for (const comp of p.components) {
+        if (comp.type === "specification") {
+          collectProjectionLabels(comp.projection, acc);
+        }
+        else {
+          acc.add(comp.label);
+        }
+      }
+    }
+    else {
+      acc.add(p.label);
+    }
+  }
+
+  // Determine which component(s) the projection references
+  const projectionComponentIds = new Set<number>();
+  for (const l of projectionLabels) {
+    if (!componentIdByNode.has(l)) {
+      // Label used in projection but never defined as given or unknown
+      // Treat it as isolated node (will be caught above if truly isolated)
+      addNode(l);
+      componentIdByNode.set(l, currentId++);
+      projectionComponentIds.add(componentIdByNode.get(l)!);
+    }
+    else {
+      projectionComponentIds.add(componentIdByNode.get(l)!);
+    }
+  }
+
+  if (projectionComponentIds.size > 1) {
+    const componentsById = new Map<number, string[]>();
+    for (const l of projectionLabels) {
+      const id = componentIdByNode.get(l)!;
+      const group = componentsById.get(id) ?? [];
+      group.push(l);
+      componentsById.set(id, group);
+    }
+    const parts = Array.from(componentsById.values()).map(g => `{ ${g.sort().join(", ")} }`);
+    throw new DisconnectedSpecificationError(
+      `Specification is disconnected. Projection references labels from multiple components: ${parts.join("; ")}.`
+    );
+  }
+
+  // If there are nodes not in the projection's component, the spec is disconnected
+  const targetComponentId = projectionComponentIds.size === 1 ? Array.from(projectionComponentIds)[0] : null;
+  if (targetComponentId !== null) {
+    const givenSet = new Set(spec.given.map(g => g.name));
+    const disconnectedLabels: string[] = [];
+    for (const n of nodeList) {
+      const id = componentIdByNode.get(n)!;
+      if (id !== targetComponentId) {
+        // Ignore givens here; they may serve as connectors only
+        if (!givenSet.has(n)) {
+          disconnectedLabels.push(n);
+        }
+      }
+    }
+
+    if (disconnectedLabels.length > 0) {
+      const sorted = disconnectedLabels.sort();
+      throw new DisconnectedSpecificationError(
+        `Specification is disconnected. Labels not connected to the projection: ${sorted.join(", ")}.`
+      );
+    }
+  }
+}

--- a/src/specification/model.ts
+++ b/src/specification/model.ts
@@ -1,6 +1,7 @@
 import { hashSymbol } from "../fact/hydrate";
 import { describeSpecification } from "./description";
 import { CompositeProjection, Condition, ExistentialCondition, FactProjection, FieldProjection, HashProjection, Match, NamedComponentProjection, PathCondition, Projection, Role, Specification } from "./specification";
+import { enforceConnectivityValidation } from "./connectivity";
 
 type RoleMap = { [role: string]: string };
 
@@ -113,6 +114,7 @@ class Given<T extends any[]> {
             matches,
             projection
         };
+        enforceConnectivityValidation(specification);
         return new SpecificationOf<T, SpecificationResult<U>>(specification);
     }
 
@@ -135,6 +137,7 @@ class Given<T extends any[]> {
             matches,
             projection
         };
+        enforceConnectivityValidation(specification);
         return new SpecificationOf<T, U>(specification);
     }
 }

--- a/src/specification/specification-parser.ts
+++ b/src/specification/specification-parser.ts
@@ -5,6 +5,7 @@ import { PurgeConditions } from "../purge/purgeConditions";
 import { PredecessorCollection } from "../storage";
 import { Declaration, DeclaredFact } from "./declaration";
 import { Condition, ExistentialCondition, Label, Match, NamedComponentProjection, PathCondition, Projection, Role, Specification } from "./specification";
+import { enforceConnectivityValidation } from "./connectivity";
 
 type FieldValue = string | number | boolean;
 
@@ -425,7 +426,10 @@ export class SpecificationParser {
         const given = this.parseGiven();
         const { matches, labels } = this.parseMatches(given);
         const projection = this.parseProjection(labels);
-        return { given, matches, projection };
+        const specification = { given, matches, projection };
+        // Validate connectivity early for DSL-parsed specifications
+        enforceConnectivityValidation(specification);
+        return specification;
     }
 
     parseDeclaration(knownFacts: Declaration): Declaration {

--- a/test/specification/connectivitySpec.ts
+++ b/test/specification/connectivitySpec.ts
@@ -1,0 +1,136 @@
+import { Jinaga, JinagaTest, Specification, SpecificationParser, validateSpecificationConnectivity, User } from "../../src";
+import { Company, Employee, Office, OfficeClosed, President, model } from "../companyModel";
+
+function parseSpec(input: string): Specification {
+  const parser = new SpecificationParser(input);
+  parser.skipWhitespace();
+  return parser.parseSpecification();
+}
+
+describe("specification connectivity", () => {
+  let j: Jinaga;
+  let company: Company;
+  let office: Office;
+  let closed: OfficeClosed;
+  let president: President;
+
+  beforeEach(() => {
+    // Build a standard test graph using existing model
+    const user = new User("--- USER ---");
+    company = new Company(user, "ACME");
+    office = new Office(company, "HQ");
+    closed = new OfficeClosed(office, new Date());
+    president = new President(office, user);
+
+    j = JinagaTest.create({ initialState: [ user, company, office, closed, president ] });
+  });
+
+  describe("builder", () => {
+    it("passes when connected by path condition", async () => {
+      const spec = model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+      );
+
+      const result = await j.query(spec, company);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("passes with existential condition connected to the match unknown", async () => {
+      const spec = model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+          .exists(off => facts.ofType(OfficeClosed).join(oc => oc.office, off))
+      );
+
+      const result = await j.query(spec, company);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("passes with nested specification component connected to outer labels", async () => {
+      const spec = model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+          .select(off => ({
+            office: off,
+            closures: facts.ofType(OfficeClosed).join(oc => oc.office, off)
+          }))
+      );
+
+      const result = await j.query(spec, company);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("validator flags when projection references a disconnected given label", async () => {
+      const spec = model.given(Company, Office).match((c, p2, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+          .select(() => ({ otherOffice: p2 }))
+      );
+
+      expect(() => validateSpecificationConnectivity(spec.specification)).toThrow(/disconnected/i);
+    });
+
+    it("validator flags when a given is unused (isolated component)", () => {
+      const spec = model.given(Company, Office).select((c, p2) => ({ company: c }));
+      expect(() => validateSpecificationConnectivity(spec.specification)).toThrow(/disconnected/i);
+    });
+  });
+
+  describe("DSL", () => {
+    it("passes when connected by path condition", () => {
+      const spec = parseSpec(`
+        (c: Company) {
+          o: Office [ o->company:Company = c ]
+        } => o
+      `);
+      // parseSpecification already validates connectivity
+      expect(() => validateSpecificationConnectivity(spec)).not.toThrow();
+    });
+
+    it("passes with existential condition", () => {
+      const spec = parseSpec(`
+        (c: Company) {
+          o: Office [
+            o->company:Company = c
+            E {
+              e: Office.Closed [ e->office:Office = o ]
+            }
+          ]
+        } => o
+      `);
+      expect(() => validateSpecificationConnectivity(spec)).not.toThrow();
+    });
+
+    it("passes with nested specification in projection that references outer label", () => {
+      const spec = parseSpec(`
+        (c: Company) {
+          o: Office [ o->company:Company = c ]
+        } => { offices = { oc: Office.Closed [ oc->office:Office = o ] } => oc }
+      `);
+      expect(() => validateSpecificationConnectivity(spec)).not.toThrow();
+    });
+
+    it("throws when projection references a disconnected label", () => {
+      const spec = parseSpec(`
+        (p1: Player, p2: Playground) {
+          j: Join [ j->player:Player = p1 ]
+        } => p2
+      `);
+      expect(() => validateSpecificationConnectivity(spec)).toThrow(/disconnected/i);
+    });
+
+    it("throws when a given is entirely unused", () => {
+      const spec = parseSpec(`
+        (a: A, b: B) { } => a
+      `);
+      expect(() => validateSpecificationConnectivity(spec)).toThrow(/disconnected/i);
+    });
+
+    it("throws when projection references labels from multiple components", () => {
+      const spec = parseSpec(`
+        (p1: P1, p2: P2) {
+          u1: U1 [ u1->p1:P1 = p1 ]
+          u2: U2 [ u2->p2:P2 = p2 ]
+        } => { a = p1 b = p2 }
+      `);
+      expect(() => validateSpecificationConnectivity(spec)).toThrow(/multiple components/i);
+    });
+  });
+});


### PR DESCRIPTION
Adds specification connectivity validation to detect disconnected graphs early, improving developer feedback.

This implements issue #136 by introducing a central validator that checks for disconnected labels in specifications. It applies to specs built via the fluent API (`model.given.match`) and parsed from the DSL, including labels within nested projections. A configurable validation mode (`off` by default) is provided for controlled rollout.

---
<a href="https://cursor.com/background-agent?bcId=bc-600f466d-cb21-4990-8714-2404af06e7df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-600f466d-cb21-4990-8714-2404af06e7df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

