### PR TITLE
Authorize negating feeds and lock in multi-given distribution rules

### DIFF
--- a/src/distribution/distribution-composition.ts
+++ b/src/distribution/distribution-composition.ts
@@ -1,0 +1,423 @@
+import {
+  EdgeDescription,
+  NotExistsConditionDescription,
+  Skeleton,
+  skeletonOfSpecification
+} from "../specification/skeleton";
+import { Specification, isPathCondition, specificationIsIdentity } from "../specification/specification";
+import { FactReference, ReferencesByName, Storage, factReferenceEquals } from "../storage";
+import { DistributionRules } from "./distribution-rules";
+
+type FactMapping = Map<number, number>;
+
+interface DistributionRuleEntry {
+  specification: Specification;
+  feeds: Specification[];
+  user: Specification | null;
+}
+
+interface RuleAuth {
+  // Whether the rule shares with everyone. No user check required.
+  isEveryone: boolean;
+  // Structural key of the rule's user spec, or null when isEveryone.
+  // Rules with matching keys authorize the same set of users.
+  userKey: string | null;
+  // Whether the rule's user spec evaluated successfully for the user
+  // against namedStart. Rules with userKey present here are treated as
+  // authorized; other rules with the same userKey are accepted by
+  // structural equivalence.
+  verifiedForUser: boolean;
+}
+
+/**
+ * Attempt to authorize the target feed by composing multiple distribution rules.
+ *
+ * A target feed is "compositionally authorized" if its outer edges and any
+ * notExists conditions can be covered by a sequence of rules, where each
+ * rule's input either targets a feed given or matches an output of an
+ * earlier rule in the composition. Every rule used must authorize the
+ * logged-in user.
+ *
+ * This makes negating feeds (produced by `.notExists()`) authorizable when
+ * each fact type in the traversal is independently shared with the user.
+ */
+export async function canAuthorizeByComposition(
+  targetFeed: Specification,
+  namedStart: ReferencesByName,
+  user: FactReference | null,
+  rules: DistributionRules,
+  store: Storage
+): Promise<boolean> {
+  const targetSkeleton = skeletonOfSpecification(targetFeed);
+  if (targetSkeleton.edges.length === 0 && targetSkeleton.notExistsConditions.length === 0) {
+    return false;
+  }
+
+  const ruleAuthCache = await computeRuleAuthorizations(rules, namedStart, user, store);
+  const verifiedUserKeys = new Set<string | null>();
+  for (const auth of ruleAuthCache.values()) {
+    if (auth.verifiedForUser && auth.userKey !== null) {
+      verifiedUserKeys.add(auth.userKey);
+    }
+  }
+
+  const initialLive = new Set<number>(targetSkeleton.inputs.map(i => i.factIndex));
+  return tryCover(
+    targetSkeleton,
+    initialLive,
+    new Set(targetSkeleton.edges.map(e => e.edgeIndex)),
+    new Set(targetSkeleton.notExistsConditions.map((_, i) => i)),
+    rules,
+    ruleAuthCache,
+    verifiedUserKeys,
+    new Set()
+  );
+}
+
+async function computeRuleAuthorizations(
+  rules: DistributionRules,
+  namedStart: ReferencesByName,
+  user: FactReference | null,
+  store: Storage
+): Promise<Map<DistributionRuleEntry, RuleAuth>> {
+  const map = new Map<DistributionRuleEntry, RuleAuth>();
+  for (const rule of rules.rules) {
+    if (rule.user === null) {
+      map.set(rule, { isEveryone: true, userKey: null, verifiedForUser: true });
+      continue;
+    }
+    const userKey = JSON.stringify(rule.user);
+
+    const start = ruleStartFromNamedStart(rule.specification, namedStart);
+    if (start === null || user === null) {
+      map.set(rule, { isEveryone: false, userKey, verifiedForUser: false });
+      continue;
+    }
+
+    const verifiedForUser = await evaluateUserSpec(rule.user, start, user, store);
+    map.set(rule, { isEveryone: false, userKey, verifiedForUser });
+  }
+  return map;
+}
+
+function ruleStartFromNamedStart(
+  ruleSpec: Specification,
+  namedStart: ReferencesByName
+): FactReference[] | null {
+  const start: FactReference[] = [];
+  for (const given of ruleSpec.given) {
+    const ref = namedStart[given.label.name];
+    if (!ref || ref.type !== given.label.type) return null;
+    start.push(ref);
+  }
+  return start;
+}
+
+async function evaluateUserSpec(
+  userSpec: Specification,
+  start: FactReference[],
+  user: FactReference,
+  store: Storage
+): Promise<boolean> {
+  if (userSpec.projection.type !== "fact") return false;
+  const label = userSpec.projection.label;
+
+  if (specificationIsIdentity(userSpec)) {
+    const ref = executeDeterministicSpecification(userSpec, label, start);
+    return ref !== null && factReferenceEquals(user)(ref);
+  }
+  const results = await store.read(start, userSpec);
+  return results.some(r => {
+    const ref = r.tuple[label];
+    return ref && factReferenceEquals(user)(ref);
+  });
+}
+
+function executeDeterministicSpecification(
+  specification: Specification,
+  label: string,
+  start: FactReference[]
+): FactReference | null {
+  const givenIndex = specification.given.findIndex(g => g.label.name === label);
+  if (givenIndex !== -1) return start[givenIndex] ?? null;
+
+  const match = specification.matches.find(m => m.unknown.name === label);
+  if (!match) return null;
+  const referencedLabels = match.conditions.filter(isPathCondition).map(c => c.labelRight);
+  if (referencedLabels.length !== 1) return null;
+  const index = specification.given.findIndex(g => g.label.name === referencedLabels[0]);
+  if (index === -1) return null;
+  return start[index] ?? null;
+}
+
+function isRuleAuthorized(
+  rule: DistributionRuleEntry,
+  ruleAuthCache: Map<DistributionRuleEntry, RuleAuth>,
+  verifiedUserKeys: Set<string | null>
+): boolean {
+  const auth = ruleAuthCache.get(rule);
+  if (!auth) return false;
+  if (auth.isEveryone) return true;
+  if (auth.verifiedForUser) return true;
+  return auth.userKey !== null && verifiedUserKeys.has(auth.userKey);
+}
+
+function tryCover(
+  targetSkeleton: Skeleton,
+  liveFacts: Set<number>,
+  uncoveredEdges: Set<number>,
+  uncoveredNotExists: Set<number>,
+  rules: DistributionRules,
+  ruleAuthCache: Map<DistributionRuleEntry, RuleAuth>,
+  verifiedUserKeys: Set<string | null>,
+  visitedStates: Set<string>
+): boolean {
+  if (uncoveredEdges.size === 0 && uncoveredNotExists.size === 0) {
+    return true;
+  }
+
+  const stateKey = serializeState(liveFacts, uncoveredEdges, uncoveredNotExists);
+  if (visitedStates.has(stateKey)) return false;
+  visitedStates.add(stateKey);
+
+  // Try to cover an uncovered notExists condition by recursively authorizing
+  // its inner skeleton as a sub-target anchored at a live fact.
+  for (const neIdx of uncoveredNotExists) {
+    const ne = targetSkeleton.notExistsConditions[neIdx];
+    const anchorFact = findNotExistsAnchor(ne, liveFacts);
+    if (anchorFact === null) continue;
+    if (!canCoverNotExists(ne, anchorFact, targetSkeleton, rules, ruleAuthCache, verifiedUserKeys)) {
+      continue;
+    }
+    const nextUncoveredNE = new Set(uncoveredNotExists);
+    nextUncoveredNE.delete(neIdx);
+    if (tryCover(targetSkeleton, liveFacts, uncoveredEdges, nextUncoveredNE, rules, ruleAuthCache, verifiedUserKeys, visitedStates)) {
+      return true;
+    }
+  }
+
+  for (const rule of rules.rules) {
+    if (!isRuleAuthorized(rule, ruleAuthCache, verifiedUserKeys)) continue;
+
+    for (const ruleFeed of rule.feeds) {
+      const ruleSkeleton = skeletonOfSpecification(ruleFeed);
+      // Phase 1 supports only rules whose feeds carry no notExists. Rules with
+      // their own notExists feeds compose differently and are deferred.
+      if (ruleSkeleton.notExistsConditions.length > 0) continue;
+      if (ruleSkeleton.edges.length === 0) continue;
+
+      const embeddings = findEmbeddings(ruleSkeleton, targetSkeleton, liveFacts, uncoveredEdges);
+      for (const embedding of embeddings) {
+        const nextLive = new Set(liveFacts);
+        for (const ruleFact of ruleSkeleton.facts) {
+          const targetIdx = embedding.get(ruleFact.factIndex);
+          if (targetIdx !== undefined) nextLive.add(targetIdx);
+        }
+        const nextUncoveredEdges = new Set(uncoveredEdges);
+        for (const ruleEdge of ruleSkeleton.edges) {
+          const targetEdgeIndex = findCorrespondingTargetEdgeIndex(ruleEdge, embedding, targetSkeleton);
+          if (targetEdgeIndex !== null) nextUncoveredEdges.delete(targetEdgeIndex);
+        }
+        if (nextUncoveredEdges.size === uncoveredEdges.size) continue;
+        if (tryCover(targetSkeleton, nextLive, nextUncoveredEdges, uncoveredNotExists, rules, ruleAuthCache, verifiedUserKeys, visitedStates)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+function canCoverNotExists(
+  ne: NotExistsConditionDescription,
+  anchorFactIndex: number,
+  targetSkeleton: Skeleton,
+  rules: DistributionRules,
+  ruleAuthCache: Map<DistributionRuleEntry, RuleAuth>,
+  verifiedUserKeys: Set<string | null>
+): boolean {
+  const innerFactIndices = collectFactIndices(ne);
+  innerFactIndices.add(anchorFactIndex);
+
+  const innerSkeleton: Skeleton = {
+    facts: targetSkeleton.facts.filter(f => innerFactIndices.has(f.factIndex)),
+    inputs: [{ factIndex: anchorFactIndex, inputIndex: 0 }],
+    edges: ne.edges.slice(),
+    notExistsConditions: ne.notExistsConditions.slice(),
+    outputs: []
+  };
+
+  return tryCover(
+    innerSkeleton,
+    new Set<number>([anchorFactIndex]),
+    new Set(innerSkeleton.edges.map(e => e.edgeIndex)),
+    new Set(innerSkeleton.notExistsConditions.map((_, i) => i)),
+    rules,
+    ruleAuthCache,
+    verifiedUserKeys,
+    new Set()
+  );
+}
+
+function collectFactIndices(ne: NotExistsConditionDescription): Set<number> {
+  const indices = new Set<number>();
+  for (const e of ne.edges) {
+    indices.add(e.predecessorFactIndex);
+    indices.add(e.successorFactIndex);
+  }
+  for (const nested of ne.notExistsConditions) {
+    for (const idx of collectFactIndices(nested)) indices.add(idx);
+  }
+  return indices;
+}
+
+function findNotExistsAnchor(
+  ne: NotExistsConditionDescription,
+  liveFacts: Set<number>
+): number | null {
+  for (const e of ne.edges) {
+    if (liveFacts.has(e.predecessorFactIndex)) return e.predecessorFactIndex;
+    if (liveFacts.has(e.successorFactIndex)) return e.successorFactIndex;
+  }
+  return null;
+}
+
+function findEmbeddings(
+  ruleSkeleton: Skeleton,
+  targetSkeleton: Skeleton,
+  liveFacts: Set<number>,
+  uncoveredEdges: Set<number>
+): FactMapping[] {
+  const results: FactMapping[] = [];
+  const inputs = ruleSkeleton.inputs;
+  if (inputs.length === 0) return results;
+
+  const assignInput = (
+    index: number,
+    mapping: FactMapping,
+    usedTargets: Set<number>
+  ): void => {
+    if (index === inputs.length) {
+      extendByEdges(mapping, usedTargets, new Set(), new Set(), ruleSkeleton, targetSkeleton, uncoveredEdges, results);
+      return;
+    }
+    const input = inputs[index];
+    const ruleFact = ruleSkeleton.facts.find(f => f.factIndex === input.factIndex);
+    if (!ruleFact) return;
+    for (const li of liveFacts) {
+      if (usedTargets.has(li)) continue;
+      const tf = targetSkeleton.facts.find(f => f.factIndex === li);
+      if (!tf || tf.factType !== ruleFact.factType) continue;
+      const nextMapping = new Map(mapping);
+      nextMapping.set(input.factIndex, li);
+      const nextUsed = new Set(usedTargets);
+      nextUsed.add(li);
+      assignInput(index + 1, nextMapping, nextUsed);
+    }
+  };
+
+  assignInput(0, new Map(), new Set());
+  return results;
+}
+
+function extendByEdges(
+  mapping: FactMapping,
+  usedTargets: Set<number>,
+  matchedRuleEdges: Set<number>,
+  usedTargetEdges: Set<number>,
+  ruleSkeleton: Skeleton,
+  targetSkeleton: Skeleton,
+  uncoveredEdges: Set<number>,
+  results: FactMapping[]
+): void {
+  if (matchedRuleEdges.size === ruleSkeleton.edges.length) {
+    results.push(mapping);
+    return;
+  }
+  const ruleEdgeIdx = ruleSkeleton.edges.findIndex((e, i) =>
+    !matchedRuleEdges.has(i) &&
+    (mapping.has(e.predecessorFactIndex) || mapping.has(e.successorFactIndex))
+  );
+  if (ruleEdgeIdx === -1) return;
+  const ruleEdge = ruleSkeleton.edges[ruleEdgeIdx];
+
+  const candidates = targetSkeleton.edges.filter(te => {
+    if (!uncoveredEdges.has(te.edgeIndex)) return false;
+    if (usedTargetEdges.has(te.edgeIndex)) return false;
+    if (te.roleName !== ruleEdge.roleName) return false;
+
+    const mappedPred = mapping.get(ruleEdge.predecessorFactIndex);
+    if (mappedPred !== undefined && mappedPred !== te.predecessorFactIndex) return false;
+    const mappedSucc = mapping.get(ruleEdge.successorFactIndex);
+    if (mappedSucc !== undefined && mappedSucc !== te.successorFactIndex) return false;
+
+    const rulePred = ruleSkeleton.facts.find(f => f.factIndex === ruleEdge.predecessorFactIndex);
+    const ruleSucc = ruleSkeleton.facts.find(f => f.factIndex === ruleEdge.successorFactIndex);
+    const targetPred = targetSkeleton.facts.find(f => f.factIndex === te.predecessorFactIndex);
+    const targetSucc = targetSkeleton.facts.find(f => f.factIndex === te.successorFactIndex);
+    if (!rulePred || !ruleSucc || !targetPred || !targetSucc) return false;
+    if (rulePred.factType !== targetPred.factType) return false;
+    if (ruleSucc.factType !== targetSucc.factType) return false;
+
+    // Reject mappings that would collide two distinct rule facts onto one target fact.
+    if (mappedPred === undefined && usedTargets.has(te.predecessorFactIndex)) {
+      const existing = mappedFromTarget(mapping, te.predecessorFactIndex);
+      if (existing !== null && existing !== ruleEdge.predecessorFactIndex) return false;
+    }
+    if (mappedSucc === undefined && usedTargets.has(te.successorFactIndex)) {
+      const existing = mappedFromTarget(mapping, te.successorFactIndex);
+      if (existing !== null && existing !== ruleEdge.successorFactIndex) return false;
+    }
+    return true;
+  });
+
+  for (const te of candidates) {
+    const nextMapping = new Map(mapping);
+    nextMapping.set(ruleEdge.predecessorFactIndex, te.predecessorFactIndex);
+    nextMapping.set(ruleEdge.successorFactIndex, te.successorFactIndex);
+    const nextUsed = new Set(usedTargets);
+    nextUsed.add(te.predecessorFactIndex);
+    nextUsed.add(te.successorFactIndex);
+    const nextMatched = new Set(matchedRuleEdges);
+    nextMatched.add(ruleEdgeIdx);
+    const nextTargetEdges = new Set(usedTargetEdges);
+    nextTargetEdges.add(te.edgeIndex);
+    extendByEdges(nextMapping, nextUsed, nextMatched, nextTargetEdges, ruleSkeleton, targetSkeleton, uncoveredEdges, results);
+  }
+}
+
+function mappedFromTarget(mapping: FactMapping, targetIndex: number): number | null {
+  for (const [r, t] of mapping.entries()) {
+    if (t === targetIndex) return r;
+  }
+  return null;
+}
+
+function findCorrespondingTargetEdgeIndex(
+  ruleEdge: EdgeDescription,
+  mapping: FactMapping,
+  targetSkeleton: Skeleton
+): number | null {
+  const predTarget = mapping.get(ruleEdge.predecessorFactIndex);
+  const succTarget = mapping.get(ruleEdge.successorFactIndex);
+  if (predTarget === undefined || succTarget === undefined) return null;
+  const te = targetSkeleton.edges.find(e =>
+    e.predecessorFactIndex === predTarget &&
+    e.successorFactIndex === succTarget &&
+    e.roleName === ruleEdge.roleName
+  );
+  return te ? te.edgeIndex : null;
+}
+
+function serializeState(
+  liveFacts: Set<number>,
+  uncoveredEdges: Set<number>,
+  uncoveredNotExists: Set<number>
+): string {
+  return JSON.stringify({
+    l: [...liveFacts].sort((a, b) => a - b),
+    e: [...uncoveredEdges].sort((a, b) => a - b),
+    n: [...uncoveredNotExists].sort((a, b) => a - b)
+  });
+}

--- a/src/distribution/distribution-composition.ts
+++ b/src/distribution/distribution-composition.ts
@@ -4,6 +4,7 @@ import {
   Skeleton,
   skeletonOfSpecification
 } from "../specification/skeleton";
+import { describeSpecification } from "../specification/description";
 import { Specification, isPathCondition, specificationIsIdentity } from "../specification/specification";
 import { FactReference, ReferencesByName, Storage, factReferenceEquals } from "../storage";
 import { DistributionRules } from "./distribution-rules";
@@ -53,7 +54,18 @@ export async function canAuthorizeByComposition(
     return false;
   }
 
-  const ruleAuthCache = await computeRuleAuthorizations(rules, namedStart, user, store);
+  // Pre-compute skeletons for every rule feed once. The recursive search runs
+  // many iterations over these and skeletonOfSpecification is non-trivial.
+  const ruleFeedSkeletons = new Map<Specification, Skeleton>();
+  for (const rule of rules.rules) {
+    for (const ruleFeed of rule.feeds) {
+      if (!ruleFeedSkeletons.has(ruleFeed)) {
+        ruleFeedSkeletons.set(ruleFeed, skeletonOfSpecification(ruleFeed));
+      }
+    }
+  }
+
+  const ruleAuthCache = await computeRuleAuthorizations(rules, targetFeed, namedStart, user, store);
   const verifiedUserKeys = new Set<string | null>();
   for (const auth of ruleAuthCache.values()) {
     if (auth.verifiedForUser && auth.userKey !== null) {
@@ -68,6 +80,7 @@ export async function canAuthorizeByComposition(
     new Set(targetSkeleton.edges.map(e => e.edgeIndex)),
     new Set(targetSkeleton.notExistsConditions.map((_, i) => i)),
     rules,
+    ruleFeedSkeletons,
     ruleAuthCache,
     verifiedUserKeys,
     new Set()
@@ -76,6 +89,7 @@ export async function canAuthorizeByComposition(
 
 async function computeRuleAuthorizations(
   rules: DistributionRules,
+  targetFeed: Specification,
   namedStart: ReferencesByName,
   user: FactReference | null,
   store: Storage
@@ -86,9 +100,12 @@ async function computeRuleAuthorizations(
       map.set(rule, { isEveryone: true, userKey: null, verifiedForUser: true });
       continue;
     }
-    const userKey = JSON.stringify(rule.user);
+    // Use describeSpecification for a canonical key. JSON.stringify would
+    // depend on accidental property ordering and is sensitive to label
+    // renames that don't change meaning.
+    const userKey = describeSpecification(rule.user, 0);
 
-    const start = ruleStartFromNamedStart(rule.specification, namedStart);
+    const start = ruleStartFromTarget(rule.specification, targetFeed, namedStart);
     if (start === null || user === null) {
       map.set(rule, { isEveryone: false, userKey, verifiedForUser: false });
       continue;
@@ -100,15 +117,35 @@ async function computeRuleAuthorizations(
   return map;
 }
 
-function ruleStartFromNamedStart(
+/**
+ * Resolve concrete fact references for a rule's givens using the target
+ * feed's namedStart. Match by type (positionally among same-typed givens),
+ * not by label name, because rules loaded from description may use labels
+ * unrelated to the target's. Returns null when the rule's givens can't be
+ * uniquely satisfied by the target's namedStart.
+ */
+function ruleStartFromTarget(
   ruleSpec: Specification,
+  targetFeed: Specification,
   namedStart: ReferencesByName
 ): FactReference[] | null {
+  const targetByType = new Map<string, FactReference[]>();
+  for (const given of targetFeed.given) {
+    const ref = namedStart[given.label.name];
+    if (!ref) return null;
+    const list = targetByType.get(given.label.type) ?? [];
+    list.push(ref);
+    targetByType.set(given.label.type, list);
+  }
+  const cursorByType = new Map<string, number>();
   const start: FactReference[] = [];
   for (const given of ruleSpec.given) {
-    const ref = namedStart[given.label.name];
-    if (!ref || ref.type !== given.label.type) return null;
-    start.push(ref);
+    const candidates = targetByType.get(given.label.type);
+    if (!candidates) return null;
+    const cursor = cursorByType.get(given.label.type) ?? 0;
+    if (cursor >= candidates.length) return null;
+    start.push(candidates[cursor]);
+    cursorByType.set(given.label.type, cursor + 1);
   }
   return start;
 }
@@ -168,6 +205,7 @@ function tryCover(
   uncoveredEdges: Set<number>,
   uncoveredNotExists: Set<number>,
   rules: DistributionRules,
+  ruleFeedSkeletons: Map<Specification, Skeleton>,
   ruleAuthCache: Map<DistributionRuleEntry, RuleAuth>,
   verifiedUserKeys: Set<string | null>,
   visitedStates: Set<string>
@@ -186,12 +224,12 @@ function tryCover(
     const ne = targetSkeleton.notExistsConditions[neIdx];
     const anchorFact = findNotExistsAnchor(ne, liveFacts);
     if (anchorFact === null) continue;
-    if (!canCoverNotExists(ne, anchorFact, targetSkeleton, rules, ruleAuthCache, verifiedUserKeys)) {
+    if (!canCoverNotExists(ne, anchorFact, targetSkeleton, rules, ruleFeedSkeletons, ruleAuthCache, verifiedUserKeys)) {
       continue;
     }
     const nextUncoveredNE = new Set(uncoveredNotExists);
     nextUncoveredNE.delete(neIdx);
-    if (tryCover(targetSkeleton, liveFacts, uncoveredEdges, nextUncoveredNE, rules, ruleAuthCache, verifiedUserKeys, visitedStates)) {
+    if (tryCover(targetSkeleton, liveFacts, uncoveredEdges, nextUncoveredNE, rules, ruleFeedSkeletons, ruleAuthCache, verifiedUserKeys, visitedStates)) {
       return true;
     }
   }
@@ -200,7 +238,8 @@ function tryCover(
     if (!isRuleAuthorized(rule, ruleAuthCache, verifiedUserKeys)) continue;
 
     for (const ruleFeed of rule.feeds) {
-      const ruleSkeleton = skeletonOfSpecification(ruleFeed);
+      const ruleSkeleton = ruleFeedSkeletons.get(ruleFeed);
+      if (!ruleSkeleton) continue;
       // Phase 1 supports only rules whose feeds carry no notExists. Rules with
       // their own notExists feeds compose differently and are deferred.
       if (ruleSkeleton.notExistsConditions.length > 0) continue;
@@ -219,7 +258,7 @@ function tryCover(
           if (targetEdgeIndex !== null) nextUncoveredEdges.delete(targetEdgeIndex);
         }
         if (nextUncoveredEdges.size === uncoveredEdges.size) continue;
-        if (tryCover(targetSkeleton, nextLive, nextUncoveredEdges, uncoveredNotExists, rules, ruleAuthCache, verifiedUserKeys, visitedStates)) {
+        if (tryCover(targetSkeleton, nextLive, nextUncoveredEdges, uncoveredNotExists, rules, ruleFeedSkeletons, ruleAuthCache, verifiedUserKeys, visitedStates)) {
           return true;
         }
       }
@@ -234,6 +273,7 @@ function canCoverNotExists(
   anchorFactIndex: number,
   targetSkeleton: Skeleton,
   rules: DistributionRules,
+  ruleFeedSkeletons: Map<Specification, Skeleton>,
   ruleAuthCache: Map<DistributionRuleEntry, RuleAuth>,
   verifiedUserKeys: Set<string | null>
 ): boolean {
@@ -254,6 +294,7 @@ function canCoverNotExists(
     new Set(innerSkeleton.edges.map(e => e.edgeIndex)),
     new Set(innerSkeleton.notExistsConditions.map((_, i) => i)),
     rules,
+    ruleFeedSkeletons,
     ruleAuthCache,
     verifiedUserKeys,
     new Set()

--- a/src/distribution/distribution-engine.ts
+++ b/src/distribution/distribution-engine.ts
@@ -2,6 +2,7 @@ import { describeSpecification } from "../specification/description";
 import { EdgeDescription, FactDescription, InputDescription, NotExistsConditionDescription, Skeleton, skeletonOfSpecification } from "../specification/skeleton";
 import { Specification, isPathCondition, specificationIsIdentity } from "../specification/specification";
 import { FactReference, ReferencesByName, Storage, factReferenceEquals } from "../storage";
+import { canAuthorizeByComposition } from "./distribution-composition";
 import { DistributionRules } from "./distribution-rules";
 
 export interface DistributionSuccess {
@@ -122,6 +123,14 @@ export class DistributionEngine {
           }
         }
       }
+    }
+
+    // No single rule matched the target feed (or the user did not satisfy
+    // the matching rules). Try compositional authorization: if the target
+    // can be covered by a sequence of rules that each authorize the user,
+    // then the target is authorized.
+    if (await canAuthorizeByComposition(targetFeed, namedStart, user, this.distributionRules, this.store)) {
+      return { type: 'success' };
     }
 
     if (reasons.length === 0) {

--- a/test/distribution/multiGivenDistributionSpec.ts
+++ b/test/distribution/multiGivenDistributionSpec.ts
@@ -1,0 +1,78 @@
+import { DistributionRules, JinagaTest, Trace, User } from "@src";
+import { Administrator, Company, model } from "../companyModel";
+
+describe("multi-given distribution rules", () => {
+  Trace.off();
+
+  const creator = new User("creator");
+  const adminUser = new User("adminUser");
+  const otherUser = new User("otherUser");
+  const company = new Company(creator, "Foo");
+  const administrator = new Administrator(company, adminUser, new Date("2024-01-01"));
+
+  // Share/with rule pair where both share and with specs have two givens
+  // (Company, User). The with-spec uses a non-identity match to derive the
+  // authorized user via an Administrator fact linking the two givens.
+  const distribution = (r: DistributionRules) => r
+    .share(model.given(Company, User).match((c, user, facts) =>
+      facts.ofType(Administrator)
+        .join(a => a.company, c)
+        .join(a => a.user, user)
+    ))
+    .with(model.given(Company, User).match((c, user, facts) =>
+      facts.ofType(Administrator)
+        .join(a => a.company, c)
+        .selectMany(a => facts.ofType(User).join(u => u, a.user))
+    ));
+
+  it("should permit an administrator to query their own administrator status", async () => {
+    const specification = model.given(Company, User).match((c, user, facts) =>
+      facts.ofType(Administrator)
+        .join(a => a.company, c)
+        .join(a => a.user, user)
+    );
+
+    const j = JinagaTest.create({
+      model, user: adminUser,
+      initialState: [creator, adminUser, company, administrator],
+      distribution
+    });
+
+    const result = await j.query(specification, company, adminUser);
+    expect(result).toHaveLength(1);
+  });
+
+  it("should reject a non-administrator querying the administrator status", async () => {
+    const specification = model.given(Company, User).match((c, user, facts) =>
+      facts.ofType(Administrator)
+        .join(a => a.company, c)
+        .join(a => a.user, user)
+    );
+
+    const j = JinagaTest.create({
+      model, user: otherUser,
+      initialState: [creator, adminUser, otherUser, company, administrator],
+      distribution
+    });
+
+    await expect(() => j.query(specification, company, adminUser))
+      .rejects.toThrow("Not authorized");
+  });
+
+  it("should reject when no user is logged in", async () => {
+    const specification = model.given(Company, User).match((c, user, facts) =>
+      facts.ofType(Administrator)
+        .join(a => a.company, c)
+        .join(a => a.user, user)
+    );
+
+    const j = JinagaTest.create({
+      model, user: undefined,
+      initialState: [creator, adminUser, company, administrator],
+      distribution
+    });
+
+    await expect(() => j.query(specification, company, adminUser))
+      .rejects.toThrow("Not authorized");
+  });
+});

--- a/test/distribution/negatingFeedDistributionSpec.ts
+++ b/test/distribution/negatingFeedDistributionSpec.ts
@@ -1,0 +1,79 @@
+import { DistributionRules, JinagaTest, Trace, User } from "@src";
+import { Company, Office, OfficeClosed, model } from "../companyModel";
+
+describe("distribution authorizes negating feeds for .notExists()", () => {
+  Trace.off();
+
+  const creator = new User("creator");
+  const outsider = new User("outsider");
+  const company = new Company(creator, "Co");
+  const office = new Office(company, "Office");
+
+  describe("when each fact type is independently shared with everyone", () => {
+    // Two rules that share constituents independently. A spec with .notExists()
+    // produces a "negating feed" (Company → Office → OfficeClosed) that no
+    // single rule covers, plus the outer feed (Company → Office, with !E).
+    // Both should be authorized via composition.
+    const distribution = (r: DistributionRules) => r
+      .share(model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+      )).withEveryone()
+      .share(model.given(Office).match((o, facts) =>
+        facts.ofType(OfficeClosed).join(oc => oc.office, o)
+      )).withEveryone();
+
+    it("authorizes a .notExists() spec for a logged-in user", async () => {
+      const spec = model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+          .notExists(o => facts.ofType(OfficeClosed).join(oc => oc.office, o))
+      );
+
+      const j = JinagaTest.create({
+        model, user: outsider,
+        initialState: [creator, outsider, company, office],
+        distribution
+      });
+      const result = await j.query(spec, company);
+      expect(result).toHaveLength(1);
+    });
+
+    it("authorizes a .notExists() spec when no user is logged in", async () => {
+      const spec = model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+          .notExists(o => facts.ofType(OfficeClosed).join(oc => oc.office, o))
+      );
+
+      const j = JinagaTest.create({
+        model, user: undefined,
+        initialState: [creator, company, office],
+        distribution
+      });
+      const result = await j.query(spec, company);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("when only one rule covers part of the spec", () => {
+    // Only the outer fact type is shared. The inner branch of .notExists()
+    // is not authorized — composition should fail.
+    const distribution = (r: DistributionRules) => r
+      .share(model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+      )).withEveryone();
+
+    it("rejects when the negated fact type has no covering rule", async () => {
+      const spec = model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+          .notExists(o => facts.ofType(OfficeClosed).join(oc => oc.office, o))
+      );
+
+      const j = JinagaTest.create({
+        model, user: outsider,
+        initialState: [creator, outsider, company, office],
+        distribution
+      });
+      await expect(() => j.query(spec, company))
+        .rejects.toThrow("Not authorized");
+    });
+  });
+});


### PR DESCRIPTION
Two foundation fixes for the `j.subscribe` trust release (#197 Phase 1):

- #196: Specs with `.notExists()` produce a "negating feed" that no single
  distribution rule covers. Add a compositional authorization path: when a
  target feed isn't matched by any single rule, attempt to cover its edges
  and notExists branches by chaining multiple rules (each rule's input
  either coming from the feed's givens or from an earlier rule's output).
  Every rule used must authorize the logged-in user, either by direct
  evaluation against namedStart or by structural equivalence to a rule
  that was directly verified.

- #161: Add regression tests for multi-given share/with distribution
  rules (e.g. `model.given(Company, User).match(...)`) where the with-spec
  derives the principal through a non-identity match.