### PR TITLE
Authorize sub-feed queries for intermediate projection facts (#204)

### DIFF
--- a/src/distribution/distribution-engine.ts
+++ b/src/distribution/distribution-engine.ts
@@ -88,7 +88,18 @@ export class DistributionEngine {
         const ruleSkeleton = skeletonOfSpecification(ruleFeed);
         const permutations = permutationsOf(start, ruleSkeleton, targetSkeleton);
         for (const permutation of permutations) {
-          if (skeletonsEqual(ruleSkeleton, targetSkeleton)) {
+          // A rule's feed authorizes its own shape exactly, and also any feed
+          // whose shape is a connected sub-portion of the rule feed (rooted at
+          // the same inputs) — e.g. a direct query for an intermediate fact that
+          // the rule only traverses through on its way to a projected leaf
+          // (`Event -> Finalist` covered by a rule that projects
+          // `Event -> Finalist -> Competitor -> CompetitorName`). `skeletonContains`
+          // only admits sub-feeds whose every output fact the rule already
+          // delivers (see its soundness argument), so this grants no data beyond
+          // what the rule authorizes. This engine backs both JinagaTest and the
+          // real replicator (jinaga-server), so they stay in lock-step. See #204.
+          if (skeletonsEqual(ruleSkeleton, targetSkeleton) ||
+              skeletonContains(ruleSkeleton, targetSkeleton)) {
             // If this rule applies to any user, then we can distribute.
             if (rule.user === null) {
               return {
@@ -341,6 +352,72 @@ function skeletonsEqual(ruleSkeleton: Skeleton, targetSkeleton: Skeleton): boole
   // They don't affect the rows that match the specification.
 
   return true;
+}
+
+/**
+ * True when `targetSkeleton` is a *sound* sub-feed of `ruleSkeleton`: the target
+ * keeps a subset of the rule's facts and the rule delivers every fact the target
+ * outputs, so authorizing the rule legitimately authorizes the target.
+ *
+ * `buildFeeds` assigns fact/edge indices by a deterministic walk outward from
+ * the givens, so a target that is a prefix of the rule's traversal carries the
+ * same indices and the existing index-based predicates line up. The caller has
+ * already matched inputs via `permutationsOf`.
+ *
+ * Soundness hinges on *which* facts the target drops:
+ *  - Dropping a fact reached by a **predecessor** join (e.g. the `Competitor` of
+ *    a `Finalist`) is safe: every successor carries all its predecessors, so the
+ *    rule delivers the same output set with or without that fact in the feed.
+ *  - Dropping a fact reached by a **successor** join or existential (e.g. the
+ *    `Publish` that a "published posts" rule requires of each `Post`) is NOT
+ *    safe: that fact restricts the rule's output, and a target lacking it would
+ *    see more than the rule grants.
+ * So a dropped fact may only appear predecessor-ward of the kept facts: no rule
+ * edge may run from a kept fact to a dropped successor.
+ *
+ * This lets an authorized user run a direct query for a fact a projection rule
+ * only traverses through (issue #204), without declaring a redundant flat rule.
+ * The same engine authorizes JinagaTest and the real replicator (jinaga-server),
+ * so the relaxation applies uniformly to both.
+ */
+function skeletonContains(ruleSkeleton: Skeleton, targetSkeleton: Skeleton): boolean {
+  // Every target fact must be a rule fact.
+  if (!isSubsetOf(targetSkeleton.facts, ruleSkeleton.facts, factsEqual)) {
+    return false;
+  }
+
+  const keptFactIndices = new Set(targetSkeleton.facts.map(f => f.factIndex));
+  const isKept = (factIndex: number) => keptFactIndices.has(factIndex);
+
+  // A rule edge leading (as a successor join) to a dropped fact is a restriction
+  // the target lacks, so the target is not covered. Only predecessor-ward facts
+  // (present for every successor) may be dropped.
+  for (const edge of ruleSkeleton.edges) {
+    if (!isKept(edge.successorFactIndex) && isKept(edge.predecessorFactIndex)) {
+      return false;
+    }
+  }
+
+  // The target must preserve exactly the rule's structure among the facts it
+  // keeps: every rule edge between two kept facts must be present, and the
+  // target may not introduce edges the rule lacks.
+  const ruleEdgesAmongKept = ruleSkeleton.edges.filter(e =>
+    isKept(e.predecessorFactIndex) && isKept(e.successorFactIndex));
+  if (!compareSets(targetSkeleton.edges, ruleEdgesAmongKept, edgesEqual)) {
+    return false;
+  }
+
+  // The target must be at least as restrictive as the rule: every not-exists
+  // condition the rule imposes must also appear in the target.
+  if (!isSubsetOf(ruleSkeleton.notExistsConditions, targetSkeleton.notExistsConditions, notExistsConditionsEqual)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isSubsetOf<T>(subset: T[], superset: T[], equals: (a: T, b: T) => boolean): boolean {
+  return subset.every(item => superset.some(candidate => equals(candidate, item)));
 }
 
 function factsEqual(ruleFact: FactDescription, targetFact: FactDescription): boolean {

--- a/src/distribution/distribution-engine.ts
+++ b/src/distribution/distribution-engine.ts
@@ -86,83 +86,88 @@ export class DistributionEngine {
     for (const rule of this.distributionRules.rules) {
       for (const ruleFeed of rule.feeds) {
         const ruleSkeleton = skeletonOfSpecification(ruleFeed);
+        // A rule's feed authorizes its own shape exactly, and also any feed
+        // whose shape is a connected sub-portion of the rule feed (rooted at
+        // the same inputs) — e.g. a direct query for an intermediate fact that
+        // the rule only traverses through on its way to a projected leaf
+        // (`Event -> Finalist` covered by a rule that projects
+        // `Event -> Finalist -> Competitor -> CompetitorName`). `skeletonContains`
+        // only admits sub-feeds whose every output fact the rule already
+        // delivers (see its soundness argument), so this grants no data beyond
+        // what the rule authorizes. This engine backs both JinagaTest and the
+        // real replicator (jinaga-server), so they stay in lock-step. See #204.
+        //
+        // The shape match depends only on the two skeletons, not on the
+        // permutation, so evaluate it once and skip the feed before enumerating
+        // permutations (which can be many when givens share a type).
+        if (!skeletonsEqual(ruleSkeleton, targetSkeleton) &&
+            !skeletonContains(ruleSkeleton, targetSkeleton)) {
+          continue;
+        }
         const permutations = permutationsOf(start, ruleSkeleton, targetSkeleton);
         for (const permutation of permutations) {
-          // A rule's feed authorizes its own shape exactly, and also any feed
-          // whose shape is a connected sub-portion of the rule feed (rooted at
-          // the same inputs) — e.g. a direct query for an intermediate fact that
-          // the rule only traverses through on its way to a projected leaf
-          // (`Event -> Finalist` covered by a rule that projects
-          // `Event -> Finalist -> Competitor -> CompetitorName`). `skeletonContains`
-          // only admits sub-feeds whose every output fact the rule already
-          // delivers (see its soundness argument), so this grants no data beyond
-          // what the rule authorizes. This engine backs both JinagaTest and the
-          // real replicator (jinaga-server), so they stay in lock-step. See #204.
-          if (skeletonsEqual(ruleSkeleton, targetSkeleton) ||
-              skeletonContains(ruleSkeleton, targetSkeleton)) {
-            // If this rule applies to any user, then we can distribute.
-            if (rule.user === null) {
-              return {
-                type: 'success'
-              };
-            }
+          // If this rule applies to any user, then we can distribute.
+          if (rule.user === null) {
+            return {
+              type: 'success'
+            };
+          }
 
-            // If there is no user logged in, then we cannot distribute.
-            if (user === null) {
-              if (reasons.length === 0) {
-                reasons.push(`User is not logged in.`);
+          // If there is no user logged in, then we cannot distribute.
+          if (user === null) {
+            if (reasons.length === 0) {
+              reasons.push(`User is not logged in.`);
+            }
+          }
+          else {
+            // The projection must be a singular label.
+            if (rule.user.projection.type !== 'fact') {
+              throw new Error('The projection must be a singular label.');
+            }
+            const label = rule.user.projection.label;
+
+            // If the user specification is deterministic, then pick the labeled given.
+            if (specificationIsIdentity(rule.user)) {
+              const userReference = executeDeterministicSpecification(rule.user, label, permutation);
+              // If the user matches the given, then we can distribute to the user.
+              const authorized = factReferenceEquals(user)(userReference);
+              if (authorized) {
+                return {
+                  type: 'success'
+                };
+              }
+
+              if (this.isTest) {
+                reasons.push(
+                  `The user does not match ${describeSpecification(rule.user, 0)}.\n` +
+                  `User hash: ${user.hash}\n` +
+                  `Expected hash: ${userReference.hash}`
+                );
+              } else {
+                reasons.push(`The user does not match ${describeSpecification(rule.user, 0)}`);
               }
             }
             else {
-              // The projection must be a singular label.
-              if (rule.user.projection.type !== 'fact') {
-                throw new Error('The projection must be a singular label.');
-              }
-              const label = rule.user.projection.label;
+              // Find the set of users to whom we can distribute this feed.
+              const users = await this.store.read(permutation, rule.user);
+              const results = users.map(user => user.tuple[label])
 
-              // If the user specification is deterministic, then pick the labeled given.
-              if (specificationIsIdentity(rule.user)) {
-                const userReference = executeDeterministicSpecification(rule.user, label, permutation);
-                // If the user matches the given, then we can distribute to the user.
-                const authorized = factReferenceEquals(user)(userReference);
-                if (authorized) {
-                  return {
-                    type: 'success'
-                  };
-                }
-                
-                if (this.isTest) {
-                  reasons.push(
-                    `The user does not match ${describeSpecification(rule.user, 0)}.\n` +
-                    `User hash: ${user.hash}\n` +
-                    `Expected hash: ${userReference.hash}`
-                  );
-                } else {
-                  reasons.push(`The user does not match ${describeSpecification(rule.user, 0)}`);
-                }
+              // If any of the results match the user, then we can distribute to the user.
+              const authorized = results.some(factReferenceEquals(user));
+              if (authorized) {
+                return {
+                  type: 'success'
+                };
               }
-              else {
-                // Find the set of users to whom we can distribute this feed.
-                const users = await this.store.read(permutation, rule.user);
-                const results = users.map(user => user.tuple[label])
 
-                // If any of the results match the user, then we can distribute to the user.
-                const authorized = results.some(factReferenceEquals(user));
-                if (authorized) {
-                  return {
-                    type: 'success'
-                  };
-                }
-                
-                if (this.isTest) {
-                  reasons.push(
-                    `The user does not match ${describeSpecification(rule.user, 0)}.\n` +
-                    `User hash: ${user.hash}\n` +
-                    `Expected hashes: [${results.map(r => r.hash).join(", ")}]`
-                  );
-                } else {
-                  reasons.push(`The user does not match ${describeSpecification(rule.user, 0)}`);
-                }
+              if (this.isTest) {
+                reasons.push(
+                  `The user does not match ${describeSpecification(rule.user, 0)}.\n` +
+                  `User hash: ${user.hash}\n` +
+                  `Expected hashes: [${results.map(r => r.hash).join(", ")}]`
+                );
+              } else {
+                reasons.push(`The user does not match ${describeSpecification(rule.user, 0)}`);
               }
             }
           }

--- a/test/distribution/distributionEngineDirectSpec.ts
+++ b/test/distribution/distributionEngineDirectSpec.ts
@@ -1,4 +1,4 @@
-import { DistributionEngine, DistributionRules, MemoryStore, User, dehydrateFact } from "@src";
+import { DistributionEngine, DistributionRules, MemoryStore, User, buildFeeds, dehydrateFact } from "@src";
 import { Blog, Post, distribution, model } from "../blogModel";
 
 describe("DistributionEngine direct usage", () => {
@@ -55,6 +55,30 @@ describe("DistributionEngine direct usage", () => {
       expect(result.reason).not.toContain("Matching set:");
       expect(result.reason).not.toContain("User fact:");
     }
+  });
+
+  it("should NOT authorize a sub-feed that drops an existential restriction (isTest=false)", async () => {
+    // The "published posts" rule (withEveryone) authorizes Blog -> Post -> Publish.
+    // A bare Blog -> Post feed would expose unpublished posts, so the sub-feed
+    // relaxation must reject it — the dropped Publish is a successor restriction,
+    // not a mandatory predecessor. This guards the replicator (isTest=false), not
+    // just JinagaTest. See issue #204.
+    const store = new MemoryStore();
+    const distributionRules = distribution(new DistributionRules([]));
+    const engine = new DistributionEngine(distributionRules, store, false);
+
+    const allPosts = model.given(Blog).match((blog, facts) =>
+      facts.ofType(Post).join(post => post.blog, blog)
+    ).specification;
+
+    const blogRecords = dehydrateFact(blog);
+    const blogReference = blogRecords[blogRecords.length - 1];
+    const namedStart = { [allPosts.given[0].label.name]: blogReference };
+
+    // Anonymous: only the published-posts (withEveryone) rule could apply, and
+    // it must not be satisfied by dropping the Publish restriction.
+    const result = await engine.canDistributeToAll(buildFeeds(allPosts), namedStart, null);
+    expect(result.type).toBe('failure');
   });
 
   it("should NOT provide detailed debug info when isTest is omitted (default behavior)", async () => {

--- a/test/distribution/intermediateProjectionFeedSpec.ts
+++ b/test/distribution/intermediateProjectionFeedSpec.ts
@@ -1,0 +1,187 @@
+import { DistributionEngine, DistributionRules, FactEnvelope, FactRecord, HashMap, JinagaTest, MemoryStore, Trace, User, buildFeeds, buildModel, dehydrateFact } from "@src";
+
+// Regression for issue #204: a distribution rule whose `.select()` projection
+// traverses *through* an intermediate fact (without exposing it as its own
+// named component) should let an authorized user run a direct query for that
+// intermediate fact under JinagaTest. The real replicator delivers those
+// intermediate facts into the client's local store as a side effect of the
+// projection feed, so direct queries there succeed; JinagaTest must mirror it
+// without forcing the app to declare redundant flat rules.
+
+class Tenant {
+  static Type = "Tenant" as const;
+  type = Tenant.Type;
+  constructor(public creator: User) { }
+}
+
+class Administrator {
+  static Type = "Administrator" as const;
+  type = Administrator.Type;
+  constructor(public tenant: Tenant, public user: User) { }
+}
+
+class Event {
+  static Type = "Event" as const;
+  type = Event.Type;
+  constructor(public tenant: Tenant, public id: string) { }
+}
+
+class Competitor {
+  static Type = "Competitor" as const;
+  type = Competitor.Type;
+  constructor(public tenant: Tenant) { }
+}
+
+// Finalist is the intermediate fact: the projection joins from Event to
+// Finalist only to reach the Competitor predecessor; Finalist is never a
+// named component of the projection.
+class Finalist {
+  static Type = "Finalist" as const;
+  type = Finalist.Type;
+  constructor(public competitor: Competitor, public event: Event) { }
+}
+
+class CompetitorName {
+  static Type = "CompetitorName" as const;
+  type = CompetitorName.Type;
+  constructor(public competitor: Competitor, public value: string, public prior: CompetitorName[]) { }
+}
+
+const model = buildModel(b => b
+  .type(User)
+  .type(Tenant, x => x.predecessor("creator", User))
+  .type(Administrator, x => x
+    .predecessor("tenant", Tenant)
+    .predecessor("user", User)
+  )
+  .type(Event, x => x.predecessor("tenant", Tenant))
+  .type(Competitor, x => x.predecessor("tenant", Tenant))
+  .type(Finalist, x => x
+    .predecessor("competitor", Competitor)
+    .predecessor("event", Event)
+  )
+  .type(CompetitorName, x => x
+    .predecessor("competitor", Competitor)
+    .predecessor("prior", CompetitorName)
+  )
+);
+
+const distribution = (r: DistributionRules) => r
+  .share(model.given(Event).select((event, facts) => ({
+    // Finalist is only a traversal step toward the competitor projection.
+    finalists: facts.ofType(Finalist)
+      .join(finalist => finalist.event, event)
+      .selectMany(finalist => finalist.competitor.predecessor()
+        .select(competitor => ({
+          competitorNames: facts.ofType(CompetitorName)
+            .join(name => name.competitor, competitor)
+            .notExists(name => facts.ofType(CompetitorName)
+              .join(next => next.prior, name)
+            )
+        }))
+      )
+  })))
+  .with(model.given(Event).match((event, facts) =>
+    facts.ofType(Administrator)
+      .join(a => a.tenant, event.tenant)
+      .selectMany(a => facts.ofType(User).join(u => u, a.user))
+  ));
+
+describe("distribution rules with intermediate projection facts (issue #204)", () => {
+  Trace.off();
+
+  const tenantUser = new User("tenant-key");
+  const tenant = new Tenant(tenantUser);
+  const adminUser = new User("admin-key");
+  const administrator = new Administrator(tenant, adminUser);
+  const outsider = new User("outsider-key");
+  const event = new Event(tenant, "event-id");
+  const competitor = new Competitor(tenant);
+  const finalist = new Finalist(competitor, event);
+
+  const initialState = [
+    tenantUser, tenant, adminUser, administrator, outsider, event, competitor, finalist
+  ];
+
+  function loggedIn(user: User | undefined) {
+    return JinagaTest.create({ model, user, initialState, distribution });
+  }
+
+  const finalistsOfEvent = model.given(Event).match((event, facts) =>
+    facts.ofType(Finalist).join(finalist => finalist.event, event)
+  );
+
+  it("authorizes a direct query for an intermediate fact of a projection rule", async () => {
+    const j = loggedIn(adminUser);
+    const results = await j.query(finalistsOfEvent, event);
+    expect(results).toHaveLength(1);
+  });
+
+  it("authorizes a direct query for a deeper intermediate fact (Competitor)", async () => {
+    const j = loggedIn(adminUser);
+    const competitorsOfEvent = model.given(Event).match((event, facts) =>
+      facts.ofType(Finalist)
+        .join(finalist => finalist.event, event)
+        .selectMany(finalist => finalist.competitor.predecessor())
+    );
+    const results = await j.query(competitorsOfEvent, event);
+    expect(results).toHaveLength(1);
+  });
+
+  it("still rejects an unauthorized user querying the same intermediate fact", async () => {
+    const j = loggedIn(outsider);
+    await expect(j.query(finalistsOfEvent, event)).rejects.toThrow("Not authorized");
+  });
+
+  it("still rejects a feed that is not a sub-path of any rule", async () => {
+    const j = loggedIn(adminUser);
+    // Administrators are not shared; a direct query for them is unrelated to
+    // the only share rule (which projects finalist/competitor data).
+    const administratorsOfTenant = model.given(Tenant).match((tenant, facts) =>
+      facts.ofType(Administrator).join(a => a.tenant, tenant)
+    );
+    await expect(j.query(administratorsOfTenant, tenant)).rejects.toThrow("Not authorized");
+  });
+
+  // The same DistributionEngine backs the real replicator (jinaga-server),
+  // which constructs it with isTest=false. Assert the relaxation applies there
+  // too, so a passing JinagaTest predicts the replicator's behavior.
+  it("authorizes the intermediate feed through the replicator engine (isTest=false)", async () => {
+    const store = await storeWith(tenantUser, tenant, adminUser, administrator, event, competitor, finalist);
+    const engine = new DistributionEngine(distribution(new DistributionRules([])), store, false);
+
+    // Mirror jinaga-server's authorization path: build feeds from the spec and
+    // key the start by the spec's (normalized) given labels.
+    const specification = finalistsOfEvent.specification;
+    const feeds = buildFeeds(specification);
+    const namedStart = namedStartFor(specification, factReference(event));
+
+    const result = await engine.canDistributeToAll(feeds, namedStart, factReference(adminUser));
+    expect(result.type).toBe("success");
+  });
+});
+
+function factReference(fact: HashMap): FactRecord {
+  const records = dehydrateFact(fact);
+  return records[records.length - 1];
+}
+
+function namedStartFor(specification: { given: { label: { name: string } }[] }, ...references: FactRecord[]) {
+  return specification.given.reduce((map, given, index) => ({
+    ...map,
+    [given.label.name]: references[index]
+  }), {} as { [name: string]: FactRecord });
+}
+
+async function storeWith(...facts: HashMap[]): Promise<MemoryStore> {
+  const store = new MemoryStore();
+  const records = new Map<string, FactRecord>();
+  for (const fact of facts) {
+    for (const record of dehydrateFact(fact)) {
+      records.set(`${record.type}:${record.hash}`, record);
+    }
+  }
+  const envelopes: FactEnvelope[] = Array.from(records.values()).map(fact => ({ fact, signatures: [] }));
+  await store.save(envelopes);
+  return store;
+}


### PR DESCRIPTION
## Summary

Fixes issue #204 (issue 1). A distribution rule whose `.select()` projection traverses *through* an intermediate fact — e.g. `Finalist`, used only to reach the `competitor` it projects, never exposed as a named component — did not authorize a direct query for that intermediate fact:

```
Not authorized: Cannot distribute to (p1: Event) {
    u1: Finalist [
        u1->event: Event = p1
    ]
}
No rules apply to this feed.
```

`canDistributeTo` required the target feed's skeleton to **equal** a rule feed's exactly, so `Event → Finalist` matched no feed of a rule projecting `Event → Finalist → Competitor → CompetitorName`. Apps had to declare redundant flat rules to work around it.

## Change

Relax the per-feed match to also accept a target that is a **sound sub-feed** of a rule feed (`skeletonContains`):

```ts
if (skeletonsEqual(ruleSkeleton, targetSkeleton) ||
    skeletonContains(ruleSkeleton, targetSkeleton)) {
```

**Soundness.** A dropped fact may only be **predecessor-ward** of the kept facts (mandatory — present for every successor, e.g. the `Competitor` of a `Finalist`). A fact reached by a **successor/existential** join restricts the rule's output, so dropping it is rejected — a "published posts" rule (`Blog → Post → Publish`) still refuses a bare `Blog → Post` query, which would otherwise leak unpublished posts. So the relaxation never authorizes a feed returning anything beyond what the rule's own tuples already deliver to that user. User authorization is unchanged; only the feed-shape match is relaxed.

**Not gated behind `isTest`.** The same `DistributionEngine` backs both `JinagaTest` and the real replicator (`jinaga-server`, constructed with `isTest=false`). Gating would make `JinagaTest` more permissive than the replicator it simulates — false confidence. Applying it uniformly keeps them in lock-step, and is safe because the relaxation is sound.

## Tests

- `test/distribution/intermediateProjectionFeedSpec.ts` (new): the `Finalist` shape via `JinagaTest` — authorizes the admin's intermediate `Finalist`/`Competitor` queries; still rejects an unauthorized outsider and an unrelated feed. Plus a direct-engine assertion at **`isTest=false`** (the replicator's config) proving parity.
- `test/distribution/distributionEngineDirectSpec.ts`: an `isTest=false` test asserting the published-posts restriction is **not** droppable (no over-authorization on the replicator path).
- Full suite: **493 passing**.

A matching server-side integration test is staged in `jinaga-server` and has been verified to reproduce the bug against 6.8.0 and pass against this build; it lands once `jinaga` is released and the dependency is bumped.

## Issue 2

Retracted by the reporter — a React hook timing artifact in their app's tests, not a `JinagaTest` bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)