### PR TITLE
Support multiple authorization and distribution blocks

### DIFF
--- a/src/authorization/authorizationRules.ts
+++ b/src/authorization/authorizationRules.ts
@@ -502,7 +502,15 @@ export class AuthorizationRules {
     static loadFromDescription(description: string): AuthorizationRules {
         const parser = new SpecificationParser(description);
         parser.skipWhitespace();
-        const authorizationRules = parser.parseAuthorizationRules();
+        let authorizationRules = AuthorizationRules.empty;
+        while (!parser.atEnd()) {
+            if (parser.continues("authorization")) {
+                authorizationRules = authorizationRules.merge(parser.parseAuthorizationRules());
+            }
+            else {
+                parser.expectEnd();
+            }
+        }
         return authorizationRules;
     }
 }

--- a/src/distribution/distribution-rules.ts
+++ b/src/distribution/distribution-rules.ts
@@ -87,7 +87,15 @@ export class DistributionRules {
   static loadFromDescription(description: string): DistributionRules {
     const parser = new SpecificationParser(description);
     parser.skipWhitespace();
-    const distributionRules = parser.parseDistributionRules();
+    let distributionRules = DistributionRules.empty;
+    while (!parser.atEnd()) {
+      if (parser.continues("distribution")) {
+        distributionRules = distributionRules.merge(parser.parseDistributionRules());
+      }
+      else {
+        parser.expectEnd();
+      }
+    }
     return distributionRules;
   }
 }

--- a/test/authorization/authorizationSpecificationSpec.ts
+++ b/test/authorization/authorizationSpecificationSpec.ts
@@ -148,6 +148,41 @@ describe("Authorization rules description", () => {
     const loaded = AuthorizationRules.loadFromDescription(description);
     expect(loaded.hasRule(Content.Type)).toBeTruthy();
   });
+
+  it("should accumulate rules across multiple authorization blocks", () => {
+    const description = `
+authorization {
+  any Jinaga.User
+}
+authorization {
+  any Feedback.Site
+}
+`;
+    const loaded = AuthorizationRules.loadFromDescription(description);
+    expect(loaded.hasRule("Jinaga.User")).toBeTruthy();
+    expect(loaded.hasRule("Feedback.Site")).toBeTruthy();
+  });
+
+  it("should reject trailing content of a different block type", () => {
+    const description = `
+authorization {
+  any Jinaga.User
+}
+distribution {
+}
+`;
+    expect(() => AuthorizationRules.loadFromDescription(description)).toThrow();
+  });
+
+  it("should reject trailing garbage", () => {
+    const description = `
+authorization {
+  any Jinaga.User
+}
+not a valid block
+`;
+    expect(() => AuthorizationRules.loadFromDescription(description)).toThrow();
+  });
 });
 
 class User {

--- a/test/distribution/distributionDescriptionSpec.ts
+++ b/test/distribution/distributionDescriptionSpec.ts
@@ -16,13 +16,10 @@ describe("Distribution rules from description", () => {
 
   it("should accumulate rules across multiple distribution blocks", () => {
     const single = describeDistributionRules(distribution);
+    const singleLoaded = DistributionRules.loadFromDescription(single);
     const doubled = single + single;
-    const loaded = DistributionRules.loadFromDescription(doubled);
-    const roundTrip = describeDistributionRules(_ => loaded);
-    // Merging the same rules with themselves yields the same set
-    // (DistributionRules.merge concatenates rule entries).
-    expect(roundTrip.startsWith("distribution {")).toBeTruthy();
-    expect(roundTrip.endsWith("}\n")).toBeTruthy();
+    const doubledLoaded = DistributionRules.loadFromDescription(doubled);
+    expect(doubledLoaded.rules.length).toEqual(singleLoaded.rules.length * 2);
   });
 
   it("should reject trailing content of a different block type", () => {

--- a/test/distribution/distributionDescriptionSpec.ts
+++ b/test/distribution/distributionDescriptionSpec.ts
@@ -13,4 +13,34 @@ describe("Distribution rules from description", () => {
     const roundTrip = describeDistributionRules(_ => loaded);
     expect(roundTrip).toEqual(description);
   });
+
+  it("should accumulate rules across multiple distribution blocks", () => {
+    const single = describeDistributionRules(distribution);
+    const doubled = single + single;
+    const loaded = DistributionRules.loadFromDescription(doubled);
+    const roundTrip = describeDistributionRules(_ => loaded);
+    // Merging the same rules with themselves yields the same set
+    // (DistributionRules.merge concatenates rule entries).
+    expect(roundTrip.startsWith("distribution {")).toBeTruthy();
+    expect(roundTrip.endsWith("}\n")).toBeTruthy();
+  });
+
+  it("should reject trailing content of a different block type", () => {
+    const description = `
+distribution {
+}
+authorization {
+}
+`;
+    expect(() => DistributionRules.loadFromDescription(description)).toThrow();
+  });
+
+  it("should reject trailing garbage", () => {
+    const description = `
+distribution {
+}
+not a valid block
+`;
+    expect(() => DistributionRules.loadFromDescription(description)).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
Updated the specification parser to support multiple `authorization` and `distribution` blocks in a single description, accumulating rules across all blocks while rejecting invalid trailing content.

## Key Changes
- **AuthorizationRules.loadFromDescription()**: Modified to loop through the description and accumulate rules from multiple `authorization` blocks using `merge()`, while rejecting any trailing content that isn't an `authorization` block
- **DistributionRules.loadFromDescription()**: Applied the same pattern to support multiple `distribution` blocks with proper accumulation and validation
- **Error handling**: Both parsers now call `expectEnd()` when encountering unrecognized content, throwing an error for invalid trailing blocks or garbage text

## Implementation Details
- Both implementations follow the same pattern: initialize with empty rules, loop while not at end of input, check for the expected block type, merge parsed rules, and reject anything else
- The `merge()` method is used to combine rules from multiple blocks
- Invalid scenarios now properly throw errors:
  - A `distribution` block following an `authorization` block (and vice versa)
  - Any unrecognized text after valid blocks
- Comprehensive test coverage added for accumulation and error cases in both spec files

https://claude.ai/code/session_01Q8hAfVRSB9pcAqpqC6XmJB