### PR TITLE
Implement websocket graph e2e plan iteratively

### DIFF
--- a/src/ws/authorization-websocket-handler.ts
+++ b/src/ws/authorization-websocket-handler.ts
@@ -73,16 +73,18 @@ export class AuthorizationWebSocketHandler {
         }
         // If we have a blank line terminator, ensure we have enough payload lines; otherwise treat as incomplete
         if (i >= parts.length || parts[i] !== "") {
-          // No terminator present; reconstruct remainder and exit
-          const remainder = [keyword, ...payload].join("\n");
-          buffer = remainder + (buffer ? "\n" + buffer : "");
-          break;
+                     // No terminator present; reconstruct remainder and exit
+           // Preserve line break so next chunk starts on a new line
+           const remainder = [keyword, ...payload].join("\n") + "\n";
+           buffer = remainder + (buffer ? buffer : "");
+           break;
         }
         const required = keyword === "SUB" ? 2 : 1;
         if (payload.length < required) {
-          // Not enough payload yet; push back without consuming terminator
-          const remainder = [keyword, ...payload].join("\n");
-          buffer = remainder + (buffer ? "\n" + buffer : "");
+          // Not enough payload yet; push back without consuming terminator.
+          // Preserve line break so the next incoming payload line does not concatenate with the keyword or prior payload.
+          const remainder = [keyword, ...payload].join("\n") + "\n";
+          buffer = remainder + (buffer ? buffer : "");
           break;
         }
         // Consume blank terminator


### PR DESCRIPTION
Fix WebSocket control-frame buffering to resolve E2E test timeout.

The previous logic for buffering incomplete control frames (like `SUB` or `UNSUB`) did not always preserve trailing newlines. This could lead to subsequent chunks being concatenated incorrectly, causing malformed frames that stalled the server and resulted in client-side test timeouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfa8ac54-761f-4466-890d-118cbcdd84a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cfa8ac54-761f-4466-890d-118cbcdd84a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

