### PR TITLE
Fix identity specification handling in match queries

### DIFF
--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -136,8 +136,6 @@ export class Jinaga {
     async query<T extends unknown[], U>(specification: SpecificationOf<T, U>, ...given: T): Promise<U[]> {
         const innerSpecification = specification.specification;
         
-        // Safety check: detect disconnected specifications as a fallback
-        // (This should already be caught during specification creation, but ensures consistency)
         detectDisconnectedSpecification(innerSpecification);
 
         if (!given || given.some(g => !g)) {

--- a/src/specification/model.ts
+++ b/src/specification/model.ts
@@ -102,8 +102,9 @@ class Given<T extends any[]> {
             return createFactProxy(factRepository, this.factTypeMap, name, [], factType);
         });
         const result = (definition as any)(...labels, factRepository);
-        const matches = result.matches ?? [];
-        const projection = result.projection;
+        const traversal = ensureTraversal(result);
+        const matches = traversal.matches;
+        const projection = traversal.projection;
         const given = this.factTypes.map((type, i) => {
             const name = `p${i + 1}`;
             return { name, type };
@@ -448,6 +449,15 @@ function lookupRoleType(factTypeMap: FactTypeMap, factType: string, role: string
         return undefined;
     }
     return roleType;
+}
+
+function ensureTraversal<U>(definition: LabelOf<U> | Traversal<U>): Traversal<U> {
+    if (isLabel<U>(definition)) {
+        return traversalFromDefinition(definition as U, []);
+    }
+    else {
+        return definition;
+    }
 }
 
 function traversalFromDefinition<U>(definition: U, matches: Match[]): Traversal<U> {

--- a/test/distribution/distributionUnitTestSpec.ts
+++ b/test/distribution/distributionUnitTestSpec.ts
@@ -1,0 +1,48 @@
+import { buildModel, DistributionRules, JinagaTest, LabelOf, User } from "../../src";
+
+describe("Distribution rules in unit tests", () => {
+    it("should pass when distribution rule allows", async () => {
+        const loggedInUser = new User("user1");
+        const jinaga = JinagaTest.create({
+            model,
+            user: loggedInUser,
+            distribution,
+            initialState: [
+                loggedInUser
+            ]
+        });
+
+        const namesSpec = model.given(User).match(user => UserName.current(user));
+        const names = await jinaga.query(namesSpec, loggedInUser);
+        expect(names).toStrictEqual([]);
+    });
+});
+
+class UserName {
+    static Type = "UserName" as const;
+    type = UserName.Type;
+
+    constructor(
+        public user: User,
+        public value: string,
+        public prior: UserName[]) {}
+
+    static current(user: LabelOf<User>) {
+        return user.successors(UserName, userName => userName.user)
+            .notExists(userName => userName.successors(UserName, next => next.prior));
+    }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(UserName, f => f
+        .predecessor("user", User)
+        .predecessor("prior", UserName)
+    )
+);
+
+function distribution(r: DistributionRules) {
+    return r
+        .share(model.given(User).match(user => UserName.current(user)))
+        .with(model.given(User).match(user => user));
+}

--- a/test/distribution/distributionUnitTestSpec.ts
+++ b/test/distribution/distributionUnitTestSpec.ts
@@ -16,6 +16,23 @@ describe("Distribution rules in unit tests", () => {
         const names = await jinaga.query(namesSpec, loggedInUser);
         expect(names).toStrictEqual([]);
     });
+
+    it("should throw when querying as a different user", async () => {
+        const user1 = new User("user1");
+        const user2 = new User("user2");
+        const jinaga = JinagaTest.create({
+            model,
+            user: user2,
+            distribution,
+            initialState: [
+                user1,
+                user2
+            ]
+        });
+
+        const namesSpec = model.given(User).match(user => UserName.current(user));
+        await expect(jinaga.query(namesSpec, user1)).rejects.toThrow();
+    });
 });
 
 class UserName {

--- a/test/specification/givenSpec.ts
+++ b/test/specification/givenSpec.ts
@@ -2,8 +2,16 @@ import { SpecificationOf, User } from "../../src";
 import { Company, Office, OfficeClosed, OfficeReopened, President, UserName, model } from "../companyModel";
 
 describe("given", () => {
-    it("should parse an identity specification", () => {
-        const specification = model.given(Company).select((company, facts) => company);
+    it("should parse an identity specification using select", () => {
+        const specification = model.given(Company).select((company) => company);
+
+        expectSpecification(specification, `
+            (p1: Company) {
+            } => p1`);
+    });
+
+    it("should parse an identity specification using match", () => {
+        const specification = model.given(Company).match((company) => company);
 
         expectSpecification(specification, `
             (p1: Company) {


### PR DESCRIPTION
Address the issue where identity specifications could not utilize match. Transform labels into traversals to ensure proper functionality and add tests to verify that distribution rules that use identity matches.