### PR TITLE
Fix HTTP 500 "Label u2 not found" for positive existentials in subscribed/distribution specs

### DIFF
--- a/src/specification/feed-builder.ts
+++ b/src/specification/feed-builder.ts
@@ -149,9 +149,16 @@ function withGiven(specification: Specification, label: Label): Specification {
 }
 
 function withCondition(specification: Specification, newGivens: SpecificationGiven[], newExistentialCondition: ExistentialCondition, targetLabel: string) {
-    // Find the match that owns this condition by its label name. The most
-    // recently added match with that name is the one currently being built.
-    const targetIndex = specification.matches.map(m => m.unknown.name).lastIndexOf(targetLabel);
+    // Find the match that owns this condition by its label name. Scan
+    // backwards so the most recently added match with that name (the one
+    // currently being built) wins.
+    let targetIndex = -1;
+    for (let index = specification.matches.length - 1; index >= 0; index--) {
+        if (specification.matches[index].unknown.name === targetLabel) {
+            targetIndex = index;
+            break;
+        }
+    }
     if (targetIndex < 0) {
         throw new Error(`Label ${targetLabel} not found when attaching existential condition`);
     }

--- a/src/specification/feed-builder.ts
+++ b/src/specification/feed-builder.ts
@@ -64,7 +64,11 @@ function addMatches(specification: Specification, unusedGivens: Label[], matches
                     exists: false,
                     matches: []
                 }, existentialCondition.matches, specification.given, unusedGivens);
-                specification = withCondition(specification, newGivens, newExistentialCondition);
+                // Attach the condition to the match it actually belongs to. A
+                // preceding positive existential may have flattened its own
+                // matches onto the end of the feed, so the current match is no
+                // longer guaranteed to be the last one.
+                specification = withCondition(specification, newGivens, newExistentialCondition, match.unknown.name);
                 unusedGivens = newUnusedGivens;
             }
         }
@@ -144,13 +148,19 @@ function withGiven(specification: Specification, label: Label): Specification {
     };
 }
 
-function withCondition(specification: Specification, newGivens: SpecificationGiven[], newExistentialCondition: ExistentialCondition) {
+function withCondition(specification: Specification, newGivens: SpecificationGiven[], newExistentialCondition: ExistentialCondition, targetLabel: string) {
+    // Find the match that owns this condition by its label name. The most
+    // recently added match with that name is the one currently being built.
+    const targetIndex = specification.matches.map(m => m.unknown.name).lastIndexOf(targetLabel);
+    if (targetIndex < 0) {
+        throw new Error(`Label ${targetLabel} not found when attaching existential condition`);
+    }
     return {
         ...specification,
         given: newGivens,
-        matches: [...specification.matches.slice(0, specification.matches.length - 1), {
-            ...specification.matches[specification.matches.length - 1],
-            conditions: [...specification.matches[specification.matches.length - 1].conditions, newExistentialCondition]
-        }]
+        matches: specification.matches.map((match, index) => index === targetIndex ? {
+            ...match,
+            conditions: [...match.conditions, newExistentialCondition]
+        } : match)
     };
 }

--- a/src/specification/specification.ts
+++ b/src/specification/specification.ts
@@ -166,17 +166,24 @@ export function getAllRoles(specification: Specification): RoleDescription[] {
             [given.label.name]: given.label.type
         }),
         {} as TypeByLabel);
-    
-    // Collect roles from existential conditions on givens
+
+    // Walk the matches first so that the label map includes every unknown in
+    // the specification, not just the givens. An existential condition lifted
+    // onto a given (as inversion does) can path-reference a sibling match
+    // label; without those labels seeded, resolving its roles would fail with
+    // "Label <name> not found".
+    const { roles: rolesFromMatches, labels: labelsFromMatches } = getAllRolesFromMatches(labels, specification.matches);
+
+    // Collect roles from existential conditions on givens, using the full
+    // label map so sibling references resolve.
     let rolesFromGivenConditions: RoleDescription[] = [];
     for (const given of specification.given) {
         for (const condition of given.conditions) {
-            const { roles } = getAllRolesFromMatches(labels, condition.matches);
+            const { roles } = getAllRolesFromMatches(labelsFromMatches, condition.matches);
             rolesFromGivenConditions.push(...roles);
         }
     }
-    
-    const { roles: rolesFromMatches, labels: labelsFromMatches } = getAllRolesFromMatches(labels, specification.matches);
+
     const components = specification.projection.type === "composite" ? specification.projection.components : [];
     const rolesFromComponents = getAllRolesFromComponents(labelsFromMatches, components);
     const roles: RoleDescription[] = [ ...rolesFromGivenConditions, ...rolesFromMatches, ...rolesFromComponents ];

