### PR TITLE
Land authorization-as-spec for j.subscribe (Phase 3, #130)

### DIFF
--- a/src/distribution/distribution-engine.ts
+++ b/src/distribution/distribution-engine.ts
@@ -3,10 +3,7 @@ import { describeSpecification } from "../specification/description";
 import { buildFeeds } from "../specification/feed-builder";
 import { EdgeDescription, FactDescription, InputDescription, NotExistsConditionDescription, Skeleton, skeletonOfSpecification } from "../specification/skeleton";
 import { Specification, isPathCondition, specificationIsIdentity } from "../specification/specification";
-import {
-  intersectSpecificationWithDistributionRule,
-  specificationHasIntersection
-} from "../specification/specification-intersection";
+import { intersectSpecificationWithDistributionRule } from "../specification/specification-intersection";
 import { FactReference, ReferencesByName, Storage, factReferenceEquals } from "../storage";
 import { canAuthorizeByComposition } from "./distribution-composition";
 import { DistributionRules } from "./distribution-rules";
@@ -54,12 +51,6 @@ export class DistributionEngine {
     // TODO: Minimize the number hits to the database.
     const reasons: string[] = [];
     for (const targetFeed of targetFeeds) {
-      // Intersected feeds carry the authorization condition inside the spec
-      // itself (the synthetic `distributionUser` given), so no separate rule
-      // check is needed — the spec returns empty until the auth fact arrives.
-      if (specificationHasIntersection(targetFeed)) {
-        continue;
-      }
       const feedResult = await this.canDistributeTo(targetFeed, namedStart, user);
       if (feedResult.type === 'failure') {
         reasons.push(feedResult.reason);
@@ -278,10 +269,20 @@ export class DistributionEngine {
 }
 
 /**
- * Pick the first applicable rule for intersection. "Applicable" means: the
- * rule's share-specification has the same skeleton as the user's target spec
- * (so the rule is meaningful for this query) and the rule has a non-null
- * user-spec (so there's something to intersect).
+ * Pick a rule whose share-specification matches the target spec by skeleton
+ * and whose user-spec has compatible given types. Returns null when no rule
+ * is applicable, or when more than one rule matches (ambiguity — see below).
+ *
+ * Ambiguity bail-out: if two rules both share the target shape but to
+ * different user sets (e.g. share with administrators OR share with
+ * creators), picking the first rule arbitrarily would make subscription
+ * activation depend on rule ordering. A user authorized only by the
+ * *other* rule would see the subscription stay empty forever, even though
+ * a valid authorization path exists. The right semantics is the union (OR)
+ * of all applicable user-specs, but the spec language has no OR primitive;
+ * until it does, we refuse to intersect in the ambiguous case so the
+ * subscribe call falls back to the existing "Not authorized" failure
+ * rather than to a silently-inactivatable subscription.
  */
 function findRuleForIntersection(
   specification: Specification,
@@ -289,24 +290,27 @@ function findRuleForIntersection(
   targetFeeds: Specification[]
 ): Specification | null {
   const targetSkeletons = targetFeeds.map(f => skeletonOfSpecification(f));
+  const matches: Specification[] = [];
   for (const rule of distributionRules.rules) {
     if (rule.user === null) continue;
     for (const ruleFeed of rule.feeds) {
       const ruleSkeleton = skeletonOfSpecification(ruleFeed);
-      if (targetSkeletons.some(ts => skeletonsEqual(ruleSkeleton, ts))) {
-        // Ensure the rule's user-spec and the target spec have compatible
-        // given types — the intersection algorithm requires this. If they
-        // don't match, skip the rule rather than fail intersection.
-        if (rule.user.given.length !== specification.given.length) continue;
-        const typesAlign = rule.user.given.every((g, i) =>
-          g.label.type === specification.given[i].label.type
-        );
-        if (!typesAlign) continue;
-        return rule.user;
-      }
+      if (!targetSkeletons.some(ts => skeletonsEqual(ruleSkeleton, ts))) continue;
+      // The intersection algorithm requires the rule's user-spec and the
+      // target spec to share given counts and types.
+      if (rule.user.given.length !== specification.given.length) continue;
+      const typesAlign = rule.user.given.every((g, i) =>
+        g.label.type === specification.given[i].label.type
+      );
+      if (!typesAlign) continue;
+      matches.push(rule.user);
+      break; // One match per rule is enough.
     }
   }
-  return null;
+  if (matches.length !== 1) {
+    return null;
+  }
+  return matches[0];
 }
 
 function skeletonsEqual(ruleSkeleton: Skeleton, targetSkeleton: Skeleton): boolean {

--- a/src/distribution/distribution-engine.ts
+++ b/src/distribution/distribution-engine.ts
@@ -8,23 +8,33 @@ import { FactReference, ReferencesByName, Storage, factReferenceEquals } from ".
 import { canAuthorizeByComposition } from "./distribution-composition";
 import { DistributionRules } from "./distribution-rules";
 
-export interface DistributionIntersectionResult {
-  /**
-   * The specification to use going forward. Either the original (when the
-   * user is already authorized, or no applicable rule was found) or a new
-   * spec with a synthetic `distributionUser` given that filters results by
-   * the rule's user pattern.
-   */
-  specification: Specification;
+export interface DistributionIntersectionBranch {
   /**
    * Aligned with `specification.given`. When intersection occurred, this is
    * the original `start` with the user's fact reference appended in the
-   * position of the new `distributionUser` given.
+   * position of the synthetic `distributionUser` given.
    */
   start: FactReference[];
   /**
-   * True when the intersection algorithm rewrote the specification. False
-   * when the original spec was returned unchanged.
+   * The specification for this branch. Either the original (passthrough) or
+   * a spec with a synthetic `distributionUser` given that filters results
+   * by one rule's user pattern.
+   */
+  specification: Specification;
+}
+
+export interface DistributionIntersectionResult {
+  /**
+   * One branch per matching distribution rule. Multiple branches express
+   * OR semantics across rules (a row is authorized if any branch's auth
+   * pattern is satisfied). For passthrough (already authorized, or no
+   * applicable rule) the array has length 1 and carries the original
+   * `(start, specification)` unchanged.
+   */
+  branches: DistributionIntersectionBranch[];
+  /**
+   * True when the intersection algorithm produced rewritten specs. False
+   * when the original spec was returned unchanged in a single branch.
    */
   intersected: boolean;
 }
@@ -210,18 +220,21 @@ export class DistributionEngine {
 
   /**
    * Phase 3 of the j.subscribe trust release. Asks: can this subscribe call
-   * proceed as-is, or do we need to compose the spec with a distribution
-   * rule so it filters by an authorizing fact that hasn't arrived yet?
+   * proceed as-is, or do we need to compose the spec with distribution
+   * rules so it filters by an authorizing fact that hasn't arrived yet?
    *
    * - If the user is already authorized (single rule or compositional
-   *   fallback), returns the original spec/start unchanged — no work to do.
-   * - If a single rule's share-spec matches the target spec by skeleton but
-   *   the user doesn't currently satisfy its user-spec, intersects with that
-   *   rule. The subscriber sees empty results until the auth fact arrives,
-   *   at which point the existing inverse engine surfaces them.
-   * - If no applicable rule was found at all, returns the original spec; the
-   *   query path will continue to fail authorization, which is the right
-   *   behavior — Phase 3 doesn't relax authorization, it makes it reactive.
+   *   fallback), returns one passthrough branch with the original
+   *   spec/start — no work to do.
+   * - If one or more rules' share-specs match the target spec by skeleton
+   *   but the user doesn't currently satisfy any user-spec, returns one
+   *   intersected branch *per* matching rule. The observer subscribes to
+   *   all branches in parallel; a row is delivered when any branch's auth
+   *   pattern fires (OR semantics).
+   * - If no applicable rule was found at all, returns one passthrough
+   *   branch; the query path will continue to fail authorization, which is
+   *   the right behavior — Phase 3 doesn't relax authorization, it makes
+   *   it reactive.
    */
   async intersectForSubscribe(
     start: FactReference[],
@@ -236,19 +249,18 @@ export class DistributionEngine {
     const targetFeeds = buildFeeds(specification);
     const authResult = await this.canDistributeToAll(targetFeeds, namedStart, user);
     if (authResult.type === 'success') {
-      return { specification, start, intersected: false };
+      return { branches: [{ start, specification }], intersected: false };
     }
 
     // The user isn't authorized via any single rule or via composition. See
-    // if any rule's share-spec applies to the user's spec (same shape by
-    // skeleton) and has a non-null user-spec — that's the rule whose auth
-    // condition we'll intersect.
-    const matchingRule = findRuleForIntersection(specification, this.distributionRules, targetFeeds);
-    if (!matchingRule) {
-      return { specification, start, intersected: false };
+    // which rules' share-specs apply to the user's spec (same shape by
+    // skeleton) and have non-null user-specs — those are the rules whose
+    // auth conditions become OR-branches.
+    const matchingRules = findRulesForIntersection(specification, this.distributionRules, targetFeeds);
+    if (matchingRules.length === 0) {
+      return { branches: [{ start, specification }], intersected: false };
     }
 
-    const intersected = intersectSpecificationWithDistributionRule(specification, matchingRule);
     // The synthetic `distributionUser` given is bound to the logged-in user.
     // When no user is logged in, fall back to a sentinel reference — the
     // existential will then never be satisfied (no User fact will ever
@@ -260,35 +272,31 @@ export class DistributionEngine {
     const userRef: FactReference = user
       ? { type: user.type, hash: user.hash }
       : { type: User.Type, hash: "" };
-    return {
-      specification: intersected,
+    const branches: DistributionIntersectionBranch[] = matchingRules.map(ruleUserSpec => ({
       start: [...start, userRef],
-      intersected: true
-    };
+      specification: intersectSpecificationWithDistributionRule(specification, ruleUserSpec)
+    }));
+    return { branches, intersected: true };
   }
 }
 
 /**
- * Pick a rule whose share-specification matches the target spec by skeleton
- * and whose user-spec has compatible given types. Returns null when no rule
- * is applicable, or when more than one rule matches (ambiguity — see below).
+ * Find every rule whose share-specification matches the target spec by
+ * skeleton and whose user-spec has compatible given types. Returns the
+ * rule user-specs in declaration order; an empty array means no rule is
+ * applicable. Multiple matches express OR semantics: any one of the
+ * returned user-specs being satisfied authorizes the subscriber.
  *
- * Ambiguity bail-out: if two rules both share the target shape but to
- * different user sets (e.g. share with administrators OR share with
- * creators), picking the first rule arbitrarily would make subscription
- * activation depend on rule ordering. A user authorized only by the
- * *other* rule would see the subscription stay empty forever, even though
- * a valid authorization path exists. The right semantics is the union (OR)
- * of all applicable user-specs, but the spec language has no OR primitive;
- * until it does, we refuse to intersect in the ambiguous case so the
- * subscribe call falls back to the existing "Not authorized" failure
- * rather than to a silently-inactivatable subscription.
+ * The observer subscribes to one intersected branch per returned rule and
+ * deduplicates results across branches, so picking up multiple rules here
+ * is the path that lets a user authorized by *any* of them see the feed
+ * once the corresponding auth fact arrives.
  */
-function findRuleForIntersection(
+function findRulesForIntersection(
   specification: Specification,
   distributionRules: DistributionRules,
   targetFeeds: Specification[]
-): Specification | null {
+): Specification[] {
   const targetSkeletons = targetFeeds.map(f => skeletonOfSpecification(f));
   const matches: Specification[] = [];
   for (const rule of distributionRules.rules) {
@@ -307,10 +315,7 @@ function findRuleForIntersection(
       break; // One match per rule is enough.
     }
   }
-  if (matches.length !== 1) {
-    return null;
-  }
-  return matches[0];
+  return matches;
 }
 
 function skeletonsEqual(ruleSkeleton: Skeleton, targetSkeleton: Skeleton): boolean {

--- a/src/distribution/distribution-engine.ts
+++ b/src/distribution/distribution-engine.ts
@@ -1,9 +1,36 @@
+import { User } from "../model/user";
 import { describeSpecification } from "../specification/description";
+import { buildFeeds } from "../specification/feed-builder";
 import { EdgeDescription, FactDescription, InputDescription, NotExistsConditionDescription, Skeleton, skeletonOfSpecification } from "../specification/skeleton";
 import { Specification, isPathCondition, specificationIsIdentity } from "../specification/specification";
+import {
+  intersectSpecificationWithDistributionRule,
+  specificationHasIntersection
+} from "../specification/specification-intersection";
 import { FactReference, ReferencesByName, Storage, factReferenceEquals } from "../storage";
 import { canAuthorizeByComposition } from "./distribution-composition";
 import { DistributionRules } from "./distribution-rules";
+
+export interface DistributionIntersectionResult {
+  /**
+   * The specification to use going forward. Either the original (when the
+   * user is already authorized, or no applicable rule was found) or a new
+   * spec with a synthetic `distributionUser` given that filters results by
+   * the rule's user pattern.
+   */
+  specification: Specification;
+  /**
+   * Aligned with `specification.given`. When intersection occurred, this is
+   * the original `start` with the user's fact reference appended in the
+   * position of the new `distributionUser` given.
+   */
+  start: FactReference[];
+  /**
+   * True when the intersection algorithm rewrote the specification. False
+   * when the original spec was returned unchanged.
+   */
+  intersected: boolean;
+}
 
 export interface DistributionSuccess {
   type: 'success';
@@ -27,6 +54,12 @@ export class DistributionEngine {
     // TODO: Minimize the number hits to the database.
     const reasons: string[] = [];
     for (const targetFeed of targetFeeds) {
+      // Intersected feeds carry the authorization condition inside the spec
+      // itself (the synthetic `distributionUser` given), so no separate rule
+      // check is needed — the spec returns empty until the auth fact arrives.
+      if (specificationHasIntersection(targetFeed)) {
+        continue;
+      }
       const feedResult = await this.canDistributeTo(targetFeed, namedStart, user);
       if (feedResult.type === 'failure') {
         reasons.push(feedResult.reason);
@@ -173,6 +206,107 @@ export class DistributionEngine {
       return userReference;
     }
   }
+
+  /**
+   * Compose a specification with a distribution rule's user specification so
+   * the result set is naturally gated by the rule. Exposed for unit testing
+   * the algorithm; runtime callers should prefer `intersectForSubscribe`,
+   * which only intersects when the user isn't already authorized.
+   */
+  intersectSpecificationWithDistributionRule(specification: Specification, ruleSpecification: Specification): Specification {
+    return intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+  }
+
+  /**
+   * Phase 3 of the j.subscribe trust release. Asks: can this subscribe call
+   * proceed as-is, or do we need to compose the spec with a distribution
+   * rule so it filters by an authorizing fact that hasn't arrived yet?
+   *
+   * - If the user is already authorized (single rule or compositional
+   *   fallback), returns the original spec/start unchanged — no work to do.
+   * - If a single rule's share-spec matches the target spec by skeleton but
+   *   the user doesn't currently satisfy its user-spec, intersects with that
+   *   rule. The subscriber sees empty results until the auth fact arrives,
+   *   at which point the existing inverse engine surfaces them.
+   * - If no applicable rule was found at all, returns the original spec; the
+   *   query path will continue to fail authorization, which is the right
+   *   behavior — Phase 3 doesn't relax authorization, it makes it reactive.
+   */
+  async intersectForSubscribe(
+    start: FactReference[],
+    specification: Specification,
+    user: FactReference | null
+  ): Promise<DistributionIntersectionResult> {
+    const namedStart = specification.given.reduce((map, given, index) => ({
+      ...map,
+      [given.label.name]: start[index]
+    }), {} as ReferencesByName);
+
+    const targetFeeds = buildFeeds(specification);
+    const authResult = await this.canDistributeToAll(targetFeeds, namedStart, user);
+    if (authResult.type === 'success') {
+      return { specification, start, intersected: false };
+    }
+
+    // The user isn't authorized via any single rule or via composition. See
+    // if any rule's share-spec applies to the user's spec (same shape by
+    // skeleton) and has a non-null user-spec — that's the rule whose auth
+    // condition we'll intersect.
+    const matchingRule = findRuleForIntersection(specification, this.distributionRules, targetFeeds);
+    if (!matchingRule) {
+      return { specification, start, intersected: false };
+    }
+
+    const intersected = intersectSpecificationWithDistributionRule(specification, matchingRule);
+    // The synthetic `distributionUser` given is bound to the logged-in user.
+    // When no user is logged in, fall back to a sentinel reference — the
+    // existential will then never be satisfied (no User fact will ever
+    // match), so the subscription stays empty until login + auth fact both
+    // exist. Normalize to a bare {type, hash} so the observer's tuple hash
+    // matches the inverse engine's tuple hash byte-for-byte (the user fact
+    // from JinagaTest carries dehydrated predecessors/fields that the
+    // spec runner discards).
+    const userRef: FactReference = user
+      ? { type: user.type, hash: user.hash }
+      : { type: User.Type, hash: "" };
+    return {
+      specification: intersected,
+      start: [...start, userRef],
+      intersected: true
+    };
+  }
+}
+
+/**
+ * Pick the first applicable rule for intersection. "Applicable" means: the
+ * rule's share-specification has the same skeleton as the user's target spec
+ * (so the rule is meaningful for this query) and the rule has a non-null
+ * user-spec (so there's something to intersect).
+ */
+function findRuleForIntersection(
+  specification: Specification,
+  distributionRules: DistributionRules,
+  targetFeeds: Specification[]
+): Specification | null {
+  const targetSkeletons = targetFeeds.map(f => skeletonOfSpecification(f));
+  for (const rule of distributionRules.rules) {
+    if (rule.user === null) continue;
+    for (const ruleFeed of rule.feeds) {
+      const ruleSkeleton = skeletonOfSpecification(ruleFeed);
+      if (targetSkeletons.some(ts => skeletonsEqual(ruleSkeleton, ts))) {
+        // Ensure the rule's user-spec and the target spec have compatible
+        // given types — the intersection algorithm requires this. If they
+        // don't match, skip the rule rather than fail intersection.
+        if (rule.user.given.length !== specification.given.length) continue;
+        const typesAlign = rule.user.given.every((g, i) =>
+          g.label.type === specification.given[i].label.type
+        );
+        if (!typesAlign) continue;
+        return rule.user;
+      }
+    }
+  }
+  return null;
 }
 
 function skeletonsEqual(ruleSkeleton: Skeleton, targetSkeleton: Skeleton): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export { describeDeclaration, describeSpecification } from './specification/desc
 export { buildFeeds } from './specification/feed-builder';
 export { FeedCache, FeedObject } from "./specification/feed-cache";
 export { invertSpecification, SpecificationInverse } from "./specification/inverse";
+export { alphaTransform, DISTRIBUTION_USER_LABEL, intersectSpecificationWithDistributionRule, specificationHasIntersection } from "./specification/specification-intersection";
 export { buildModel, FactRepository, LabelOf, Model, ModelBuilder, ProjectionOf, SpecificationOf } from './specification/model';
 export { EdgeDescription, emptySkeleton, FactDescription, InputDescription, NotExistsConditionDescription, OutputDescription, Skeleton, skeletonOfSpecification } from './specification/skeleton';
 export { ComponentProjection, CompositeProjection, Condition, emptySpecification, ExistentialCondition, FactProjection, FieldProjection, getAllFactTypes, getAllRoles, HashProjection, isExistentialCondition, isPathCondition, Label, Match, NamedComponentProjection, PathCondition, Projection, reduceSpecification, Role, SingularProjection, Specification, SpecificationGiven, specificationIsDeterministic, specificationIsIdentity, specificationIsNotDeterministic, SpecificationProjection, splitBeforeFirstSuccessor, TimeProjection } from './specification/specification';

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -50,6 +50,15 @@ export class NetworkNoOp implements Network {
 
 export class NetworkDistribution implements Network {
     private feedCache = new FeedCache();
+    // Feed hashes this instance produced via Phase 3 intersection. Used as
+    // an unforgeable bypass token for the authorization check on those
+    // feeds: an intersected spec already encodes the auth pattern, and its
+    // augmented skeleton doesn't match any distribution rule, so a normal
+    // `canDistributeToAll` would reject it. The hashes are recorded only
+    // by `intersectForSubscribe` (computed from feeds the engine itself
+    // produced), so a caller can't spoof the bypass by crafting a spec
+    // with a `distributionUser` given.
+    private readonly intersectedFeeds = new Set<string>();
 
     constructor(
         private readonly distributionEngine: DistributionEngine,
@@ -62,11 +71,21 @@ export class NetworkDistribution implements Network {
             ...map,
             [given.label.name]: start[index]
         }), {} as ReferencesByName);
-        const canDistribute = await this.distributionEngine.canDistributeToAll(feeds, namedStart, this.user);
-        if (canDistribute.type === 'failure') {
-            throw new Error(`Not authorized: ${canDistribute.reason}`);
+        // Compute feed hashes upfront so we can recognize feeds the engine
+        // produced earlier via intersection (whose hashes we've cached) and
+        // skip the auth check just for those. A caller-supplied spec that
+        // happens to look intersected won't produce matching hashes unless
+        // its content equals one we actually generated.
+        const feedHashes = this.feedCache.addFeeds(feeds, namedStart);
+        const allFromIntersection = feedHashes.length > 0
+            && feedHashes.every(h => this.intersectedFeeds.has(h));
+        if (!allFromIntersection) {
+            const canDistribute = await this.distributionEngine.canDistributeToAll(feeds, namedStart, this.user);
+            if (canDistribute.type === 'failure') {
+                throw new Error(`Not authorized: ${canDistribute.reason}`);
+            }
         }
-        return this.feedCache.addFeeds(feeds, namedStart);
+        return feedHashes;
     }
 
     async fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
@@ -74,10 +93,11 @@ export class NetworkDistribution implements Network {
         if (!feedObject) {
             throw new Error(`Feed ${feed} not found`);
         }
-        const canDistribute = await this.distributionEngine.canDistributeToAll([feedObject.feed], feedObject.namedStart, this.user);
-
-        if (canDistribute.type === 'failure') {
-            throw new Error(`Not authorized: ${canDistribute.reason}`);
+        if (!this.intersectedFeeds.has(feed)) {
+            const canDistribute = await this.distributionEngine.canDistributeToAll([feedObject.feed], feedObject.namedStart, this.user);
+            if (canDistribute.type === 'failure') {
+                throw new Error(`Not authorized: ${canDistribute.reason}`);
+            }
         }
 
         // Pretend that we are at the end of the feed.
@@ -91,6 +111,10 @@ export class NetworkDistribution implements Network {
         const feedObject = this.feedCache.getFeed(feed);
         if (!feedObject) {
             onError(new Error(`Feed ${feed} not found`));
+            return () => { };
+        }
+        if (this.intersectedFeeds.has(feed)) {
+            onResponse([], bookmark);
             return () => { };
         }
         this.distributionEngine.canDistributeToAll([feedObject.feed], feedObject.namedStart, this.user)
@@ -114,6 +138,21 @@ export class NetworkDistribution implements Network {
 
     async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
         const result = await this.distributionEngine.intersectForSubscribe(start, specification, this.user);
+        if (result.intersected) {
+            // Pre-compute feed hashes from the intersected spec and remember
+            // them. When the observer later calls `feeds` (after
+            // `reduceSpecification` reshapes the spec into a fresh object),
+            // we recognize the produced hashes and skip auth — without
+            // trusting the spec's structure as a marker.
+            const reducedIntersected = reduceSpecification(result.specification);
+            const namedStart = reducedIntersected.given.reduce((map, given, index) => ({
+                ...map,
+                [given.label.name]: result.start[index]
+            }), {} as ReferencesByName);
+            const producedFeeds = buildFeeds(reducedIntersected);
+            const producedHashes = this.feedCache.addFeeds(producedFeeds, namedStart);
+            for (const h of producedHashes) this.intersectedFeeds.add(h);
+        }
         return { start: result.start, specification: result.specification };
     }
 }

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -15,6 +15,14 @@ export interface Network {
     streamFeed(feed: string, bookmark: string, onResponse: (factReferences: FactReference[], nextBookmark: string) => Promise<void>, onError: (err: Error) => void, feedRefreshIntervalSeconds: number): () => void;
     load(factReferences: FactReference[]): Promise<FactEnvelope[]>;
 
+    /**
+     * Phase 3 hook for j.subscribe authorization-as-spec. Returns a possibly
+     * rewritten (start, specification) pair so that subscribing to an
+     * initially-forbidden feed succeeds and pushes results when the
+     * authorizing fact later arrives. Implementations without distribution
+     * rules should return the inputs unchanged.
+     */
+    intersectForSubscribe?(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }>;
 }
 
 export class NetworkNoOp implements Network {
@@ -33,6 +41,10 @@ export class NetworkNoOp implements Network {
 
     load(factReferences: FactReference[]): Promise<FactEnvelope[]> {
         return Promise.resolve([]);
+    }
+
+    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
+        return { start, specification };
     }
 }
 
@@ -98,6 +110,11 @@ export class NetworkDistribution implements Network {
 
     load(factReferences: FactReference[]): Promise<FactEnvelope[]> {
         return Promise.resolve([]);
+    }
+
+    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
+        const result = await this.distributionEngine.intersectForSubscribe(start, specification, this.user);
+        return { start: result.start, specification: result.specification };
     }
 }
 
@@ -199,6 +216,13 @@ export class NetworkManager {
             this.removeFeedsFromCache(start, reducedSpecification);
             throw e;
         }
+    }
+
+    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
+        if (this.network.intersectForSubscribe) {
+            return await this.network.intersectForSubscribe(start, specification);
+        }
+        return { start, specification };
     }
 
     async subscribe(start: FactReference[], specification: Specification): Promise<string[]> {

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -1,4 +1,4 @@
-import { DistributionEngine } from "../distribution/distribution-engine";
+import { DistributionEngine, DistributionIntersectionBranch } from "../distribution/distribution-engine";
 import { FeedResponse } from "../http/messages";
 import { Subscriber } from "../observer/subscriber";
 import { describeDeclaration, describeSpecification } from "../specification/description";
@@ -16,13 +16,15 @@ export interface Network {
     load(factReferences: FactReference[]): Promise<FactEnvelope[]>;
 
     /**
-     * Phase 3 hook for j.subscribe authorization-as-spec. Returns a possibly
-     * rewritten (start, specification) pair so that subscribing to an
-     * initially-forbidden feed succeeds and pushes results when the
-     * authorizing fact later arrives. Implementations without distribution
-     * rules should return the inputs unchanged.
+     * Phase 3 hook for j.subscribe authorization-as-spec. Returns one or more
+     * `(start, specification)` branches so that subscribing to an
+     * initially-forbidden feed succeeds and pushes results when an
+     * authorizing fact later arrives. Multiple branches express OR
+     * semantics across distribution rules. Implementations without
+     * distribution rules should return the inputs unchanged in a single
+     * branch.
      */
-    intersectForSubscribe?(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }>;
+    intersectForSubscribe?(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]>;
 }
 
 export class NetworkNoOp implements Network {
@@ -43,8 +45,8 @@ export class NetworkNoOp implements Network {
         return Promise.resolve([]);
     }
 
-    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
-        return { start, specification };
+    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+        return [{ start, specification }];
     }
 }
 
@@ -136,24 +138,26 @@ export class NetworkDistribution implements Network {
         return Promise.resolve([]);
     }
 
-    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
+    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
         const result = await this.distributionEngine.intersectForSubscribe(start, specification, this.user);
         if (result.intersected) {
-            // Pre-compute feed hashes from the intersected spec and remember
-            // them. When the observer later calls `feeds` (after
+            // Pre-compute feed hashes from each intersected branch and
+            // remember them. When the observer later calls `feeds` (after
             // `reduceSpecification` reshapes the spec into a fresh object),
             // we recognize the produced hashes and skip auth — without
             // trusting the spec's structure as a marker.
-            const reducedIntersected = reduceSpecification(result.specification);
-            const namedStart = reducedIntersected.given.reduce((map, given, index) => ({
-                ...map,
-                [given.label.name]: result.start[index]
-            }), {} as ReferencesByName);
-            const producedFeeds = buildFeeds(reducedIntersected);
-            const producedHashes = this.feedCache.addFeeds(producedFeeds, namedStart);
-            for (const h of producedHashes) this.intersectedFeeds.add(h);
+            for (const branch of result.branches) {
+                const reducedIntersected = reduceSpecification(branch.specification);
+                const namedStart = reducedIntersected.given.reduce((map, given, index) => ({
+                    ...map,
+                    [given.label.name]: branch.start[index]
+                }), {} as ReferencesByName);
+                const producedFeeds = buildFeeds(reducedIntersected);
+                const producedHashes = this.feedCache.addFeeds(producedFeeds, namedStart);
+                for (const h of producedHashes) this.intersectedFeeds.add(h);
+            }
         }
-        return { start: result.start, specification: result.specification };
+        return result.branches;
     }
 }
 
@@ -257,11 +261,11 @@ export class NetworkManager {
         }
     }
 
-    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
+    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
         if (this.network.intersectForSubscribe) {
             return await this.network.intersectForSubscribe(start, specification);
         }
-        return { start, specification };
+        return [{ start, specification }];
     }
 
     async subscribe(start: FactReference[], specification: Specification): Promise<string[]> {

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -124,6 +124,10 @@ export class FactManager {
         return await this.networkManager.subscribe(start, specification);
     }
 
+    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
+        return await this.networkManager.intersectForSubscribe(start, specification);
+    }
+
     unsubscribe(feeds: string[]) {
         this.networkManager.unsubscribe(feeds);
     }

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -2,6 +2,7 @@ import { generateKeyPair, KeyPair, signFacts } from "../cryptography/key-pair";
 import { computeHash } from "../fact/hash";
 import { Fork } from "../fork/fork";
 import { PersistentFork } from "../fork/persistent-fork";
+import { DistributionIntersectionBranch } from "../distribution/distribution-engine";
 import { ObservableSource, SpecificationListener } from "../observable/observable";
 import { Observer, ObserverImpl, ResultAddedFunc } from "../observer/observer";
 import { testSpecificationForCompliance } from "../purge/purgeCompliance";
@@ -124,7 +125,7 @@ export class FactManager {
         return await this.networkManager.subscribe(start, specification);
     }
 
-    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<{ start: FactReference[]; specification: Specification }> {
+    async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
         return await this.networkManager.intersectForSubscribe(start, specification);
     }
 

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -35,12 +35,44 @@ interface ObserverBranch {
     specification: Specification;
     feeds: string[];
     listeners: SpecificationListener[];
+    /**
+     * Labels of this branch's spec (givens + match unknowns). Used to
+     * compute a stable "vote id" for per-row ref counting: the same
+     * (row, auth path) tuple from this branch's ADD inverse and its
+     * REMOVE inverse hash to the same id because both bind the same set
+     * of labels (the inverse's "from" fact differs but the resolved
+     * spec labels match in shape and value).
+     */
+    voteLabels: string[];
 }
 
 export class ObserverImpl<T> implements Observer<T> {
     private givenHash: string;
     private cachedPromise: Promise<boolean> | undefined;
     private loadedPromise: Promise<void> | undefined;
+    /**
+     * Root-level per-row ref counting for OR semantics across branches.
+     * Keyed by the row identity hash (subset over `rowIdentityLabels`).
+     * The value set holds one entry per branch+auth-path combination
+     * that currently authorizes the row — a "vote." A row is delivered
+     * to the handler on the *first* vote and its removal callback fires
+     * on the *last* withdrawn vote, so revoking one of two overlapping
+     * authorizations leaves the row in place and revoking the last one
+     * removes it. Only applied at `path === ""` (the user-visible root
+     * subscription) — nested child projections live within a single
+     * branch's auth path and use the standard full-tuple dedup below.
+     */
+    private branchVotesByRow = new Map<string, Set<string>>();
+    /**
+     * Root-level removal callbacks, keyed by the same row identity hash
+     * as `branchVotesByRow`.
+     */
+    private removalsByRow = new Map<string, () => Promise<void>>();
+    /**
+     * Child-path dedup and removal registry. The full-tuple hash is a
+     * stable identifier for nested rows because each nested row carries a
+     * distinct combination of parent + child labels.
+     */
     private removalsByTuple: {
         [tupleHash: string]: () => Promise<void>;
     } = {};
@@ -82,7 +114,7 @@ export class ObserverImpl<T> implements Observer<T> {
      * This map is used to buffer results that are produced before any handlers are registered,
      * enabling replay of results to late-registered handlers.
      */
-    private pendingAddsByKey: Map<string, { projection: Projection; parentSubset: string[]; results: ProjectedResult[] }>
+    private pendingAddsByKey: Map<string, { projection: Projection; parentSubset: string[]; results: ProjectedResult[]; branch: ObserverBranch }>
         = new Map();
     /**
      * Labels (givens + match unknowns) drawn from the pre-intersection
@@ -90,7 +122,7 @@ export class ObserverImpl<T> implements Observer<T> {
      * different alpha-renamed auth-path unknowns to the tuple, so a hash
      * over the full tuple would differ across branches for the same row.
      * Hashing only over these labels yields a stable row identity that
-     * collapses identical rows across branches for `notifiedTuples`.
+     * collapses identical rows across branches for `branchVotesByRow`.
      */
     private rowIdentityLabels: string[];
 
@@ -100,20 +132,24 @@ export class ObserverImpl<T> implements Observer<T> {
         specification: Specification,
         resultAdded: ResultAddedFunc<T>
     ) {
-        // Start with a single passthrough branch. `applySubscribeIntersection`
-        // may replace this with one branch per matching distribution rule.
-        this.branches = [{
-            specification,
-            feeds: [],
-            listeners: []
-        }];
-
         // Capture the original spec's labels. These are stable across any
         // future branch fan-out from `applySubscribeIntersection`.
         this.rowIdentityLabels = [
             ...specification.given.map(g => g.label.name),
             ...specification.matches.map(m => m.unknown.name)
         ];
+
+        // Start with a single passthrough branch. `applySubscribeIntersection`
+        // may replace this with one branch per matching distribution rule.
+        // For an unintersected branch the vote labels equal the row identity
+        // labels, so each row carries exactly one vote and ref counting
+        // reduces to the pre-fix behavior.
+        this.branches = [{
+            specification,
+            feeds: [],
+            listeners: [],
+            voteLabels: [...this.rowIdentityLabels]
+        }];
 
         // Map the given facts to a tuple.
         const tuple = specification.given.reduce((tuple, label, index) => ({
@@ -213,7 +249,7 @@ export class ObserverImpl<T> implements Observer<T> {
             branch.listeners = inverses.map((inverse, index) => {
                 const listener = this.factManager.addSpecificationListener(
                     inverse.inverseSpecification,
-                    (results) => this.onResult(inverse, results)
+                    (results) => this.onResult(inverse, results, branch)
                 );
                 const path = inverse.path || "(root)";
                 Trace.info(`[Observer] Branch ${branchIndex} registered listener ${index + 1}/${inverses.length} for path: ${path}`);
@@ -303,7 +339,17 @@ export class ObserverImpl<T> implements Observer<T> {
         this.branches = branches.map(b => ({
             specification: b.specification,
             feeds: [],
-            listeners: []
+            listeners: [],
+            // Vote labels are the branch's spec labels — broader than the
+            // shared row-identity labels because each branch's auth path
+            // contributes alpha-renamed unknowns (dist_admin, dist_user,
+            // distributionUser, ...). Two distinct auth paths through the
+            // same branch produce different vote ids; identical paths
+            // collide and ref-count as one.
+            voteLabels: [
+                ...b.specification.given.map(g => g.label.name),
+                ...b.specification.matches.map(m => m.unknown.name)
+            ]
         }));
         // Re-key any handlers that were registered with the pre-intersection
         // givenHash. Notification routing matches handlers by tupleHash, so a
@@ -352,11 +398,11 @@ export class ObserverImpl<T> implements Observer<T> {
         }
         for (const { branch, projected } of branchResults) {
             const givenSubset = branch.specification.given.map(g => g.label.name);
-            await this.notifyAdded(projected, branch.specification.projection, "", givenSubset);
+            await this.notifyAdded(projected, branch.specification.projection, "", givenSubset, branch);
         }
     }
 
-    private async onResult(inverse: SpecificationInverse, results: ProjectedResult[]): Promise<void> {
+    private async onResult(inverse: SpecificationInverse, results: ProjectedResult[], branch: ObserverBranch): Promise<void> {
         const path = inverse.path || "(root)";
         Trace.info(`[Observer] ON_RESULT - Path: ${path}, Operation: ${inverse.operation}, Results count: ${results.length}, Given hash: ${this.givenHash.substring(0, 8)}...`);
         
@@ -374,10 +420,10 @@ export class ObserverImpl<T> implements Observer<T> {
             Trace.info(`[Observer] Matching results: ${matchingResults.length} - Path: ${path}, Operation: ${inverse.operation}`);
 
             if (inverse.operation === "add") {
-                return await this.notifyAdded(matchingResults, inverse.inverseSpecification.projection, inverse.path, inverse.parentSubset);
+                return await this.notifyAdded(matchingResults, inverse.inverseSpecification.projection, inverse.path, inverse.parentSubset, branch);
             }
             else if (inverse.operation === "remove") {
-                return await this.notifyRemoved(inverse.resultSubset, matchingResults);
+                return await this.notifyRemoved(inverse, matchingResults, branch);
             }
             else {
                 const _exhaustiveCheck: never = inverse.operation;
@@ -394,75 +440,97 @@ export class ObserverImpl<T> implements Observer<T> {
         await notificationPromise;
     }
 
-    private async notifyAdded(projectedResults: ProjectedResult[], projection: Projection, path: string, parentSubset: string[]) {
+    private async notifyAdded(projectedResults: ProjectedResult[], projection: Projection, path: string, parentSubset: string[], branch: ObserverBranch) {
         const displayPath = path || "(root)";
         Trace.info(`[Observer] NOTIFY_ADDED - Path: ${displayPath}, Results: ${projectedResults.length}, Parent subset: [${parentSubset.join(', ')}]`);
-        
+
+        // OR ref counting applies at the root path only. Nested children
+        // live within the same auth path as their parent — branching is a
+        // root-level concern — so they continue to dedup by full-tuple
+        // hash and store removals in `removalsByTuple`.
+        const isRoot = path === "";
+
         for (const pr of projectedResults) {
             const result: any = await this.injectObservers(pr, projection, path);
             const parentTupleHash = computeTupleSubsetHash(pr.tuple, parentSubset);
-            // Identify the row for dedup. In single-branch mode (no
-            // intersection, or single-rule intersection) the full tuple
-            // is the row identity. In multi-branch OR intersection each
-            // branch carries different alpha-renamed auth-path unknowns,
-            // so the full tuple would differ across branches for the
-            // same row; fall back to a subset hash over the pre-
-            // intersection spec's labels, which is stable across
-            // branches.
-            const tupleHash = this.branches.length > 1
+            // For root rows, `rowHash` collapses the same row across
+            // branches (subset over `rowIdentityLabels`). For nested
+            // rows, the full-tuple hash is the right identity.
+            const rowHash = isRoot
                 ? this.computeRowIdentityHash(pr.tuple)
                 : computeObjectHash(pr.tuple);
-            
-            Trace.info(`[Observer] Processing result - Path: ${displayPath}, Tuple hash: ${tupleHash.substring(0, 8)}..., Parent tuple hash: ${parentTupleHash.substring(0, 8)}...`);
-            
+            // At the root, the vote id additionally tracks *which* auth
+            // path is currently authorizing the row, so revoking one path
+            // can leave another in place. Not needed for child rows.
+            const voteId = isRoot
+                ? computeTupleSubsetHash(pr.tuple, branch.voteLabels)
+                : rowHash;
+
+            Trace.info(`[Observer] Processing result - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}..., Vote id: ${voteId.substring(0, 8)}..., Parent tuple hash: ${parentTupleHash.substring(0, 8)}...`);
+
             const addedHandler = this.addedHandlers.find(h => h.tupleHash === parentTupleHash && h.path === path);
             const resultAdded = addedHandler?.handler;
-            
+
             if (!addedHandler) {
                 Trace.warn(`[Observer] NO HANDLER FOUND - Path: ${displayPath}, Parent tuple hash: ${parentTupleHash.substring(0, 8)}..., Available handlers: ${this.addedHandlers.length}`);
                 this.addedHandlers.forEach((h, index) => {
                     Trace.warn(`[Observer]   Handler ${index + 1}: Path="${h.path}", Tuple hash: ${h.tupleHash.substring(0, 8)}...`);
                 });
                 // Buffer for replay when the handler registers later.
-                this.bufferPendingNotification(path, pr, projection, parentSubset);
+                this.bufferPendingNotification(path, pr, projection, parentSubset, branch);
                 // Skip deeper recursion until handler is registered.
                 continue;
             } else if (!resultAdded) {
                 Trace.warn(`[Observer] Handler found but no callback - Path: ${displayPath}`);
                 // Buffer for replay when the callback is attached.
-                this.bufferPendingNotification(path, pr, projection, parentSubset);
+                this.bufferPendingNotification(path, pr, projection, parentSubset, branch);
                 continue;
             } else {
                 Trace.info(`[Observer] Handler found - Path: ${displayPath}`);
             }
-            
-            // Don't call result added if we have already called it for this tuple.
-            if (this.notifiedTuples.has(tupleHash) === false) {
-                // Check if observer was stopped before calling the handler
+
+            let isFirstDelivery: boolean;
+            if (isRoot) {
+                let supportingVotes = this.branchVotesByRow.get(rowHash);
+                isFirstDelivery = !supportingVotes;
+                if (!supportingVotes) {
+                    supportingVotes = new Set();
+                    this.branchVotesByRow.set(rowHash, supportingVotes);
+                }
+                supportingVotes.add(voteId);
+            } else {
+                isFirstDelivery = !this.notifiedTuples.has(rowHash);
+                if (isFirstDelivery) this.notifiedTuples.add(rowHash);
+            }
+
+            if (isFirstDelivery) {
                 if (this.stopped) {
-                    Trace.info(`[Observer] SKIPPING HANDLER - Observer stopped, Path: ${displayPath}, Tuple hash: ${tupleHash.substring(0, 8)}...`);
+                    Trace.info(`[Observer] SKIPPING HANDLER - Observer stopped, Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}...`);
                     continue;
                 }
-                Trace.info(`[Observer] CALLING HANDLER - Path: ${displayPath}, Tuple hash: ${tupleHash.substring(0, 8)}...`);
+                Trace.info(`[Observer] CALLING HANDLER - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}...`);
                 const promiseMaybe = resultAdded(result);
-                this.notifiedTuples.add(tupleHash);
+                const storeRemoval = (fn: () => Promise<void>) => {
+                    if (isRoot) this.removalsByRow.set(rowHash, fn);
+                    else this.removalsByTuple[rowHash] = fn;
+                };
                 if (promiseMaybe instanceof Promise) {
                     const functionMaybe = await promiseMaybe;
                     if (functionMaybe instanceof Function) {
-                        this.removalsByTuple[tupleHash] = functionMaybe;
+                        storeRemoval(functionMaybe);
                     }
                 }
                 else {
                     const functionMaybe = promiseMaybe;
                     if (functionMaybe instanceof Function) {
-                        this.removalsByTuple[tupleHash] = async () => {
+                        storeRemoval(async () => {
                             functionMaybe();
                             return Promise.resolve();
-                        };
+                        });
                     }
                 }
-            } else if (this.notifiedTuples.has(tupleHash)) {
-                Trace.info(`[Observer] Skipping already notified tuple - Path: ${displayPath}, Tuple hash: ${tupleHash.substring(0, 8)}...`);
+            } else {
+                Trace.info(`[Observer] Skipping already notified row - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}...`);
             }
 
             // Recursively notify added for specification results.
@@ -472,23 +540,48 @@ export class ObserverImpl<T> implements Observer<T> {
                         const childPath = path + "." + component.name;
                         const childResults = pr.result[component.name];
                         Trace.info(`[Observer] Processing nested spec - Parent path: ${displayPath}, Child path: ${childPath}, Child results: ${childResults?.length || 0}`);
-                        await this.notifyAdded(childResults, component.projection, childPath, Object.keys(pr.tuple));
+                        await this.notifyAdded(childResults, component.projection, childPath, Object.keys(pr.tuple), branch);
                     }
                 }
             }
         }
     }
 
-    async notifyRemoved(resultSubset: string[], projectedResult: ProjectedResult[]): Promise<void> {
+    async notifyRemoved(inverse: SpecificationInverse, projectedResult: ProjectedResult[], branch: ObserverBranch): Promise<void> {
+        const isRoot = inverse.path === "";
         for (const pr of projectedResult) {
-            const resultTupleHash = computeTupleSubsetHash(pr.tuple, resultSubset);
-            const removal = this.removalsByTuple[resultTupleHash];
-            if (removal !== undefined) {
-                await removal();
-                delete this.removalsByTuple[resultTupleHash];
-
-                // After the tuple is removed, it can be re-added.
-                this.notifiedTuples.delete(resultTupleHash);
+            if (isRoot) {
+                const rowHash = this.computeRowIdentityHash(pr.tuple);
+                const voteId = computeTupleSubsetHash(pr.tuple, branch.voteLabels);
+                const supportingVotes = this.branchVotesByRow.get(rowHash);
+                if (!supportingVotes) continue;
+                // `delete` returns false if this vote wasn't recorded, in
+                // which case the remove is for a (row, auth path) the
+                // observer never delivered — nothing to do.
+                if (!supportingVotes.delete(voteId)) continue;
+                if (supportingVotes.size > 0) {
+                    Trace.info(`[Observer] NOTIFY_REMOVED - Row hash: ${rowHash.substring(0, 8)}..., Remaining votes: ${supportingVotes.size} (row retained)`);
+                    continue;
+                }
+                // Last vote withdrawn — fire the row's removal callback and
+                // forget the row entirely so a future add can re-deliver it.
+                const removal = this.removalsByRow.get(rowHash);
+                this.branchVotesByRow.delete(rowHash);
+                this.removalsByRow.delete(rowHash);
+                if (removal !== undefined) {
+                    Trace.info(`[Observer] NOTIFY_REMOVED - Row hash: ${rowHash.substring(0, 8)}..., Last vote withdrawn, firing removal`);
+                    await removal();
+                }
+            } else {
+                // Nested removals: look up the registered removal by the
+                // inverse's resultSubset, the way it always did.
+                const resultTupleHash = computeTupleSubsetHash(pr.tuple, inverse.resultSubset);
+                const removal = this.removalsByTuple[resultTupleHash];
+                if (removal !== undefined) {
+                    await removal();
+                    delete this.removalsByTuple[resultTupleHash];
+                    this.notifiedTuples.delete(resultTupleHash);
+                }
             }
         }
     }
@@ -501,7 +594,7 @@ export class ObserverImpl<T> implements Observer<T> {
      * @param projection - The projection associated with the result
      * @param parentSubset - The parent subset of fact references
      */
-    private bufferPendingNotification(path: string, pr: ProjectedResult, projection: Projection, parentSubset: string[]): void {
+    private bufferPendingNotification(path: string, pr: ProjectedResult, projection: Projection, parentSubset: string[], branch: ObserverBranch): void {
         const parentTupleHash = computeTupleSubsetHash(pr.tuple, parentSubset);
         const key = `${path}|${parentTupleHash}`;
         const existing = this.pendingAddsByKey.get(key);
@@ -509,14 +602,14 @@ export class ObserverImpl<T> implements Observer<T> {
             existing.results.push(pr);
         }
         else {
-            this.pendingAddsByKey.set(key, { projection, parentSubset, results: [pr] });
+            this.pendingAddsByKey.set(key, { projection, parentSubset, results: [pr], branch });
         }
     }
 
     /**
      * Hash that identifies a row by the pre-intersection spec's labels,
      * skipping any branch-specific auth-path unknowns. Used for cross-branch
-     * dedup in `notifiedTuples`.
+     * dedup and ref counting in `branchVotesByRow`.
      */
     private computeRowIdentityHash(tuple: ReferencesByName): string {
         return computeTupleSubsetHash(tuple, this.rowIdentityLabels);
@@ -552,7 +645,7 @@ export class ObserverImpl<T> implements Observer<T> {
                                 // Track this replay as a pending notification
                                 const replayWork = async () => {
                                     try {
-                                        await this.notifyAdded(pending.results, pending.projection, path, pending.parentSubset);
+                                        await this.notifyAdded(pending.results, pending.projection, path, pending.parentSubset, pending.branch);
                                     } catch (error) {
                                         Trace.error(`[Observer] ERROR in buffered replay - Path: ${path}, Error: ${error}`);
                                     }

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -51,32 +51,26 @@ export class ObserverImpl<T> implements Observer<T> {
     private cachedPromise: Promise<boolean> | undefined;
     private loadedPromise: Promise<void> | undefined;
     /**
-     * Root-level per-row ref counting for OR semantics across branches.
-     * Keyed by the row identity hash (subset over `rowIdentityLabels`).
-     * The value set holds one entry per branch+auth-path combination
-     * that currently authorizes the row — a "vote." A row is delivered
-     * to the handler on the *first* vote and its removal callback fires
-     * on the *last* withdrawn vote, so revoking one of two overlapping
-     * authorizations leaves the row in place and revoking the last one
-     * removes it. Only applied at `path === ""` (the user-visible root
-     * subscription) — nested child projections live within a single
-     * branch's auth path and use the standard full-tuple dedup below.
+     * Per-row ref counting. At every path each row carries a set of
+     * "votes" — distinct authorizing paths that currently support it.
+     * The row is delivered to the handler on the *first* vote in and
+     * its removal callback fires on the *last* vote out.
+     *
+     * At the root path, the OR over distribution rules makes multi-vote
+     * rows possible: branch A authorizes via Administrator while branch B
+     * authorizes via President, both producing the same user-visible row.
+     * At nested paths each row has exactly one possible authorizing
+     * path (its parent's branch), so `voteId === rowHash` and the set
+     * degenerates to a single element — add → deliver, remove → tear
+     * down, identical to the pre-OR behavior. One mechanism with a
+     * degenerate case, not two parallel mechanisms.
      */
-    private branchVotesByRow = new Map<string, Set<string>>();
+    private votesByRow = new Map<string, Set<string>>();
     /**
-     * Root-level removal callbacks, keyed by the same row identity hash
-     * as `branchVotesByRow`.
+     * Removal callbacks registered when each row was first delivered,
+     * keyed by the same row identity hash as `votesByRow`.
      */
     private removalsByRow = new Map<string, () => Promise<void>>();
-    /**
-     * Child-path dedup and removal registry. The full-tuple hash is a
-     * stable identifier for nested rows because each nested row carries a
-     * distinct combination of parent + child labels.
-     */
-    private removalsByTuple: {
-        [tupleHash: string]: () => Promise<void>;
-    } = {};
-    private notifiedTuples = new Set<string>();
     private addedHandlers: {
         tupleHash: string;
         path: string;
@@ -122,7 +116,7 @@ export class ObserverImpl<T> implements Observer<T> {
      * different alpha-renamed auth-path unknowns to the tuple, so a hash
      * over the full tuple would differ across branches for the same row.
      * Hashing only over these labels yields a stable row identity that
-     * collapses identical rows across branches for `branchVotesByRow`.
+     * collapses identical rows across branches for `votesByRow`.
      */
     private rowIdentityLabels: string[];
 
@@ -440,31 +434,32 @@ export class ObserverImpl<T> implements Observer<T> {
         await notificationPromise;
     }
 
+    /**
+     * Pick (rowHash, voteId) for `path`. At the root they're distinct so
+     * the same row from two branches collides on `rowHash` while their
+     * distinct auth paths separate on `voteId` — that's the OR fan-out.
+     * At nested paths there's a single possible auth path per row, so
+     * the two hashes coincide and the vote set degenerates to one entry.
+     */
+    private rowAndVoteHashes(tuple: ReferencesByName, path: string, branch: ObserverBranch): { rowHash: string; voteId: string } {
+        if (path === "") {
+            return {
+                rowHash: computeTupleSubsetHash(tuple, this.rowIdentityLabels),
+                voteId: computeTupleSubsetHash(tuple, branch.voteLabels)
+            };
+        }
+        const h = computeObjectHash(tuple);
+        return { rowHash: h, voteId: h };
+    }
+
     private async notifyAdded(projectedResults: ProjectedResult[], projection: Projection, path: string, parentSubset: string[], branch: ObserverBranch) {
         const displayPath = path || "(root)";
         Trace.info(`[Observer] NOTIFY_ADDED - Path: ${displayPath}, Results: ${projectedResults.length}, Parent subset: [${parentSubset.join(', ')}]`);
 
-        // OR ref counting applies at the root path only. Nested children
-        // live within the same auth path as their parent — branching is a
-        // root-level concern — so they continue to dedup by full-tuple
-        // hash and store removals in `removalsByTuple`.
-        const isRoot = path === "";
-
         for (const pr of projectedResults) {
             const result: any = await this.injectObservers(pr, projection, path);
             const parentTupleHash = computeTupleSubsetHash(pr.tuple, parentSubset);
-            // For root rows, `rowHash` collapses the same row across
-            // branches (subset over `rowIdentityLabels`). For nested
-            // rows, the full-tuple hash is the right identity.
-            const rowHash = isRoot
-                ? this.computeRowIdentityHash(pr.tuple)
-                : computeObjectHash(pr.tuple);
-            // At the root, the vote id additionally tracks *which* auth
-            // path is currently authorizing the row, so revoking one path
-            // can leave another in place. Not needed for child rows.
-            const voteId = isRoot
-                ? computeTupleSubsetHash(pr.tuple, branch.voteLabels)
-                : rowHash;
+            const { rowHash, voteId } = this.rowAndVoteHashes(pr.tuple, path, branch);
 
             Trace.info(`[Observer] Processing result - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}..., Vote id: ${voteId.substring(0, 8)}..., Parent tuple hash: ${parentTupleHash.substring(0, 8)}...`);
 
@@ -489,19 +484,17 @@ export class ObserverImpl<T> implements Observer<T> {
                 Trace.info(`[Observer] Handler found - Path: ${displayPath}`);
             }
 
-            let isFirstDelivery: boolean;
-            if (isRoot) {
-                let supportingVotes = this.branchVotesByRow.get(rowHash);
-                isFirstDelivery = !supportingVotes;
-                if (!supportingVotes) {
-                    supportingVotes = new Set();
-                    this.branchVotesByRow.set(rowHash, supportingVotes);
-                }
-                supportingVotes.add(voteId);
-            } else {
-                isFirstDelivery = !this.notifiedTuples.has(rowHash);
-                if (isFirstDelivery) this.notifiedTuples.add(rowHash);
+            // Cast the vote. First vote into an empty set means this is
+            // the first time the user sees this row; subsequent votes
+            // (other branches authorizing the same row, or another auth
+            // path within the same branch) ref-count silently.
+            let votes = this.votesByRow.get(rowHash);
+            const isFirstDelivery = !votes;
+            if (!votes) {
+                votes = new Set();
+                this.votesByRow.set(rowHash, votes);
             }
+            votes.add(voteId);
 
             if (isFirstDelivery) {
                 if (this.stopped) {
@@ -510,20 +503,16 @@ export class ObserverImpl<T> implements Observer<T> {
                 }
                 Trace.info(`[Observer] CALLING HANDLER - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}...`);
                 const promiseMaybe = resultAdded(result);
-                const storeRemoval = (fn: () => Promise<void>) => {
-                    if (isRoot) this.removalsByRow.set(rowHash, fn);
-                    else this.removalsByTuple[rowHash] = fn;
-                };
                 if (promiseMaybe instanceof Promise) {
                     const functionMaybe = await promiseMaybe;
                     if (functionMaybe instanceof Function) {
-                        storeRemoval(functionMaybe);
+                        this.removalsByRow.set(rowHash, functionMaybe);
                     }
                 }
                 else {
                     const functionMaybe = promiseMaybe;
                     if (functionMaybe instanceof Function) {
-                        storeRemoval(async () => {
+                        this.removalsByRow.set(rowHash, async () => {
                             functionMaybe();
                             return Promise.resolve();
                         });
@@ -548,40 +537,26 @@ export class ObserverImpl<T> implements Observer<T> {
     }
 
     async notifyRemoved(inverse: SpecificationInverse, projectedResult: ProjectedResult[], branch: ObserverBranch): Promise<void> {
-        const isRoot = inverse.path === "";
         for (const pr of projectedResult) {
-            if (isRoot) {
-                const rowHash = this.computeRowIdentityHash(pr.tuple);
-                const voteId = computeTupleSubsetHash(pr.tuple, branch.voteLabels);
-                const supportingVotes = this.branchVotesByRow.get(rowHash);
-                if (!supportingVotes) continue;
-                // `delete` returns false if this vote wasn't recorded, in
-                // which case the remove is for a (row, auth path) the
-                // observer never delivered — nothing to do.
-                if (!supportingVotes.delete(voteId)) continue;
-                if (supportingVotes.size > 0) {
-                    Trace.info(`[Observer] NOTIFY_REMOVED - Row hash: ${rowHash.substring(0, 8)}..., Remaining votes: ${supportingVotes.size} (row retained)`);
-                    continue;
-                }
-                // Last vote withdrawn — fire the row's removal callback and
-                // forget the row entirely so a future add can re-deliver it.
-                const removal = this.removalsByRow.get(rowHash);
-                this.branchVotesByRow.delete(rowHash);
-                this.removalsByRow.delete(rowHash);
-                if (removal !== undefined) {
-                    Trace.info(`[Observer] NOTIFY_REMOVED - Row hash: ${rowHash.substring(0, 8)}..., Last vote withdrawn, firing removal`);
-                    await removal();
-                }
-            } else {
-                // Nested removals: look up the registered removal by the
-                // inverse's resultSubset, the way it always did.
-                const resultTupleHash = computeTupleSubsetHash(pr.tuple, inverse.resultSubset);
-                const removal = this.removalsByTuple[resultTupleHash];
-                if (removal !== undefined) {
-                    await removal();
-                    delete this.removalsByTuple[resultTupleHash];
-                    this.notifiedTuples.delete(resultTupleHash);
-                }
+            const { rowHash, voteId } = this.rowAndVoteHashes(pr.tuple, inverse.path, branch);
+            const votes = this.votesByRow.get(rowHash);
+            if (!votes) continue;
+            // `delete` returns false if this vote wasn't recorded, in
+            // which case the remove is for a (row, auth path) the
+            // observer never delivered — nothing to do.
+            if (!votes.delete(voteId)) continue;
+            if (votes.size > 0) {
+                Trace.info(`[Observer] NOTIFY_REMOVED - Row hash: ${rowHash.substring(0, 8)}..., Remaining votes: ${votes.size} (row retained)`);
+                continue;
+            }
+            // Last vote withdrawn — fire the row's removal callback and
+            // forget the row entirely so a future add can re-deliver it.
+            const removal = this.removalsByRow.get(rowHash);
+            this.votesByRow.delete(rowHash);
+            this.removalsByRow.delete(rowHash);
+            if (removal !== undefined) {
+                Trace.info(`[Observer] NOTIFY_REMOVED - Row hash: ${rowHash.substring(0, 8)}..., Last vote withdrawn, firing removal`);
+                await removal();
             }
         }
     }
@@ -606,15 +581,6 @@ export class ObserverImpl<T> implements Observer<T> {
         }
     }
 
-    /**
-     * Hash that identifies a row by the pre-intersection spec's labels,
-     * skipping any branch-specific auth-path unknowns. Used for cross-branch
-     * dedup and ref counting in `branchVotesByRow`.
-     */
-    private computeRowIdentityHash(tuple: ReferencesByName): string {
-        return computeTupleSubsetHash(tuple, this.rowIdentityLabels);
-    }
-    
     private async injectObservers(pr: ProjectedResult, projection: Projection, parentPath: string): Promise<any> {
         const displayPath = parentPath || "(root)";
         

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -31,11 +31,16 @@ export interface Observer<T> {
     stop(): void;
 }
 
+interface ObserverBranch {
+    specification: Specification;
+    feeds: string[];
+    listeners: SpecificationListener[];
+}
+
 export class ObserverImpl<T> implements Observer<T> {
     private givenHash: string;
     private cachedPromise: Promise<boolean> | undefined;
     private loadedPromise: Promise<void> | undefined;
-    private listeners: SpecificationListener[] = [];
     private removalsByTuple: {
         [tupleHash: string]: () => Promise<void>;
     } = {};
@@ -46,7 +51,15 @@ export class ObserverImpl<T> implements Observer<T> {
         handler: ResultAddedFunc<any>;
     }[] = [];
     private specificationHash: string;
-    private feeds: string[] = [];
+    /**
+     * One branch per distribution-rule intersection that authorizes the
+     * subscription. Length 1 when no intersection occurred (no rule, or the
+     * user is already authorized). Length >=1 with multiple entries when
+     * two or more rules independently authorize the same target shape;
+     * each branch is subscribed and its results deduplicated at the
+     * observer for OR semantics.
+     */
+    private branches: ObserverBranch[];
     private stopped: boolean = false;
     private listenersAdded: boolean = false;
     private loadResolve: (() => void) | undefined;
@@ -71,13 +84,37 @@ export class ObserverImpl<T> implements Observer<T> {
      */
     private pendingAddsByKey: Map<string, { projection: Projection; parentSubset: string[]; results: ProjectedResult[] }>
         = new Map();
+    /**
+     * Labels (givens + match unknowns) drawn from the pre-intersection
+     * specification. With multi-branch OR intersection each branch adds
+     * different alpha-renamed auth-path unknowns to the tuple, so a hash
+     * over the full tuple would differ across branches for the same row.
+     * Hashing only over these labels yields a stable row identity that
+     * collapses identical rows across branches for `notifiedTuples`.
+     */
+    private rowIdentityLabels: string[];
 
     constructor(
         private factManager: FactManager,
         private given: FactReference[],
-        private specification: Specification,
+        specification: Specification,
         resultAdded: ResultAddedFunc<T>
     ) {
+        // Start with a single passthrough branch. `applySubscribeIntersection`
+        // may replace this with one branch per matching distribution rule.
+        this.branches = [{
+            specification,
+            feeds: [],
+            listeners: []
+        }];
+
+        // Capture the original spec's labels. These are stable across any
+        // future branch fan-out from `applySubscribeIntersection`.
+        this.rowIdentityLabels = [
+            ...specification.given.map(g => g.label.name),
+            ...specification.matches.map(m => m.unknown.name)
+        ];
+
         // Map the given facts to a tuple.
         const tuple = specification.given.reduce((tuple, label, index) => ({
             ...tuple,
@@ -159,30 +196,32 @@ export class ObserverImpl<T> implements Observer<T> {
         if (this.listenersAdded) {
             return;
         }
-        Trace.info(`[Observer] ADDING LISTENERS - Spec hash: ${this.specificationHash.substring(0, 8)}..., Given hash: ${this.givenHash.substring(0, 8)}...`);
-        
-        const inverses = invertSpecification(this.specification);
-        Trace.info(`[Observer] Generated ${inverses.length} inverse specifications`);
-        
-        inverses.forEach((inverse, index) => {
-            const givenType = inverse.inverseSpecification.given[0].label.type;
-            const path = inverse.path || "(root)";
-            const operation = inverse.operation;
-            Trace.info(`[Observer] Inverse ${index + 1}/${inverses.length} - Path: ${path}, Operation: ${operation}, Given type: ${givenType}, Given subset: [${inverse.givenSubset.join(', ')}], Parent subset: [${inverse.parentSubset.join(', ')}]`);
-        });
-        
-        const listeners = inverses.map((inverse, index) => {
-            const listener = this.factManager.addSpecificationListener(
-                inverse.inverseSpecification,
-                (results) => this.onResult(inverse, results)
-            );
-            const path = inverse.path || "(root)";
-            Trace.info(`[Observer] Registered listener ${index + 1}/${inverses.length} for path: ${path}`);
-            return listener;
-        });
-        
-        this.listeners = listeners;
-        Trace.info(`[Observer] LISTENERS REGISTERED - Total: ${this.listeners.length}, Spec hash: ${this.specificationHash.substring(0, 8)}...`);
+        Trace.info(`[Observer] ADDING LISTENERS - Spec hash: ${this.specificationHash.substring(0, 8)}..., Given hash: ${this.givenHash.substring(0, 8)}..., Branches: ${this.branches.length}`);
+
+        for (let branchIndex = 0; branchIndex < this.branches.length; branchIndex++) {
+            const branch = this.branches[branchIndex];
+            const inverses = invertSpecification(branch.specification);
+            Trace.info(`[Observer] Branch ${branchIndex} produced ${inverses.length} inverse specifications`);
+
+            inverses.forEach((inverse, index) => {
+                const givenType = inverse.inverseSpecification.given[0].label.type;
+                const path = inverse.path || "(root)";
+                const operation = inverse.operation;
+                Trace.info(`[Observer] Branch ${branchIndex} Inverse ${index + 1}/${inverses.length} - Path: ${path}, Operation: ${operation}, Given type: ${givenType}, Given subset: [${inverse.givenSubset.join(', ')}], Parent subset: [${inverse.parentSubset.join(', ')}]`);
+            });
+
+            branch.listeners = inverses.map((inverse, index) => {
+                const listener = this.factManager.addSpecificationListener(
+                    inverse.inverseSpecification,
+                    (results) => this.onResult(inverse, results)
+                );
+                const path = inverse.path || "(root)";
+                Trace.info(`[Observer] Branch ${branchIndex} registered listener ${index + 1}/${inverses.length} for path: ${path}`);
+                return listener;
+            });
+        }
+        const totalListeners = this.branches.reduce((sum, b) => sum + b.listeners.length, 0);
+        Trace.info(`[Observer] LISTENERS REGISTERED - Total: ${totalListeners}, Spec hash: ${this.specificationHash.substring(0, 8)}...`);
         this.listenersAdded = true;
     }
 
@@ -215,11 +254,14 @@ export class ObserverImpl<T> implements Observer<T> {
 
     public stop() {
         this.stopped = true;
-        for (const listener of this.listeners) {
-            this.factManager.removeSpecificationListener(listener);
-        }
-        if (this.feeds.length > 0) {
-            this.factManager.unsubscribe(this.feeds);
+        for (const branch of this.branches) {
+            for (const listener of branch.listeners) {
+                this.factManager.removeSpecificationListener(listener);
+            }
+            if (branch.feeds.length > 0) {
+                this.factManager.unsubscribe(branch.feeds);
+                branch.feeds = [];
+            }
         }
         // Settle loadedPromise if it is still pending, so callers that await
         // loaded() are not permanently suspended after stop().
@@ -230,22 +272,39 @@ export class ObserverImpl<T> implements Observer<T> {
     }
 
     private async applySubscribeIntersection() {
-        const result = await this.factManager.intersectForSubscribe(this.given, this.specification);
-        if (result.specification === this.specification && result.start === this.given) {
+        const originalSpec = this.branches[0].specification;
+        const branches = await this.factManager.intersectForSubscribe(this.given, originalSpec);
+        // Passthrough: a single branch carrying the original (start, spec).
+        // Keep the constructor-set state intact.
+        const passthrough = branches.length === 1
+            && branches[0].specification === originalSpec
+            && branches[0].start === this.given;
+        if (passthrough) {
             return;
         }
         const previousGivenHash = this.givenHash;
-        this.given = result.start;
-        this.specification = result.specification;
-        // Recompute identifying hashes against the augmented (start, spec).
-        const tuple = this.specification.given.reduce((tuple, label, index) => ({
+        // Every branch's intersected spec shares the same augmented given
+        // shape — the synthetic `distributionUser` given is appended with
+        // a fixed label and type, bound to the same userRef in every
+        // branch. So a single observer-level `given` and `givenHash`
+        // suffices; per-branch state covers only the spec / feeds /
+        // listeners that actually differ.
+        this.given = branches[0].start;
+        const augmentedSpec = branches[0].specification;
+        const tuple = augmentedSpec.given.reduce((tuple, label, index) => ({
             ...tuple,
             [label.label.name]: this.given[index]
         }), {} as ReferencesByName);
         this.givenHash = computeObjectHash(tuple);
-        const declarationString = describeDeclaration(this.given, this.specification.given.map(g => g.label));
-        const specificationString = describeSpecification(this.specification, 0);
-        this.specificationHash = computeStringHash(`${declarationString}\n${specificationString}`);
+        // Keep `specificationHash` as the pre-intersection identity (set
+        // in the constructor). That hash is the MRU cache key and the
+        // user-facing subscription identity; intersection is an internal
+        // rewrite that should not change it.
+        this.branches = branches.map(b => ({
+            specification: b.specification,
+            feeds: [],
+            listeners: []
+        }));
         // Re-key any handlers that were registered with the pre-intersection
         // givenHash. Notification routing matches handlers by tupleHash, so a
         // stale value here would silently drop every result.
@@ -254,32 +313,47 @@ export class ObserverImpl<T> implements Observer<T> {
                 handler.tupleHash = this.givenHash;
             }
         }
-        Trace.info(`[Observer] INTERSECTED - Spec hash: ${this.specificationHash.substring(0, 8)}..., Given hash: ${this.givenHash.substring(0, 8)}...`);
+        Trace.info(`[Observer] INTERSECTED - Spec hash: ${this.specificationHash.substring(0, 8)}..., Given hash: ${this.givenHash.substring(0, 8)}..., Branches: ${this.branches.length}`);
     }
 
     private async fetch(keepAlive: boolean) {
         if (keepAlive) {
-            this.feeds = await this.factManager.subscribe(this.given, this.specification);
-            // If stop() was called while we were awaiting subscribe(), clean up the
-            // feeds that were just registered so the subscriber is not leaked.
-            if (this.stopped && this.feeds.length > 0) {
-                this.factManager.unsubscribe(this.feeds);
-                this.feeds = [];
-            }
+            await Promise.all(this.branches.map(async branch => {
+                const feeds = await this.factManager.subscribe(this.given, branch.specification);
+                if (this.stopped) {
+                    // If stop() was called while we were awaiting subscribe(),
+                    // clean up the feeds that were just registered so the
+                    // subscriber is not leaked.
+                    if (feeds.length > 0) {
+                        this.factManager.unsubscribe(feeds);
+                    }
+                    return;
+                }
+                branch.feeds = feeds;
+            }));
         }
         else {
-            await this.factManager.fetch(this.given, this.specification);
+            await Promise.all(this.branches.map(branch =>
+                this.factManager.fetch(this.given, branch.specification)));
         }
     }
 
     private async read() {
-        const projectedResults = await this.factManager.read(this.given, this.specification);
+        // Read every branch's spec. Each branch produces an independently
+        // filtered result set (different intersected auth conditions); the
+        // dedup at `notifyAdded` ensures each row surfaces only once.
+        const branchResults = await Promise.all(this.branches.map(async branch => ({
+            branch,
+            projected: await this.factManager.read(this.given, branch.specification)
+        })));
         if (this.stopped) {
             // The observer was stopped before the read completed.
             return;
         }
-        const givenSubset = this.specification.given.map(g => g.label.name);
-        await this.notifyAdded(projectedResults, this.specification.projection, "", givenSubset);
+        for (const { branch, projected } of branchResults) {
+            const givenSubset = branch.specification.given.map(g => g.label.name);
+            await this.notifyAdded(projected, branch.specification.projection, "", givenSubset);
+        }
     }
 
     private async onResult(inverse: SpecificationInverse, results: ProjectedResult[]): Promise<void> {
@@ -327,7 +401,17 @@ export class ObserverImpl<T> implements Observer<T> {
         for (const pr of projectedResults) {
             const result: any = await this.injectObservers(pr, projection, path);
             const parentTupleHash = computeTupleSubsetHash(pr.tuple, parentSubset);
-            const tupleHash = computeObjectHash(pr.tuple);
+            // Identify the row for dedup. In single-branch mode (no
+            // intersection, or single-rule intersection) the full tuple
+            // is the row identity. In multi-branch OR intersection each
+            // branch carries different alpha-renamed auth-path unknowns,
+            // so the full tuple would differ across branches for the
+            // same row; fall back to a subset hash over the pre-
+            // intersection spec's labels, which is stable across
+            // branches.
+            const tupleHash = this.branches.length > 1
+                ? this.computeRowIdentityHash(pr.tuple)
+                : computeObjectHash(pr.tuple);
             
             Trace.info(`[Observer] Processing result - Path: ${displayPath}, Tuple hash: ${tupleHash.substring(0, 8)}..., Parent tuple hash: ${parentTupleHash.substring(0, 8)}...`);
             
@@ -427,6 +511,15 @@ export class ObserverImpl<T> implements Observer<T> {
         else {
             this.pendingAddsByKey.set(key, { projection, parentSubset, results: [pr] });
         }
+    }
+
+    /**
+     * Hash that identifies a row by the pre-intersection spec's labels,
+     * skipping any branch-specific auth-path unknowns. Used for cross-branch
+     * dedup in `notifiedTuples`.
+     */
+    private computeRowIdentityHash(tuple: ReferencesByName): string {
+        return computeTupleSubsetHash(tuple, this.rowIdentityLabels);
     }
     
     private async injectObservers(pr: ProjectedResult, projection: Projection, parentPath: string): Promise<any> {

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -102,11 +102,20 @@ export class ObserverImpl<T> implements Observer<T> {
     public start(keepAlive: boolean) {
         const givenTypes = this.given.map(g => g.type).join(', ');
         Trace.info(`[Observer] START - Spec hash: ${this.specificationHash.substring(0, 8)}..., Given hash: ${this.givenHash.substring(0, 8)}..., Given types: [${givenTypes}], KeepAlive: ${keepAlive}`);
-        
+
         this.cachedPromise = new Promise((cacheResolve, _) => {
             this.loadedPromise = new Promise(async (loadResolve, loadReject) => {
                 this.loadResolve = loadResolve;
                 try {
+                    // Phase 3 of j.subscribe trust release: intersect with any
+                    // applicable distribution rule before installing listeners
+                    // and reading. This way the spec returns empty until the
+                    // authorizing fact arrives, at which point the existing
+                    // inverse engine surfaces results via the auth-fact
+                    // inverses that intersection added.
+                    if (keepAlive) {
+                        await this.applySubscribeIntersection();
+                    }
                     // Ensure listeners are added BEFORE any read/fetch to close T2–T3 window.
                     if (!this.listenersAdded) {
                         this.addSpecificationListeners();
@@ -218,6 +227,34 @@ export class ObserverImpl<T> implements Observer<T> {
             this.loadResolve();
             this.loadResolve = undefined;
         }
+    }
+
+    private async applySubscribeIntersection() {
+        const result = await this.factManager.intersectForSubscribe(this.given, this.specification);
+        if (result.specification === this.specification && result.start === this.given) {
+            return;
+        }
+        const previousGivenHash = this.givenHash;
+        this.given = result.start;
+        this.specification = result.specification;
+        // Recompute identifying hashes against the augmented (start, spec).
+        const tuple = this.specification.given.reduce((tuple, label, index) => ({
+            ...tuple,
+            [label.label.name]: this.given[index]
+        }), {} as ReferencesByName);
+        this.givenHash = computeObjectHash(tuple);
+        const declarationString = describeDeclaration(this.given, this.specification.given.map(g => g.label));
+        const specificationString = describeSpecification(this.specification, 0);
+        this.specificationHash = computeStringHash(`${declarationString}\n${specificationString}`);
+        // Re-key any handlers that were registered with the pre-intersection
+        // givenHash. Notification routing matches handlers by tupleHash, so a
+        // stale value here would silently drop every result.
+        for (const handler of this.addedHandlers) {
+            if (handler.tupleHash === previousGivenHash) {
+                handler.tupleHash = this.givenHash;
+            }
+        }
+        Trace.info(`[Observer] INTERSECTED - Spec hash: ${this.specificationHash.substring(0, 8)}..., Given hash: ${this.givenHash.substring(0, 8)}...`);
     }
 
     private async fetch(keepAlive: boolean) {

--- a/src/specification/UnionFind.ts
+++ b/src/specification/UnionFind.ts
@@ -105,6 +105,23 @@ class UnionFind {
  * Also collects all labels encountered during traversal.
  */
 function addConnectionsToUnionFind(specification: Specification, unionFind: UnionFind, allLabels: Set<string>, labelTypes: Map<string, string>): void {
+    // Conditions on givens (e.g., the existential introduced by
+    // distribution-rule intersection) reference other labels and are part
+    // of the connectivity graph. The inverter promotes given conditions to
+    // match conditions, so connectedness must include them too.
+    for (const given of specification.given) {
+        for (const condition of given.conditions) {
+            for (const nestedMatch of condition.matches) {
+                addConnectionsFromMatchToUnionFind(unionFind, nestedMatch, allLabels, labelTypes);
+                const nestedConnections = getLabelsReferencedInMatch(nestedMatch);
+                for (const connectedLabel of nestedConnections) {
+                    allLabels.add(connectedLabel);
+                    unionFind.union(given.label.name, connectedLabel);
+                }
+            }
+        }
+    }
+
     // Add connections from path conditions in matches
     for (const match of specification.matches) {
         addConnectionsFromMatchToUnionFind(unionFind, match, allLabels, labelTypes);

--- a/src/specification/specification-intersection.ts
+++ b/src/specification/specification-intersection.ts
@@ -355,10 +355,16 @@ export function intersectSpecificationWithDistributionRule(
 }
 
 /**
- * True if `specification` already carries the synthetic `distributionUser`
- * given — i.e., it has already been intersected. Used by the distribution
- * engine to skip authorization re-checks on intersected feeds, since the
- * spec itself now encodes the auth pattern.
+ * True if `specification` carries the synthetic `distributionUser` given —
+ * i.e., it has the surface shape an intersected spec would have.
+ *
+ * **Not a security boundary.** The shape is trivially forgeable by a caller
+ * (anyone can author a spec with a given named `distributionUser` of type
+ * `Jinaga.User`), so this MUST NOT be used to bypass authorization checks.
+ * The bypass for intersected feeds lives in `NetworkDistribution` as
+ * runtime state populated only by the engine's own intersection — that
+ * marker is unforgeable and is the one to trust. Keep this helper for
+ * diagnostic/serialization purposes only.
  */
 export function specificationHasIntersection(specification: Specification): boolean {
     return specification.given.some(g =>

--- a/src/specification/specification-intersection.ts
+++ b/src/specification/specification-intersection.ts
@@ -249,13 +249,26 @@ export function intersectSpecificationWithDistributionRule(
 
     // Rename every rule unknown to a non-colliding dist_-prefixed name. The
     // shared given names stay the same so the rule's path conditions still
-    // reference the original givens.
+    // reference the original givens. Walk nested existentials too: an
+    // unknown introduced inside `match.conditions.matches` (e.g. a
+    // `notExists(...)` revocation) is also a label the rule binds, and
+    // skipping it leaves the original name in place, which can collide
+    // with a caller-spec label.
+    const ruleGivenNames = new Set(ruleSpecification.given.map(g => g.label.name));
     const ruleUnknowns = new Set<string>();
-    ruleSpecification.matches.forEach(m => {
-        if (!ruleSpecification.given.some(g => g.label.name === m.unknown.name)) {
-            ruleUnknowns.add(m.unknown.name);
+    function collectRuleUnknowns(matches: Match[]) {
+        for (const m of matches) {
+            if (!ruleGivenNames.has(m.unknown.name)) {
+                ruleUnknowns.add(m.unknown.name);
+            }
+            for (const condition of m.conditions) {
+                if (condition.type === "existential") {
+                    collectRuleUnknowns(condition.matches);
+                }
+            }
         }
-    });
+    }
+    collectRuleUnknowns(ruleSpecification.matches);
     const mapping: Record<string, string> = {};
     for (const unknown of ruleUnknowns) {
         let newName = "dist_" + unknown;

--- a/src/specification/specification-intersection.ts
+++ b/src/specification/specification-intersection.ts
@@ -1,0 +1,367 @@
+import { User } from "../model/user";
+import {
+    Condition,
+    ExistentialCondition,
+    Match,
+    NamedComponentProjection,
+    Projection,
+    Specification,
+    SpecificationGiven
+} from "./specification";
+import { Invalid } from "./specification-parser";
+
+/**
+ * Rename labels in a specification according to a mapping.
+ *
+ * The transformation is "alpha" in the lambda-calculus sense — it preserves
+ * meaning by renaming bound names consistently. Used by intersection to avoid
+ * label collisions when merging a distribution rule's user spec into the
+ * caller's spec.
+ */
+export function alphaTransform(spec: Specification, mapping: Record<string, string>): Specification {
+    if (spec === null || spec === undefined) {
+        throw new Invalid("Specification is required");
+    }
+    if (mapping === null || mapping === undefined) {
+        throw new Invalid("Mapping is required");
+    }
+
+    const allLabels = new Set<string>();
+    function collectLabels(spec: Specification) {
+        spec.given.forEach(g => {
+            allLabels.add(g.label.name);
+            g.conditions.forEach(c => collectConditionLabels(c));
+        });
+        spec.matches.forEach(m => {
+            allLabels.add(m.unknown.name);
+            m.conditions.forEach(c => collectConditionLabels(c));
+        });
+        collectProjectionLabels(spec.projection);
+    }
+    function collectConditionLabels(condition: Condition) {
+        if (condition.type === "path") {
+            allLabels.add(condition.labelRight);
+        } else if (condition.type === "existential") {
+            condition.matches.forEach(m => {
+                allLabels.add(m.unknown.name);
+                m.conditions.forEach(c => collectConditionLabels(c));
+            });
+        }
+    }
+    function collectProjectionLabels(projection: Projection) {
+        if (projection.type === "composite") {
+            projection.components.forEach(c => collectComponentLabels(c));
+        } else if (projection.type === "field" || projection.type === "hash" || projection.type === "fact") {
+            allLabels.add(projection.label);
+        }
+    }
+    function collectComponentLabels(component: NamedComponentProjection) {
+        if (component.type === "specification") {
+            component.matches.forEach(m => {
+                allLabels.add(m.unknown.name);
+                m.conditions.forEach(c => collectConditionLabels(c));
+            });
+            collectProjectionLabels(component.projection);
+        } else if (component.type === "field" || component.type === "hash" || component.type === "fact") {
+            allLabels.add(component.label);
+        }
+    }
+    collectLabels(spec);
+
+    const mappedValues = Object.values(mapping);
+    const uniqueMappedValues = new Set(mappedValues);
+    if (uniqueMappedValues.size !== mappedValues.length) {
+        throw new Invalid("Mapping contains duplicate target names");
+    }
+
+    const mappedKeys = new Set(Object.keys(mapping));
+    for (const label of allLabels) {
+        if (!mappedKeys.has(label)) {
+            if (uniqueMappedValues.has(label)) {
+                throw new Invalid(`Mapped name '${label}' conflicts with existing unmapped label`);
+            }
+        }
+    }
+
+    const transformLabel = (name: string) => mapping[name] || name;
+
+    const transformGiven = (given: SpecificationGiven): SpecificationGiven => ({
+        label: { ...given.label, name: transformLabel(given.label.name) },
+        conditions: given.conditions.map(transformCondition) as ExistentialCondition[]
+    });
+
+    const transformMatch = (match: Match): Match => ({
+        unknown: { ...match.unknown, name: transformLabel(match.unknown.name) },
+        conditions: match.conditions.map(transformCondition)
+    });
+
+    const transformCondition = (condition: Condition): Condition => {
+        if (condition.type === "path") {
+            return {
+                ...condition,
+                labelRight: transformLabel(condition.labelRight)
+            };
+        } else if (condition.type === "existential") {
+            return {
+                ...condition,
+                matches: condition.matches.map(transformMatch)
+            };
+        }
+        return condition;
+    };
+
+    const transformProjection = (projection: Projection): Projection => {
+        if (projection.type === "composite") {
+            return {
+                ...projection,
+                components: projection.components.map(transformComponent)
+            };
+        } else if (projection.type === "field" || projection.type === "hash" || projection.type === "fact") {
+            return {
+                ...projection,
+                label: transformLabel(projection.label)
+            };
+        }
+        return projection;
+    };
+
+    const transformComponent = (component: NamedComponentProjection): NamedComponentProjection => {
+        if (component.type === "specification") {
+            return {
+                ...component,
+                matches: component.matches.map(transformMatch),
+                projection: transformProjection(component.projection)
+            };
+        } else if (component.type === "field" || component.type === "hash" || component.type === "fact") {
+            return {
+                ...component,
+                label: transformLabel(component.label)
+            };
+        }
+        return component;
+    };
+
+    return {
+        given: spec.given.map(transformGiven),
+        matches: spec.matches.map(transformMatch),
+        projection: transformProjection(spec.projection)
+    };
+}
+
+/**
+ * Name of the synthetic given that the intersection introduces. It binds to
+ * the user fact whose authorization the spec is being filtered for, so the
+ * intersected spec returns empty when that user isn't authorized and fills
+ * in when they are.
+ */
+export const DISTRIBUTION_USER_LABEL = "distributionUser";
+
+/**
+ * Intersect a specification with a distribution rule's user specification,
+ * producing a specification whose result set is gated by the rule.
+ *
+ * Mechanic: add a synthetic `distributionUser` given (a `Jinaga.User`), then
+ * lift the rule's user-spec matches into the target spec as top-level
+ * matches (alpha-renamed to avoid collisions). Pin the rule's projected
+ * user label to `distributionUser` with an extra path condition; if the
+ * rule projects a given directly, synthesize an in-spec equality match.
+ *
+ * Lifting into top-level matches (rather than wrapping in an existential
+ * on a synthetic anchor) gives every new label a path condition into the
+ * spec graph — so the connectivity check and `shakeTree` in the inverter
+ * walk it the same way they walk any other spec. The inverter then
+ * naturally produces inverses for the authorizing fact pattern, and a
+ * subscriber sees results materialize the moment the auth fact arrives —
+ * no client-side retry, no observer.loaded().catch() guard.
+ *
+ * For typical "share with admin" rules each (start, distributionUser) tuple
+ * admits at most one authorizing path, so lifted matches don't multiply
+ * the output. Specs that authorize via multiple distinct paths (e.g., user
+ * is both creator and administrator) may see duplicated rows; observer-
+ * level dedup is the safety net there.
+ */
+export function intersectSpecificationWithDistributionRule(
+    specification: Specification,
+    ruleSpecification: Specification
+): Specification {
+    if (specification === null || specification === undefined) {
+        throw new Error("Specification is required");
+    }
+    if (ruleSpecification === null || ruleSpecification === undefined) {
+        throw new Error("Rule specification is required");
+    }
+    if (specification.given.length !== ruleSpecification.given.length) {
+        throw new Error("The number of givens in the rule specification must match the number of givens in the original specification.");
+    }
+    for (let i = 0; i < specification.given.length; i++) {
+        const given = specification.given[i];
+        const ruleGiven = ruleSpecification.given[i];
+        if (given.label.type !== ruleGiven.label.type) {
+            throw new Error("The givens in the rule specification must have the same types as the givens in the original specification.");
+        }
+    }
+
+    const ruleProjection = ruleSpecification.projection;
+    if (ruleProjection.type !== "fact") {
+        throw new Error("Distribution rule specification must have a fact projection.");
+    }
+    const projectedLabel = ruleProjection.label;
+
+    // The user can come from either an unknown match or directly from a given.
+    const distributionUserMatch = ruleSpecification.matches.find(m => m.unknown.name === projectedLabel);
+    const projectedFromGiven = ruleSpecification.given.find(g => g.label.name === projectedLabel);
+    if (!distributionUserMatch && !projectedFromGiven) {
+        throw new Error("Distribution rule specification must have a match or given for the projected user fact.");
+    }
+    const projectedType = distributionUserMatch ? distributionUserMatch.unknown.type : projectedFromGiven!.label.type;
+    if (projectedType !== User.Type) {
+        throw new Error("Distribution rule specification must project a user fact.");
+    }
+
+    // Collect every label name that already exists in either spec so we can
+    // pick non-colliding names for the rule's unknowns. The new synthetic
+    // given is also reserved.
+    const originalLabels = new Set<string>();
+    function collectAllLabels(spec: Specification) {
+        spec.given.forEach(g => originalLabels.add(g.label.name));
+        function visitMatches(matches: Match[]) {
+            matches.forEach(m => {
+                originalLabels.add(m.unknown.name);
+                m.conditions.forEach(c => {
+                    if (c.type === "existential") visitMatches(c.matches);
+                });
+            });
+        }
+        visitMatches(spec.matches);
+        if (spec.projection.type === "fact" || spec.projection.type === "field" || spec.projection.type === "hash") {
+            originalLabels.add(spec.projection.label);
+        } else if (spec.projection.type === "composite") {
+            spec.projection.components.forEach(c => {
+                if (c.type === "fact" || c.type === "field" || c.type === "hash") {
+                    originalLabels.add(c.label);
+                }
+            });
+        }
+    }
+    collectAllLabels(specification);
+    collectAllLabels(ruleSpecification);
+    originalLabels.add(DISTRIBUTION_USER_LABEL);
+
+    // Rename every rule unknown to a non-colliding dist_-prefixed name. The
+    // shared given names stay the same so the rule's path conditions still
+    // reference the original givens.
+    const ruleUnknowns = new Set<string>();
+    ruleSpecification.matches.forEach(m => {
+        if (!ruleSpecification.given.some(g => g.label.name === m.unknown.name)) {
+            ruleUnknowns.add(m.unknown.name);
+        }
+    });
+    const mapping: Record<string, string> = {};
+    for (const unknown of ruleUnknowns) {
+        let newName = "dist_" + unknown;
+        let counter = 1;
+        while (originalLabels.has(newName)) {
+            newName = "dist_" + unknown + counter;
+            counter++;
+        }
+        mapping[unknown] = newName;
+        originalLabels.add(newName);
+    }
+
+    const transformedRuleSpec = alphaTransform(ruleSpecification, mapping);
+    if (transformedRuleSpec.projection.type !== "fact") {
+        throw new Error("Transformed rule specification must have a fact projection.");
+    }
+    const transformedProjectedLabel = transformedRuleSpec.projection.label;
+
+    // Lift the rule's matches into top-level matches with the projected
+    // user pinned to the new `distributionUser` given.
+    let liftedMatches: Match[];
+    if (transformedRuleSpec.matches.find(m => m.unknown.name === transformedProjectedLabel)) {
+        liftedMatches = transformedRuleSpec.matches.map(match => {
+            if (match.unknown.name === transformedProjectedLabel) {
+                return {
+                    ...match,
+                    conditions: [
+                        ...match.conditions,
+                        {
+                            type: "path",
+                            labelRight: DISTRIBUTION_USER_LABEL,
+                            rolesLeft: [],
+                            rolesRight: []
+                        }
+                    ]
+                };
+            }
+            return match;
+        });
+    } else {
+        // The rule projects a given directly (e.g., `select(user => user)`).
+        // Synthesize an identity match that ties that given to the new
+        // `distributionUser` given.
+        const givenProjected = transformedRuleSpec.given.find(g => g.label.name === transformedProjectedLabel);
+        if (!givenProjected) {
+            throw new Error("Transformed rule specification must have a match or given for the projected user fact.");
+        }
+        const synthName = `dist_${transformedProjectedLabel}`;
+        let candidate = synthName;
+        let counter = 1;
+        while (originalLabels.has(candidate)) {
+            candidate = synthName + counter;
+            counter++;
+        }
+        originalLabels.add(candidate);
+        liftedMatches = [
+            ...transformedRuleSpec.matches,
+            {
+                unknown: { name: candidate, type: User.Type },
+                conditions: [
+                    {
+                        type: "path",
+                        labelRight: transformedProjectedLabel,
+                        rolesLeft: [],
+                        rolesRight: []
+                    },
+                    {
+                        type: "path",
+                        labelRight: DISTRIBUTION_USER_LABEL,
+                        rolesLeft: [],
+                        rolesRight: []
+                    }
+                ]
+            }
+        ];
+    }
+
+    const distributionUserGiven: SpecificationGiven = {
+        label: {
+            name: DISTRIBUTION_USER_LABEL,
+            type: User.Type
+        },
+        conditions: []
+    };
+
+    return {
+        given: [
+            ...specification.given,
+            distributionUserGiven
+        ],
+        // Lifted matches go before the original spec matches so the auth
+        // path is established and connected before the spec's own matches
+        // produce candidates.
+        matches: [...liftedMatches, ...specification.matches],
+        projection: specification.projection
+    };
+}
+
+/**
+ * True if `specification` already carries the synthetic `distributionUser`
+ * given — i.e., it has already been intersected. Used by the distribution
+ * engine to skip authorization re-checks on intersected feeds, since the
+ * spec itself now encodes the auth pattern.
+ */
+export function specificationHasIntersection(specification: Specification): boolean {
+    return specification.given.some(g =>
+        g.label.name === DISTRIBUTION_USER_LABEL && g.label.type === User.Type
+    );
+}

--- a/test/distribution/distributionEngineIntersectionSpec.ts
+++ b/test/distribution/distributionEngineIntersectionSpec.ts
@@ -1,5 +1,5 @@
 import { describeSpecification, DistributionEngine, DistributionRules, FactProjection, MemoryStore, Specification, User } from "@src";
-import { Blog, Comment, model, Post, Publish } from "../blogModel";
+import { Blog, Comment, CommentApproved, model, Post, Publish } from "../blogModel";
 
 describe("DistributionEngine.intersectSpecificationWithDistributionRule", () => {
     let engine: DistributionEngine;
@@ -191,6 +191,56 @@ describe("DistributionEngine.intersectSpecificationWithDistributionRule", () => 
                         }
                     ]
                 } => u1`);
+        });
+    });
+
+    describe("Label collision tests", () => {
+        it("renames unknowns inside nested existential conditions of the rule", () => {
+            // The rule's user-spec embeds a CommentApproved match inside a
+            // `notExists`. The intersection algorithm lifts the rule's
+            // matches into the caller's spec; if it only renames top-level
+            // rule unknowns it leaves the nested `comment`/`commentApproved`
+            // names alone, which can collide with the caller's labels and
+            // silently change semantics. After the fix every rule-bound
+            // unknown — including those inside existentials — must carry
+            // the `dist_` prefix in the merged spec.
+            const specification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(Post)
+                    .join(post => post.blog, blog)
+            ).specification;
+
+            // Rule: shared with the blog creator, but only if some
+            // CommentApproved exists for some Comment on the blog — the
+            // inner Comment and CommentApproved matches live inside an
+            // existential on the User match.
+            const ruleSpecification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(User)
+                    .join(u => u, blog.creator)
+                    .exists(u => facts.ofType(Comment)
+                        .join(comment => comment.post.blog, blog)
+                        .exists(comment => facts.ofType(CommentApproved)
+                            .join(approved => approved.comment, comment)
+                        )
+                    )
+            ).specification;
+
+            const result = engine.intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+            const description = describeSpecification(result, 0);
+
+            // The model builder auto-numbers rule unknowns as u1/u2/u3.
+            // After alpha-renaming, every rule-bound unknown — at any depth
+            // — must carry the `dist_` prefix. If the bug were still present
+            // the nested Comment and CommentApproved matches would remain
+            // bare `u2`/`u3` and collide with the caller's `u1: Post`.
+            expect(description).toContain("dist_u1: Jinaga.User"); // top-level (worked pre-fix)
+            expect(description).toContain("dist_u2: Comment");     // inside outer existential
+            expect(description).toContain("dist_u3: CommentApproved"); // inside nested existential
+
+            // No bare rule-bound names should leak through inside the
+            // lifted existential (the caller's `u1: Post` is the only
+            // un-prefixed `u1` allowed).
+            expect(description).not.toMatch(/\bu2: Comment\b/);
+            expect(description).not.toMatch(/\bu3: CommentApproved\b/);
         });
     });
 

--- a/test/distribution/distributionEngineIntersectionSpec.ts
+++ b/test/distribution/distributionEngineIntersectionSpec.ts
@@ -1,0 +1,217 @@
+import { describeSpecification, DistributionEngine, DistributionRules, FactProjection, MemoryStore, Specification, User } from "@src";
+import { Blog, Comment, model, Post, Publish } from "../blogModel";
+
+describe("DistributionEngine.intersectSpecificationWithDistributionRule", () => {
+    let engine: DistributionEngine;
+
+    beforeEach(() => {
+        const distributionRules = new DistributionRules([]);
+        const store = new MemoryStore();
+        engine = new DistributionEngine(distributionRules, store);
+    });
+
+    describe("Basic functionality tests", () => {
+        it("adds distributionUser given of type Jinaga.User", () => {
+            const specification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(Post)
+                    .join(post => post.blog, blog)
+            ).specification;
+
+            const ruleSpecification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(User)
+                    .join(u => u, blog.creator)
+            ).specification;
+
+            const result = engine.intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+
+            expect("\n" + describeSpecification(result, 4).trimEnd()).toBe(`
+                (p1: Blog, distributionUser: Jinaga.User) {
+                    dist_u1: Jinaga.User [
+                        dist_u1 = p1->creator: Jinaga.User
+                        dist_u1 = distributionUser
+                    ]
+                    u1: Post [
+                        u1->blog: Blog = p1
+                    ]
+                } => u1`);
+        });
+
+        it("pins the rule's projected user to the distributionUser given", () => {
+            const specification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(Post)
+                    .join(post => post.blog, blog)
+            ).specification;
+
+            const ruleSpecification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(User)
+                    .join(u => u, blog.creator)
+            ).specification;
+
+            const result = engine.intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+
+            const lastGiven = result.given[result.given.length - 1];
+            expect(lastGiven.label.name).toBe("distributionUser");
+            expect(lastGiven.label.type).toBe(User.Type);
+            expect(lastGiven.conditions).toHaveLength(0);
+
+            // The first match is the lifted rule's user match. It must have
+            // a path condition equating it to the new `distributionUser`
+            // given — that's what gates the result by authorization.
+            const lifted = result.matches[0];
+            expect(lifted.unknown.type).toBe(User.Type);
+            const distributionUserPaths = lifted.conditions
+                .filter(c => c.type === "path")
+                .filter((c: any) => c.labelRight === "distributionUser");
+            expect(distributionUserPaths).toHaveLength(1);
+        });
+    });
+
+    describe("Edge case tests", () => {
+        it("handles a specification with only givens", () => {
+            const specification: Specification = {
+                given: [{ label: { name: "p1", type: "Blog" }, conditions: [] }],
+                matches: [],
+                projection: { type: "fact", label: "p1" } as FactProjection
+            };
+
+            const ruleSpecification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(User)
+                    .join(u => u, blog.creator)
+            ).specification;
+
+            const result = engine.intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+
+            expect("\n" + describeSpecification(result, 4).trimEnd()).toBe(`
+                (p1: Blog, distributionUser: Jinaga.User) {
+                    dist_u1: Jinaga.User [
+                        dist_u1 = p1->creator: Jinaga.User
+                        dist_u1 = distributionUser
+                    ]
+                } => p1`);
+        });
+
+        it("throws when the rule does not have a fact projection", () => {
+            const specification = model.given(Blog).select(blog => blog).specification;
+
+            const ruleSpecification = model.given(Blog).select(blog => ({
+                posts: blog.successors(Post, post => post.blog)
+            })).specification;
+
+            expect(() => {
+                engine.intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+            }).toThrow("Distribution rule specification must have a fact projection");
+        });
+    });
+
+    describe("Integration tests", () => {
+        it("preserves nested existential conditions in the original spec", () => {
+            const specification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(Post)
+                    .join(post => post.blog, blog)
+                    .exists(post => facts.ofType(Publish)
+                        .join(publish => publish.post, post)
+                    )
+            ).specification;
+
+            const ruleSpecification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(User)
+                    .join(u => u, blog.creator)
+            ).specification;
+
+            const result = engine.intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+
+            expect("\n" + describeSpecification(result, 4).trimEnd()).toBe(`
+                (p1: Blog, distributionUser: Jinaga.User) {
+                    dist_u1: Jinaga.User [
+                        dist_u1 = p1->creator: Jinaga.User
+                        dist_u1 = distributionUser
+                    ]
+                    u1: Post [
+                        u1->blog: Blog = p1
+                        E {
+                            u2: Publish [
+                                u2->post: Post = u1
+                            ]
+                        }
+                    ]
+                } => u1`);
+        });
+
+        it("works with rules that have no matches (project a given)", () => {
+            const specification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(Post)
+                    .join(post => post.blog, blog)
+            ).specification;
+
+            // Rule whose user spec projects the given directly: every reader
+            // is allowed iff they're the blog's creator referenced from the
+            // given. The intersection must still produce a syntactic gate
+            // that the spec runner can evaluate.
+            const ruleSpecification = model.given(Blog).match(blog => blog.creator.predecessor()).specification;
+
+            const result = engine.intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+
+            expect("\n" + describeSpecification(result, 4).trimEnd()).toBe(`
+                (p1: Blog, distributionUser: Jinaga.User) {
+                    dist_u1: Jinaga.User [
+                        dist_u1 = p1->creator: Jinaga.User
+                        dist_u1 = distributionUser
+                    ]
+                    u1: Post [
+                        u1->blog: Blog = p1
+                    ]
+                } => u1`);
+        });
+
+        it("handles a self-referencing rule with a Comment chain", () => {
+            const specification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(Post)
+                    .join(post => post.blog, blog)
+                    .exists(post => facts.ofType(Comment)
+                        .join(comment => comment.post, post)
+                    )
+            ).specification;
+
+            const ruleSpecification = model.given(Blog).match(blog => blog.creator.predecessor()).specification;
+
+            const result = engine.intersectSpecificationWithDistributionRule(specification, ruleSpecification);
+
+            expect("\n" + describeSpecification(result, 4).trimEnd()).toBe(`
+                (p1: Blog, distributionUser: Jinaga.User) {
+                    dist_u1: Jinaga.User [
+                        dist_u1 = p1->creator: Jinaga.User
+                        dist_u1 = distributionUser
+                    ]
+                    u1: Post [
+                        u1->blog: Blog = p1
+                        E {
+                            u2: Comment [
+                                u2->post: Post = u1
+                            ]
+                        }
+                    ]
+                } => u1`);
+        });
+    });
+
+    describe("Error handling tests", () => {
+        it("throws for a null specification", () => {
+            const ruleSpecification = model.given(Blog).match((blog, facts) =>
+                facts.ofType(User)
+                    .join(u => u, blog.creator)
+            ).specification;
+
+            expect(() => {
+                engine.intersectSpecificationWithDistributionRule(null as any, ruleSpecification);
+            }).toThrow();
+        });
+
+        it("throws for a null rule specification", () => {
+            const specification = model.given(Blog).select(blog => blog).specification;
+
+            expect(() => {
+                engine.intersectSpecificationWithDistributionRule(specification, null as any);
+            }).toThrow();
+        });
+    });
+});

--- a/test/distribution/distributionEngineSubscribeIntersectionSpec.ts
+++ b/test/distribution/distributionEngineSubscribeIntersectionSpec.ts
@@ -1,0 +1,96 @@
+import {
+    dehydrateFact,
+    DistributionEngine,
+    DistributionRules,
+    MemoryStore,
+    User
+} from "@src";
+import { Administrator, Company, model } from "../companyModel";
+
+// Direct coverage of `DistributionEngine.intersectForSubscribe` — the seam
+// Phase 3 wires intersection through. Verifies that:
+//  - already-authorized callers see the original (start, spec) untouched;
+//  - unauthorized callers get a rewritten spec that carries the auth
+//    pattern, plus a synthetic distributionUser ref appended to start.
+describe("DistributionEngine.intersectForSubscribe", () => {
+    const creator = new User("creator");
+    const subscriber = new User("subscriber");
+    const company = new Company(creator, "Co");
+
+    const ruleUserSpec = model.given(Company).match((c, facts) =>
+        facts.ofType(Administrator)
+            .join(a => a.company, c)
+            .selectMany(a => facts.ofType(User).join(u => u, a.user))
+    );
+    const shareSpec = model.given(Company).match((c, facts) =>
+        facts.ofType(Administrator).join(a => a.company, c)
+    );
+
+    function makeEngine(seedAdmin: boolean): DistributionEngine {
+        const store = new MemoryStore();
+        const records = [
+            ...dehydrateFact(creator),
+            ...dehydrateFact(subscriber),
+            ...dehydrateFact(company)
+        ];
+        if (seedAdmin) {
+            records.push(...dehydrateFact(new Administrator(company, subscriber, new Date("2026-05-26"))));
+        }
+        store.save(records.map(r => ({ fact: r, signatures: [] })));
+        const rules = new DistributionRules([])
+            .share(shareSpec).with(ruleUserSpec);
+        return new DistributionEngine(rules, store);
+    }
+
+    const spec = model.given(Company).match((c, facts) =>
+        facts.ofType(Administrator).join(a => a.company, c)
+    ).specification;
+    const companyRef = dehydrateFact(company)[1]; // [0] is the creator User
+    const subscriberRef = dehydrateFact(subscriber)[0];
+
+    it("returns the original spec when the user is already authorized", async () => {
+        const engine = makeEngine(/* seedAdmin */ true);
+        const result = await engine.intersectForSubscribe(
+            [companyRef],
+            spec,
+            subscriberRef
+        );
+        expect(result.intersected).toBe(false);
+        expect(result.specification).toBe(spec);
+        expect(result.start).toEqual([companyRef]);
+    });
+
+    it("intersects when the user is not yet authorized", async () => {
+        const engine = makeEngine(/* seedAdmin */ false);
+        const result = await engine.intersectForSubscribe(
+            [companyRef],
+            spec,
+            subscriberRef
+        );
+        expect(result.intersected).toBe(true);
+        // The synthetic distributionUser given is appended; the start carries
+        // the user fact reference in matching position.
+        expect(result.specification.given).toHaveLength(2);
+        expect(result.specification.given[1].label.type).toBe(User.Type);
+        expect(result.start).toHaveLength(2);
+        expect(result.start[1]).toEqual({ type: subscriberRef.type, hash: subscriberRef.hash });
+    });
+
+    it("returns the original spec when no rule's shape matches the target", async () => {
+        const engine = makeEngine(/* seedAdmin */ false);
+        // A spec the rule doesn't cover at all (different fact type). The
+        // engine has no business intersecting an unrelated spec — that would
+        // change semantics for downstream evaluation — so it falls back.
+        const otherSpec = model.given(Company).match((c, facts) =>
+            facts.ofType(User).join(u => u, c.creator)
+        ).specification;
+
+        const result = await engine.intersectForSubscribe(
+            [companyRef],
+            otherSpec,
+            subscriberRef
+        );
+        expect(result.intersected).toBe(false);
+        expect(result.specification).toBe(otherSpec);
+    });
+});

--- a/test/distribution/distributionEngineSubscribeIntersectionSpec.ts
+++ b/test/distribution/distributionEngineSubscribeIntersectionSpec.ts
@@ -56,8 +56,9 @@ describe("DistributionEngine.intersectForSubscribe", () => {
             subscriberRef
         );
         expect(result.intersected).toBe(false);
-        expect(result.specification).toBe(spec);
-        expect(result.start).toEqual([companyRef]);
+        expect(result.branches).toHaveLength(1);
+        expect(result.branches[0].specification).toBe(spec);
+        expect(result.branches[0].start).toEqual([companyRef]);
     });
 
     it("intersects when the user is not yet authorized", async () => {
@@ -68,12 +69,14 @@ describe("DistributionEngine.intersectForSubscribe", () => {
             subscriberRef
         );
         expect(result.intersected).toBe(true);
+        expect(result.branches).toHaveLength(1);
         // The synthetic distributionUser given is appended; the start carries
         // the user fact reference in matching position.
-        expect(result.specification.given).toHaveLength(2);
-        expect(result.specification.given[1].label.type).toBe(User.Type);
-        expect(result.start).toHaveLength(2);
-        expect(result.start[1]).toEqual({ type: subscriberRef.type, hash: subscriberRef.hash });
+        const branch = result.branches[0];
+        expect(branch.specification.given).toHaveLength(2);
+        expect(branch.specification.given[1].label.type).toBe(User.Type);
+        expect(branch.start).toHaveLength(2);
+        expect(branch.start[1]).toEqual({ type: subscriberRef.type, hash: subscriberRef.hash });
     });
 
     it("returns the original spec when no rule's shape matches the target", async () => {
@@ -91,6 +94,45 @@ describe("DistributionEngine.intersectForSubscribe", () => {
             subscriberRef
         );
         expect(result.intersected).toBe(false);
-        expect(result.specification).toBe(otherSpec);
+        expect(result.branches).toHaveLength(1);
+        expect(result.branches[0].specification).toBe(otherSpec);
+    });
+
+    it("returns one branch per matching rule when two rules authorize the same target", async () => {
+        const store = new MemoryStore();
+        const records = [
+            ...dehydrateFact(creator),
+            ...dehydrateFact(subscriber),
+            ...dehydrateFact(company)
+        ];
+        store.save(records.map(r => ({ fact: r, signatures: [] })));
+        // Two rules with the same share-spec (Company → Administrator) but
+        // distinct user-spec shapes. The subscriber satisfies neither today,
+        // so both rules should yield an intersected branch.
+        const secondUserSpec = model.given(Company).match((c, facts) =>
+            facts.ofType(Administrator)
+                .join(a => a.company, c)
+                .selectMany(a => facts.ofType(User).join(u => u, c.creator))
+        );
+        const rules = new DistributionRules([])
+            .share(shareSpec).with(ruleUserSpec)
+            .share(shareSpec).with(secondUserSpec);
+        const engine = new DistributionEngine(rules, store);
+
+        const result = await engine.intersectForSubscribe(
+            [companyRef],
+            spec,
+            subscriberRef
+        );
+
+        expect(result.intersected).toBe(true);
+        expect(result.branches).toHaveLength(2);
+        for (const branch of result.branches) {
+            // Each branch carries the synthetic distributionUser given.
+            expect(branch.specification.given).toHaveLength(2);
+            expect(branch.specification.given[1].label.type).toBe(User.Type);
+            expect(branch.start).toHaveLength(2);
+            expect(branch.start[1]).toEqual({ type: subscriberRef.type, hash: subscriberRef.hash });
+        }
     });
 });

--- a/test/distribution/multiRuleOrSubscribeSpec.ts
+++ b/test/distribution/multiRuleOrSubscribeSpec.ts
@@ -4,6 +4,7 @@ import {
     AdministratorRevoked,
     Company,
     Office,
+    OfficeClosed,
     President,
     model
 } from "../companyModel";
@@ -209,6 +210,90 @@ describe("subscribe with multi-rule OR authorization", () => {
         expect(offices).toEqual([j.hash(office)]);
 
         await j.fact(new AdministratorRevoked(administrator));
+        await observer.processed();
+        observer.stop();
+
+        expect(offices).toEqual([]);
+    });
+
+    // Companion to "keeps the row when one of two authorizations is
+    // revoked." If every branch's authorization drops, no rule is left to
+    // authorize the row, so the OR result must collapse to empty.
+    //
+    // SKIPPED: documents a known gap in the OR-remove path. The observer
+    // dedupes ADDS across branches via a row-identity hash over the pre-
+    // intersection labels (so the same row surfaced by two branches calls
+    // the handler once), but `notifyRemoved` still keys by
+    // `inverse.resultSubset` — which on an intersected spec includes
+    // branch-specific alpha-renamed auth-path unknowns. The remove-side
+    // hash therefore won't match the add-side hash in multi-branch mode,
+    // so the registered removal callback isn't invoked when a branch's
+    // authorization is revoked — and the row is left in place even after
+    // every branch is revoked. Proper OR-remove accounting would need
+    // per-branch ref-counting against the same row identity, with the
+    // handler's removal firing only when the count drops to zero. Un-skip
+    // once that lands; the test asserts the desired behavior.
+    it.skip("removes the row when every branch's authorization is revoked", async () => {
+        // Both rules use a revocation pattern so they can each be
+        // independently turned off at runtime. Administrator is revoked
+        // via AdministratorRevoked; President is revoked by closing the
+        // office it presides over.
+        const distributionWithBothRevocable = (r: DistributionRules) => r
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .notExists(a => facts.ofType(AdministratorRevoked).join(r => r.administrator, a))
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ))
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(President)
+                    .join(p => p.office.company, c)
+                    .notExists(p => facts.ofType(OfficeClosed).join(oc => oc.office, p.office))
+                    .selectMany(p => facts.ofType(User).join(u => u, p.user))
+            ));
+
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution: distributionWithBothRevocable
+        });
+
+        const offices: string[] = [];
+        const observer = j.subscribe(
+            targetSpec,
+            company,
+            o => {
+                const hash = j.hash(o);
+                offices.push(hash);
+                return () => {
+                    const i = offices.indexOf(hash);
+                    if (i >= 0) offices.splice(i, 1);
+                };
+            }
+        );
+
+        await observer.loaded();
+
+        const administrator = new Administrator(company, subscriber, new Date("2026-05-26"));
+        const president = new President(office, subscriber);
+        await j.fact(administrator);
+        await j.fact(president);
+        await observer.processed();
+        expect(offices).toEqual([j.hash(office)]);
+
+        // Revoke both auths in turn. After the second revocation the row
+        // has no surviving authorization on any branch — every removal
+        // callback registered at add-time should have fired by now.
+        await j.fact(new AdministratorRevoked(administrator));
+        await j.fact(new OfficeClosed(office, new Date("2026-05-26")));
         await observer.processed();
         observer.stop();
 

--- a/test/distribution/multiRuleOrSubscribeSpec.ts
+++ b/test/distribution/multiRuleOrSubscribeSpec.ts
@@ -1,0 +1,246 @@
+import { DistributionRules, JinagaTest, Trace, User } from "@src";
+import {
+    Administrator,
+    AdministratorRevoked,
+    Company,
+    Office,
+    President,
+    model
+} from "../companyModel";
+
+// When two distribution rules independently authorize the same target shape
+// (e.g. "the comments on a post are visible to its author OR to a member of
+// a private group"), the previous behaviour was to refuse intersection on
+// the grounds that the spec language has no OR primitive. That left a user
+// authorized by either rule unable to subscribe — even though either rule's
+// auth fact would suffice. The engine treats rules as OR everywhere else
+// (canDistributeTo returns success on first match), so the subscribe path
+// now does the same: produce one intersected branch per matching rule,
+// subscribe to all of them in parallel, and dedup at the observer.
+describe("subscribe with multi-rule OR authorization", () => {
+    Trace.off();
+
+    const creator = new User("creator");
+    const subscriber = new User("subscriber");
+    const company = new Company(creator, "Co");
+
+    // Two rules with the same share-spec (Company → Office) and distinct
+    // user-spec shapes. Either path authorizes the subscriber.
+    const distribution = (r: DistributionRules) => r
+        .share(model.given(Company).match((c, facts) =>
+            facts.ofType(Office).join(o => o.company, c)
+        ))
+        .with(model.given(Company).match((c, facts) =>
+            facts.ofType(Administrator)
+                .join(a => a.company, c)
+                .selectMany(a => facts.ofType(User).join(u => u, a.user))
+        ))
+        .share(model.given(Company).match((c, facts) =>
+            facts.ofType(Office).join(o => o.company, c)
+        ))
+        .with(model.given(Company).match((c, facts) =>
+            facts.ofType(President)
+                .join(p => p.office.company, c)
+                .selectMany(p => facts.ofType(User).join(u => u, p.user))
+        ));
+
+    const targetSpec = model.given(Company).match((c, facts) =>
+        facts.ofType(Office).join(o => o.company, c)
+    );
+
+    it("activates the subscription when the Administrator auth fact arrives", async () => {
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution
+        });
+
+        const offices: string[] = [];
+        const observer = j.subscribe(
+            targetSpec,
+            company,
+            o => { offices.push(j.hash(o)); }
+        );
+
+        await observer.loaded();
+        expect(offices).toEqual([]);
+
+        await j.fact(new Administrator(company, subscriber, new Date("2026-05-26")));
+        await observer.processed();
+        observer.stop();
+
+        expect(offices).toContain(j.hash(office));
+    });
+
+    it("activates the subscription when the President auth fact arrives", async () => {
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution
+        });
+
+        const offices: string[] = [];
+        const observer = j.subscribe(
+            targetSpec,
+            company,
+            o => { offices.push(j.hash(o)); }
+        );
+
+        await observer.loaded();
+        expect(offices).toEqual([]);
+
+        await j.fact(new President(office, subscriber));
+        await observer.processed();
+        observer.stop();
+
+        expect(offices).toContain(j.hash(office));
+    });
+
+    it("keeps the row when one of two authorizations is revoked and the other still holds", async () => {
+        // Rule A admits the subscriber via Administrator *unless* it has
+        // been revoked — so revoking the admin fires a "remove" inverse on
+        // branch A. Rule B (President) is unchanged.
+        const distributionWithRevocation = (r: DistributionRules) => r
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .notExists(a => facts.ofType(AdministratorRevoked).join(r => r.administrator, a))
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ))
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(President)
+                    .join(p => p.office.company, c)
+                    .selectMany(p => facts.ofType(User).join(u => u, p.user))
+            ));
+
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution: distributionWithRevocation
+        });
+
+        const offices: string[] = [];
+        const observer = j.subscribe(
+            targetSpec,
+            company,
+            o => {
+                const hash = j.hash(o);
+                offices.push(hash);
+                return () => {
+                    const i = offices.indexOf(hash);
+                    if (i >= 0) offices.splice(i, 1);
+                };
+            }
+        );
+
+        await observer.loaded();
+        expect(offices).toEqual([]);
+
+        // Both auth facts arrive, then the admin one is revoked. The OR
+        // accounting at the observer must keep the office in the result
+        // set because the president authorization still holds.
+        const administrator = new Administrator(company, subscriber, new Date("2026-05-26"));
+        await j.fact(administrator);
+        await j.fact(new President(office, subscriber));
+        await observer.processed();
+        expect(offices).toEqual([j.hash(office)]);
+
+        await j.fact(new AdministratorRevoked(administrator));
+        await observer.processed();
+        observer.stop();
+
+        expect(offices).toEqual([j.hash(office)]);
+    });
+
+    // Control test: in single-rule mode (no OR), revoking the only auth
+    // should remove the row. If this passes, removal callbacks actually
+    // fire through intersected specs — and the multi-rule "row stays"
+    // test above is a real assertion, not vacuously true.
+    it("control: single-rule intersection — revoking the only auth removes the row", async () => {
+        const singleRuleWithRevocation = (r: DistributionRules) => r
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .notExists(a => facts.ofType(AdministratorRevoked).join(r => r.administrator, a))
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ));
+
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution: singleRuleWithRevocation
+        });
+
+        const offices: string[] = [];
+        const observer = j.subscribe(
+            targetSpec,
+            company,
+            o => {
+                const hash = j.hash(o);
+                offices.push(hash);
+                return () => {
+                    const i = offices.indexOf(hash);
+                    if (i >= 0) offices.splice(i, 1);
+                };
+            }
+        );
+
+        await observer.loaded();
+        const administrator = new Administrator(company, subscriber, new Date("2026-05-26"));
+        await j.fact(administrator);
+        await observer.processed();
+        expect(offices).toEqual([j.hash(office)]);
+
+        await j.fact(new AdministratorRevoked(administrator));
+        await observer.processed();
+        observer.stop();
+
+        expect(offices).toEqual([]);
+    });
+
+    it("delivers each row exactly once when both rules authorize the subscriber", async () => {
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution
+        });
+
+        const offices: string[] = [];
+        const observer = j.subscribe(
+            targetSpec,
+            company,
+            o => { offices.push(j.hash(o)); }
+        );
+
+        await observer.loaded();
+        expect(offices).toEqual([]);
+
+        // Both auth facts arrive — either rule alone authorizes the office.
+        // Dedup at the observer must collapse them to a single delivery.
+        await j.fact(new Administrator(company, subscriber, new Date("2026-05-26")));
+        await j.fact(new President(office, subscriber));
+        await observer.processed();
+        observer.stop();
+
+        expect(offices).toEqual([j.hash(office)]);
+    });
+});

--- a/test/distribution/multiRuleOrSubscribeSpec.ts
+++ b/test/distribution/multiRuleOrSubscribeSpec.ts
@@ -219,21 +219,10 @@ describe("subscribe with multi-rule OR authorization", () => {
     // Companion to "keeps the row when one of two authorizations is
     // revoked." If every branch's authorization drops, no rule is left to
     // authorize the row, so the OR result must collapse to empty.
-    //
-    // SKIPPED: documents a known gap in the OR-remove path. The observer
-    // dedupes ADDS across branches via a row-identity hash over the pre-
-    // intersection labels (so the same row surfaced by two branches calls
-    // the handler once), but `notifyRemoved` still keys by
-    // `inverse.resultSubset` — which on an intersected spec includes
-    // branch-specific alpha-renamed auth-path unknowns. The remove-side
-    // hash therefore won't match the add-side hash in multi-branch mode,
-    // so the registered removal callback isn't invoked when a branch's
-    // authorization is revoked — and the row is left in place even after
-    // every branch is revoked. Proper OR-remove accounting would need
-    // per-branch ref-counting against the same row identity, with the
-    // handler's removal firing only when the count drops to zero. Un-skip
-    // once that lands; the test asserts the desired behavior.
-    it.skip("removes the row when every branch's authorization is revoked", async () => {
+    // Per-row ref counting in the observer registers one vote per branch
+    // that authorizes a row; the removal callback fires only when the
+    // last vote is withdrawn.
+    it("removes the row when every branch's authorization is revoked", async () => {
         // Both rules use a revocation pattern so they can each be
         // independently turned off at runtime. Administrator is revoked
         // via AdministratorRevoked; President is revoked by closing the
@@ -298,6 +287,73 @@ describe("subscribe with multi-rule OR authorization", () => {
         observer.stop();
 
         expect(offices).toEqual([]);
+    });
+
+    it("re-delivers a row after every authorization has been revoked then a new one arrives", async () => {
+        // Sanity check on the bookkeeping: once the last vote is withdrawn
+        // and the row is removed, a future add must be able to re-deliver
+        // it. If we left stale ref-count or removal entries behind, the
+        // next add would either be silently deduped or fire against a
+        // dead removal closure.
+        const distributionWithBothRevocable = (r: DistributionRules) => r
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .notExists(a => facts.ofType(AdministratorRevoked).join(r => r.administrator, a))
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ))
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(President)
+                    .join(p => p.office.company, c)
+                    .notExists(p => facts.ofType(OfficeClosed).join(oc => oc.office, p.office))
+                    .selectMany(p => facts.ofType(User).join(u => u, p.user))
+            ));
+
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution: distributionWithBothRevocable
+        });
+
+        const offices: string[] = [];
+        const observer = j.subscribe(
+            targetSpec,
+            company,
+            o => {
+                const hash = j.hash(o);
+                offices.push(hash);
+                return () => {
+                    const i = offices.indexOf(hash);
+                    if (i >= 0) offices.splice(i, 1);
+                };
+            }
+        );
+
+        await observer.loaded();
+
+        const administrator = new Administrator(company, subscriber, new Date("2026-05-26"));
+        await j.fact(administrator);
+        await observer.processed();
+        expect(offices).toEqual([j.hash(office)]);
+
+        await j.fact(new AdministratorRevoked(administrator));
+        await observer.processed();
+        expect(offices).toEqual([]);
+
+        // A new authorization arrives. The row must come back.
+        await j.fact(new President(office, subscriber));
+        await observer.processed();
+        observer.stop();
+
+        expect(offices).toEqual([j.hash(office)]);
     });
 
     it("delivers each row exactly once when both rules authorize the subscriber", async () => {

--- a/test/distribution/subscribeIntersectionSpec.ts
+++ b/test/distribution/subscribeIntersectionSpec.ts
@@ -171,6 +171,45 @@ describe("subscribe with distribution-rule intersection (Phase 3, #130)", () => 
         });
     });
 
+    describe("authorization bypass via forged intersection marker", () => {
+        // Distribution checks must not be skippable by a caller who crafts
+        // a spec carrying a `distributionUser: Jinaga.User` given. The
+        // bypass for genuine intersected specs is keyed off feed hashes the
+        // engine itself produced, not off spec structure.
+        const distribution = (r: DistributionRules) => r
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ));
+
+        it("rejects a query whose spec was hand-crafted to look intersected", async () => {
+            const office = new Office(company, "Office1");
+            const j = JinagaTest.create({
+                model,
+                user: subscriber,
+                initialState: [creator, subscriber, company, office],
+                distribution
+            });
+
+            // A query that should be Forbidden (no Administrator yet) but
+            // whose spec has been authored with the synthetic given. If the
+            // engine treated the spec-structure marker as a bypass, this
+            // would silently leak offices. It must instead reject — either
+            // by failing authorization or by failing the connectedness
+            // check (the forged given has no link to the rest of the spec).
+            const forgedSpec = model.given(Company, User).match((c, distributionUser, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            );
+            await expect(() =>
+                j.query(forgedSpec, company, subscriber)
+            ).rejects.toThrow(/Not authorized|Disconnected specification/);
+        });
+    });
+
     describe("intersection composes with multi-given share/with rules (#161 shape)", () => {
         // Both share and with specs have two givens (Company, User). The
         // share-spec joins Employee to *both* givens (its match references

--- a/test/distribution/subscribeIntersectionSpec.ts
+++ b/test/distribution/subscribeIntersectionSpec.ts
@@ -1,0 +1,225 @@
+import { DistributionRules, JinagaTest, Trace, User } from "@src";
+import {
+    Administrator,
+    Company,
+    Employee,
+    Office,
+    OfficeClosed,
+    model
+} from "../companyModel";
+
+// Phase 3 of the j.subscribe trust release: when subscribe runs on a feed
+// that the user isn't yet authorized for, the call should succeed (returning
+// empty) and later push results when the authorizing fact arrives — no
+// client-side retry, no observer.loaded().catch() guard. The mechanism is
+// distribution-rule intersection: the authorization pattern becomes a fact
+// pattern the existing inverse engine already handles.
+describe("subscribe with distribution-rule intersection (Phase 3, #130)", () => {
+    Trace.off();
+
+    const creator = new User("creator");
+    const subscriber = new User("subscriber");
+    const company = new Company(creator, "Co");
+
+    describe("plain subscribe on an initially-forbidden feed", () => {
+        // Rule: share Company→Office with users who are administrators of
+        // the company. Subscriber is not yet an administrator.
+        const distribution = (r: DistributionRules) => r
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office)
+                    .join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ));
+
+        it("succeeds with empty results, then pushes when the auth fact arrives", async () => {
+            const office = new Office(company, "Office1");
+            const j = JinagaTest.create({
+                model,
+                user: subscriber,
+                // Seed the local store with descendants but withhold the
+                // authorizing Administrator fact. Without Phase 3, subscribe
+                // would throw "Not authorized" because no rule grants the
+                // subscriber access.
+                initialState: [creator, subscriber, company, office],
+                distribution
+            });
+
+            const offices: string[] = [];
+            const observer = j.subscribe(
+                model.given(Company).match((c, facts) =>
+                    facts.ofType(Office)
+                        .join(o => o.company, c)
+                ),
+                company,
+                o => {
+                    offices.push(j.hash(o));
+                }
+            );
+
+            // Phase 3 contract: subscribe must succeed even though the user
+            // is not currently authorized — no Forbidden, no retry.
+            await observer.loaded();
+            expect(offices).toEqual([]);
+
+            // The authorizing fact arrives. The intersected spec's inverses
+            // include the Administrator pattern, so the existing inverse
+            // engine fires and surfaces the previously-withheld office.
+            const administrator = new Administrator(company, subscriber, new Date("2026-05-26"));
+            await j.fact(administrator);
+            await observer.processed();
+            observer.stop();
+
+            expect(offices).toContain(j.hash(office));
+        });
+
+        it("stays empty when the auth fact is for a different user", async () => {
+            const otherUser = new User("other");
+            const office = new Office(company, "Office1");
+            const j = JinagaTest.create({
+                model,
+                user: subscriber,
+                initialState: [creator, subscriber, otherUser, company, office],
+                distribution
+            });
+
+            const offices: string[] = [];
+            const observer = j.subscribe(
+                model.given(Company).match((c, facts) =>
+                    facts.ofType(Office)
+                        .join(o => o.company, c)
+                ),
+                company,
+                o => {
+                    offices.push(j.hash(o));
+                }
+            );
+
+            await observer.loaded();
+            expect(offices).toEqual([]);
+
+            // Administrator linking a *different* user — doesn't satisfy
+            // the intersected auth pattern for `subscriber`.
+            await j.fact(new Administrator(company, otherUser, new Date("2026-05-26")));
+            await observer.processed();
+            observer.stop();
+
+            expect(offices).toEqual([]);
+        });
+    });
+
+    describe("intersection composes with .notExists() (#196 negating-feed shape)", () => {
+        // Share the .notExists() spec itself with administrators. The share
+        // spec contains the negating successor, so intersection needs to
+        // produce a feed-builder shape that doesn't drop the negation.
+        const distribution = (r: DistributionRules) => r
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office)
+                    .join(o => o.company, c)
+                    .notExists(o => facts.ofType(OfficeClosed)
+                        .join(oc => oc.office, o)
+                    )
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ));
+
+        it("subscribes to a .notExists() spec and pushes when admin is granted", async () => {
+            const openOffice = new Office(company, "Open");
+            const closedOffice = new Office(company, "Closed");
+            const j = JinagaTest.create({
+                model,
+                user: subscriber,
+                initialState: [
+                    creator, subscriber, company, openOffice, closedOffice,
+                    new OfficeClosed(closedOffice, new Date("2026-05-26"))
+                ],
+                distribution
+            });
+
+            const offices: string[] = [];
+            const observer = j.subscribe(
+                model.given(Company).match((c, facts) =>
+                    facts.ofType(Office)
+                        .join(o => o.company, c)
+                        .notExists(o => facts.ofType(OfficeClosed)
+                            .join(oc => oc.office, o)
+                        )
+                ),
+                company,
+                o => {
+                    offices.push(j.hash(o));
+                }
+            );
+
+            await observer.loaded();
+            expect(offices).toEqual([]);
+
+            await j.fact(new Administrator(company, subscriber, new Date("2026-05-26")));
+            await observer.processed();
+            observer.stop();
+
+            // The open office surfaces; the closed one does not (the
+            // negating branch still works after intersection).
+            expect(offices).toContain(j.hash(openOffice));
+            expect(offices).not.toContain(j.hash(closedOffice));
+        });
+    });
+
+    describe("intersection composes with multi-given share/with rules (#161 shape)", () => {
+        // Both share and with specs have two givens (Company, User). The
+        // share-spec joins Employee to *both* givens (its match references
+        // each one), and the with-spec derives the authorized user via an
+        // Administrator linking the two givens.
+        const distribution = (r: DistributionRules) => r
+            .share(model.given(Company, User).match((c, user, facts) =>
+                facts.ofType(Employee)
+                    .join(e => e.office.company, c)
+                    .join(e => e.user, user)
+            ))
+            .with(model.given(Company, User).match((c, user, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ));
+
+        it("subscribes to a multi-given spec and pushes when admin is granted", async () => {
+            const office = new Office(company, "Office1");
+            const employee = new Employee(office, subscriber);
+            const j = JinagaTest.create({
+                model,
+                user: subscriber,
+                initialState: [creator, subscriber, company, office, employee],
+                distribution
+            });
+
+            const employees: string[] = [];
+            const observer = j.subscribe(
+                model.given(Company, User).match((c, user, facts) =>
+                    facts.ofType(Employee)
+                        .join(e => e.office.company, c)
+                        .join(e => e.user, user)
+                ),
+                company,
+                subscriber,
+                e => {
+                    employees.push(j.hash(e));
+                }
+            );
+
+            await observer.loaded();
+            expect(employees).toEqual([]);
+
+            await j.fact(new Administrator(company, subscriber, new Date("2026-05-26")));
+            await observer.processed();
+            observer.stop();
+
+            expect(employees).toContain(j.hash(employee));
+        });
+    });
+});

--- a/test/specification/alphaSpec.ts
+++ b/test/specification/alphaSpec.ts
@@ -1,0 +1,125 @@
+import { alphaTransform, Invalid, Specification, SpecificationParser } from "@src";
+
+function parseSpecification(input: string): Specification {
+    const parser = new SpecificationParser(input);
+    parser.skipWhitespace();
+    return parser.parseSpecification();
+}
+
+describe("Alpha transformation", () => {
+    it("transforms specification labels with a mapping", () => {
+        const specification = parseSpecification(`(user: Jinaga.User) {
+            assignment: MyApp.Assignment [
+                assignment->user:Jinaga.User = user
+            ]
+        }`);
+
+        const mapping = { user: "u", assignment: "a" };
+
+        const result = alphaTransform(specification, mapping);
+
+        const expected = parseSpecification(`(u: Jinaga.User) {
+            a: MyApp.Assignment [
+                a->user:Jinaga.User = u
+            ]
+        }`);
+
+        expect(result).toEqual(expected);
+    });
+
+    it("throws Invalid error for null specification", () => {
+        const mapping = { user: "u" };
+
+        expect(() => alphaTransform(null as any, mapping)).toThrow(Invalid);
+    });
+
+    it("throws Invalid error when mapping would create duplicate label names", () => {
+        const specification = parseSpecification(`(user: Jinaga.User) {
+            assignment: MyApp.Assignment [
+                assignment->user:Jinaga.User = user
+            ]
+        }`);
+
+        const mapping = { user: "u", assignment: "u" };
+
+        expect(() => alphaTransform(specification, mapping)).toThrow(Invalid);
+    });
+
+    it("transforms specifications with nested existential conditions", () => {
+        const specification = parseSpecification(`(user: Jinaga.User) {
+        post: MyApp.Post [
+            post->user:Jinaga.User = user
+            E {
+                comment: MyApp.Comment [
+                    comment->post:MyApp.Post = post
+                    E {
+                        reply: MyApp.Reply [
+                            reply->comment:MyApp.Comment = comment
+                        ]
+                    }
+                ]
+            }
+        ] }`);
+
+        const mapping = { user: "u", post: "p", comment: "c", reply: "r" };
+
+        const result = alphaTransform(specification, mapping);
+
+        const expected = parseSpecification(`(u: Jinaga.User) {
+        p: MyApp.Post [
+            p->user:Jinaga.User = u
+            E {
+                c: MyApp.Comment [
+                    c->post:MyApp.Post = p
+                    E {
+                        r: MyApp.Reply [
+                            r->comment:MyApp.Comment = c
+                        ]
+                    }
+                ]
+            }
+        ] }`);
+
+        expect(result).toEqual(expected);
+    });
+
+    it("transforms field projections", () => {
+        const specification = parseSpecification(`(user: Jinaga.User) {
+            name: MyApp.User.Name [
+                name->user:Jinaga.User = user
+            ]
+        } => name.value`);
+
+        const mapping = { user: "u", name: "n" };
+
+        const result = alphaTransform(specification, mapping);
+
+        const expected = parseSpecification(`(u: Jinaga.User) {
+            n: MyApp.User.Name [
+                n->user:Jinaga.User = u
+            ]
+        } => n.value`);
+
+        expect(result).toEqual(expected);
+    });
+
+    it("integrates parsing and alpha transformation", () => {
+        const input = `(user: Jinaga.User) {
+            assignment: MyApp.Assignment [
+                assignment->user:Jinaga.User = user
+            ]
+        }`;
+        const specification = parseSpecification(input);
+
+        const mapping = { user: "u", assignment: "a" };
+        const transformed = alphaTransform(specification, mapping);
+
+        const expected = parseSpecification(`(u: Jinaga.User) {
+            a: MyApp.Assignment [
+                a->user:Jinaga.User = u
+            ]
+        }`);
+
+        expect(transformed).toEqual(expected);
+    });
+});


### PR DESCRIPTION
Phase 3 of the j.subscribe trust release (#197). When a subscriber isn't yet
authorized for a feed, the call now succeeds with empty results and surfaces
matches as soon as the authorizing fact arrives — no client-side retry, no
observer.loaded().catch() guard.

Mechanism: distribution-rule intersection. A new specification-intersection
module composes the target spec with the applicable rule's user-spec, adding
a synthetic distributionUser given and lifting the rule's user matches into
the spec with the projected user pinned to that given. The intersected spec
is what the observer's listeners are inverted from, so the existing inverse
engine fires on auth-fact arrivals (e.g. Administrator) the same way it
fires on any other fact — exactly one evaluation engine, as #197 commits to.

Integration seam: DistributionEngine.intersectForSubscribe runs the
canDistributeToAll path first, so already-authorized subscribers keep the
original spec untouched and Phase 1's compositional fallback for negating
feeds is preserved. Only when the user isn't authorized but a rule's shape
matches the target does the engine rewrite. The Network interface gains an
optional intersectForSubscribe hook so NetworkDistribution can plumb the
rewritten (start, spec) back through the observer in subscribe (keepAlive)
mode.

UnionFind connectivity detection now walks given conditions too, matching
what the inverter already does when it promotes given conditions to match
conditions. Without it, the intersected spec's distributionUser given would
trip the disconnected-specification guard.

Tests cover the three exit criteria from #197 Phase 3: plain subscribe on a
forbidden feed activates on auth-fact arrival; intersection composes with
.notExists() (#196 negating-feed shape); intersection composes with
model.given(Tenant, User) multi-given share/with rules (#161 shape). All use
the raw-envelope seeding pattern from PR #200 so the "auth arrives after
subscription" timing is genuine.

The alpha-transform and intersection-algorithm tests are ported from PR #160
(the genuine intellectual contribution there); test deletions and stale
integration that branch carried have been dropped per the issue guidance.
inverse.ts semantics are unchanged.

https://claude.ai/code/session_01GFBGEUoUxShMDy53BiuwRE