--- a/test/specification/feedBuilderSpec.ts
+++ b/test/specification/feedBuilderSpec.ts
@@ -1,4 +1,4 @@
-import { SpecificationParser, buildFeeds, describeSpecification } from "@src";
+import { SpecificationParser, buildFeeds, describeSpecification, invertSpecification } from "@src";
 
 describe("feed generator", () => {
     it("should produce no feeds for an identity specification", () => {
@@ -142,6 +142,107 @@ describe("feed generator", () => {
         ];
 
         expect(feeds).toEqual(expectedFeeds);
+    });
+
+    it("should attach a sibling negative existential to its own match after a positive existential", () => {
+        // Regression for jinaga/jinaga-replicator#52: a match carrying a
+        // positive existential (which is flattened into top-level matches)
+        // followed by a negative existential must keep the negative attached
+        // to the original match, not to the flattened positive match.
+        const feeds = getFeeds(`
+            (root: Root) {
+                item: Item [
+                    item->root: Root = root
+                    E {
+                        tag: Tag [
+                            tag->item: Item = item
+                        ]
+                    }
+                    !E {
+                        del: Deleted [
+                            del->item: Item = item
+                        ]
+                    }
+                ]
+            }`);
+
+        const expectedFeeds: string[] = [
+            // Negating detector feed: tag (from the positive existential) and del.
+            `(root: Root) {
+                item: Item [
+                    item->root: Root = root
+                ]
+                tag: Tag [
+                    tag->item: Item = item
+                ]
+                del: Deleted [
+                    del->item: Item = item
+                ]
+            }`,
+            // Main feed: the negative existential stays on item, while tag
+            // (the flattened positive existential) is a top-level match.
+            `(root: Root) {
+                item: Item [
+                    item->root: Root = root
+                    !E {
+                        del: Deleted [
+                            del->item: Item = item
+                        ]
+                    }
+                ]
+                tag: Tag [
+                    tag->item: Item = item
+                ]
+            }`
+        ];
+
+        expect(feeds).toEqual(expectedFeeds);
+    });
+
+    it("should produce re-parseable, invertible feeds when a match mixes positive and negative existentials", () => {
+        // The feeds produced for such a specification must be valid on their
+        // own — describable, re-parseable, and invertible — because the
+        // replicator serializes feeds and inverts them at NOTIFY time. A
+        // mis-attached existential previously produced a feed that threw
+        // "Label u2 not found" during inversion.
+        const specification = getSpecification(`
+            (user: Jinaga.User) {
+                provisioner: Provisioner [
+                    provisioner->user: Jinaga.User = user
+                ]
+                request: Request [
+                    request->domain: Domain = provisioner->domain: Domain
+                    E {
+                        redemption: Redemption [
+                            redemption->request: Request = request
+                        ]
+                    }
+                    !E {
+                        workspace: Workspace [
+                            workspace->request: Request = request
+                        ]
+                        owner: Owner [
+                            owner->workspace: Workspace = workspace
+                        ]
+                    }
+                    !E {
+                        denied: Denied [
+                            denied->request: Request = request
+                        ]
+                    }
+                ]
+            } => request`);
+
+        const feeds = buildFeeds(specification);
+        expect(feeds.length).toBeGreaterThan(0);
+        for (const feed of feeds) {
+            const description = describeSpecification(feed, 0);
+            const parser = new SpecificationParser(description);
+            parser.skipWhitespace();
+            const reparsed = parser.parseSpecification();
+            // Inversion must not throw "Label ... not found".
+            expect(() => invertSpecification(reparsed)).not.toThrow();
+        }
     });
 
     it("should parse deeply nested projection", () => {

--- a/test/specification/getAllRolesSpec.ts
+++ b/test/specification/getAllRolesSpec.ts
@@ -1,0 +1,79 @@
+import { buildModel, getAllRoles, invertSpecification, Specification, User } from "@src";
+
+describe("getAllRoles", () => {
+    // Regression for jinaga/jinaga-replicator#52. When a positive existential
+    // (.exists) is inverted, the resulting inverse can carry that existential on
+    // its given, with an inner match that path-references a SIBLING match label
+    // rather than the given itself. The Postgres store resolves role IDs through
+    // getAllRoles, which previously seeded its label map with only the given
+    // labels and threw "Label <name> not found" on such inverses — surfacing as
+    // an HTTP 500 on /save. (The in-memory store never calls getAllRoles, which
+    // is why JinagaTest did not reproduce it.)
+    it("resolves an existential on the given that references a sibling match label", () => {
+        const specification: Specification = {
+            given: [{
+                label: { name: "u3", type: "Redemption" },
+                conditions: [{
+                    type: "existential",
+                    exists: true,
+                    matches: [{
+                        unknown: { name: "u4", type: "Receipt" },
+                        conditions: [{
+                            type: "path",
+                            rolesLeft: [{ name: "request", predecessorType: "Request" }],
+                            labelRight: "u2",
+                            rolesRight: []
+                        }]
+                    }]
+                }]
+            }],
+            matches: [{
+                unknown: { name: "u2", type: "Request" },
+                conditions: [{
+                    type: "path",
+                    rolesLeft: [],
+                    labelRight: "u3",
+                    rolesRight: [{ name: "request", predecessorType: "Request" }]
+                }]
+            }],
+            projection: { type: "fact", label: "u2" }
+        };
+
+        expect(() => getAllRoles(specification)).not.toThrow();
+
+        const roles = getAllRoles(specification);
+        // The role referenced through the sibling label must be resolved with
+        // the correct successor type (Receipt -> request -> Request).
+        expect(roles).toContainEqual({
+            successorType: "Receipt",
+            name: "request",
+            predecessorType: "Request"
+        });
+    });
+
+    it("resolves roles for every inverse of a spec with a nested positive existential", () => {
+        class Domain { static Type = "Domain" as const; type = Domain.Type; constructor(public identifier: string) { } }
+        class Provisioner { static Type = "Provisioner" as const; type = Provisioner.Type; constructor(public user: User, public domain: Domain) { } }
+        class Request { static Type = "Request" as const; type = Request.Type; constructor(public domain: Domain, public identifier: string) { } }
+        class Redemption { static Type = "Redemption" as const; type = Redemption.Type; constructor(public request: Request) { } }
+        class Receipt { static Type = "Receipt" as const; type = Receipt.Type; constructor(public request: Request) { } }
+
+        const model = buildModel(m => m
+            .type(User).type(Domain)
+            .type(Provisioner, f => f.predecessor("user", User).predecessor("domain", Domain))
+            .type(Request, f => f.predecessor("domain", Domain))
+            .type(Redemption, f => f.predecessor("request", Request))
+            .type(Receipt, f => f.predecessor("request", Request)));
+
+        const specification = model.given(User).match((user, facts) =>
+            facts.ofType(Provisioner).join(p => p.user, user)
+                .selectMany(p => facts.ofType(Request).join(r => r.domain, p.domain)
+                    .exists(r => facts.ofType(Redemption).join(red => red.request, r)
+                        .exists(red => facts.ofType(Receipt).join(rc => rc.request, r)))));
+
+        const inverses = invertSpecification(specification.specification);
+        for (const inverse of inverses) {
+            expect(() => getAllRoles(inverse.inverseSpecification)).not.toThrow();
+        }
+    });
+});

--- a/test/specification/getAllRolesSpec.ts
+++ b/test/specification/getAllRolesSpec.ts
@@ -39,8 +39,7 @@ describe("getAllRoles", () => {
             projection: { type: "fact", label: "u2" }
         };
 
-        expect(() => getAllRoles(specification)).not.toThrow();
-
+        // Must not throw "Label u2 not found" — the sibling reference resolves.
         const roles = getAllRoles(specification);
         // The role referenced through the sibling label must be resolved with
         // the correct successor type (Receipt -> request -> Request).


### PR DESCRIPTION
## Summary

Fixes the HTTP 500 `Error: Label u2 not found` on `/save` reported in **jinaga/jinaga-replicator#52**, which occurs when a subscribed/distribution specification contains a positive existential (`.exists(...)`). The fix lives in jinaga.js (the replicator builds on it).

There are two related defects, each with its own commit and regression tests.

### 1. `getAllRoles` — the actual cause of the 500 (`specification.ts`)

At NOTIFY time the worker's subscription spec is inverted and the inverses are registered as listeners. Inverting a positive existential can lift that existential **onto the given** of an inverse, where its inner match path-references a **sibling match label** (the auto-named `u2` = the `Request`) rather than the given itself.

`getAllRoles` seeded its label map with only the *given* labels before walking the given-attached existential conditions, so the sibling reference `u2` was unknown and it threw the bare `Label u2 not found` (distinct from the jinaga-server store messages, which append `Known labels: ...`).

This path is **Postgres-only**: `PostgresStore.read` resolves role IDs via `getAllRoles`, while `MemoryStore.read` never calls it — which is why in-memory `JinagaTest` did not reproduce the failure.

**Fix:** walk the matches first to build the full label map, then resolve roles for the given-attached existential conditions against that map so sibling references resolve. Final role ordering/dedup is unchanged.

### 2. Feed builder — mis-attached sibling existential (`feed-builder.ts`)

While investigating I found a separate, genuine bug in `buildFeeds`: when a match carried a positive existential (which is flattened into top-level matches) followed by a **negative** existential, the negative was attached via `withCondition` to whatever match happened to be last (the flattened positive match) instead of the match that actually owns it. The result was a structurally-invalid feed whose description could not be re-parsed.

**Fix:** attach the existential condition to the match that owns it, looked up by label name, rather than blindly to the last match.

## Reproduction & tests

- Confirmed the bare `Label u2 not found` both with a hand-built inverse shape and end-to-end by inverting a spec with a nested positive existential and calling `getAllRoles` on each inverse.
- Added `test/specification/getAllRolesSpec.ts` (2 tests).
- Added 2 regression tests to `test/specification/feedBuilderSpec.ts`.
- Full suite: **497 passing**; `tsc --noEmit` (test project) clean.

## Notes

- The documented workaround (root the spec at the successor instead of using a positive `.exists`) sidesteps the issue by never producing the given-attached positive existential; with this fix it is no longer required.
- Credit to the detailed root-cause analysis in the issue thread, which correctly pinpointed `specification.ts` rather than `inverse.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRCUN86EtD1zXJJ3T5EsBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRCUN86EtD1zXJJ3T5EsBw)_