### PR TITLE
Add distribution denial codes and per-feed diagnostics (issue #207)

### DIFF
--- a/src/distribution/distribution-engine.ts
+++ b/src/distribution/distribution-engine.ts
@@ -51,15 +51,26 @@ export interface DistributionIntersectionResult {
  *   is not among those it authorizes.
  * - `not-authenticated` means a rule's shape matched but no user is logged in.
  *
- * Note: a "rule too restrictive" outcome is not a distinct engine state — it
- * surfaces as `principal-excluded`. Do not add a code the engine cannot
- * produce.
+ * Note the distinction between the two "restrictive" ideas: a rule that is too
+ * restrictive *for this user* (the rule excludes them) is not a distinct code —
+ * it surfaces as `principal-excluded`. That is different from
+ * `spec-more-restrictive-than-rule`, which is about the *target specification*
+ * being narrower than a rule (it adds a positive join the rule lacks) and is
+ * produced by the near-miss classification pass. Do not add a code the engine
+ * cannot produce.
+ *
+ * `distributionDenialCodes` is the runtime source of truth; the type is derived
+ * from it so callers (e.g. the `POST /feeds` response parser) can validate
+ * codes against the same list.
  */
-export type DistributionDenialCode =
-  | 'no-matching-rule'
-  | 'spec-more-restrictive-than-rule'  // produced by the near-miss classification pass
-  | 'principal-excluded'
-  | 'not-authenticated';
+export const distributionDenialCodes = [
+  'no-matching-rule',
+  'spec-more-restrictive-than-rule',  // produced by the near-miss classification pass
+  'principal-excluded',
+  'not-authenticated',
+] as const;
+
+export type DistributionDenialCode = typeof distributionDenialCodes[number];
 
 export interface DistributionSuccess {
   type: 'success';

--- a/src/distribution/distribution-engine.ts
+++ b/src/distribution/distribution-engine.ts
@@ -1,5 +1,6 @@
 import { User } from "../model/user";
 import { describeSpecification } from "../specification/description";
+import { computeFeedHash } from "../specification/feed-cache";
 import { buildFeeds } from "../specification/feed-builder";
 import { EdgeDescription, FactDescription, InputDescription, NotExistsConditionDescription, Skeleton, skeletonOfSpecification } from "../specification/skeleton";
 import { Specification, isPathCondition, specificationIsIdentity } from "../specification/specification";
@@ -39,16 +40,76 @@ export interface DistributionIntersectionResult {
   intersected: boolean;
 }
 
+/**
+ * A discriminant that categorizes *why* a feed could not be distributed. The
+ * categories split by whether the outcome can self-heal when a fact later
+ * arrives (see issue #207):
+ *
+ * - `no-matching-rule` / `spec-more-restrictive-than-rule` are structural
+ *   authoring errors: no rule covers the feed, so it can never self-heal.
+ * - `principal-excluded` means a rule's shape matched but the logged-in user
+ *   is not among those it authorizes.
+ * - `not-authenticated` means a rule's shape matched but no user is logged in.
+ *
+ * Note: a "rule too restrictive" outcome is not a distinct engine state — it
+ * surfaces as `principal-excluded`. Do not add a code the engine cannot
+ * produce.
+ */
+export type DistributionDenialCode =
+  | 'no-matching-rule'
+  | 'spec-more-restrictive-than-rule'  // produced by the near-miss classification pass
+  | 'principal-excluded'
+  | 'not-authenticated';
+
 export interface DistributionSuccess {
   type: 'success';
+}
+
+/**
+ * The per-feed detail behind a distribution failure. `feed` is the same
+ * URL-safe hash the client uses to fetch the feed, so callers can correlate a
+ * denial with a specific feed.
+ */
+export interface DistributionPerFeedFailure {
+  feed: string;
+  code: DistributionDenialCode;
+  reason: string;
 }
 
 export interface DistributionFailure {
   type: 'failure';
   reason: string;
+  code: DistributionDenialCode;
+  perFeed: DistributionPerFeedFailure[];
 }
 
 export type DistributionResult = DistributionSuccess | DistributionFailure;
+
+/**
+ * The single-feed result computed by `canDistributeTo`. It carries a code and
+ * reason but not the per-feed array or feed hash; `canDistributeToAll`
+ * assembles those into the aggregate `DistributionFailure`.
+ */
+interface PerFeedFailure {
+  type: 'failure';
+  reason: string;
+  code: DistributionDenialCode;
+}
+
+type PerFeedResult = DistributionSuccess | PerFeedFailure;
+
+/**
+ * Relative actionability of the denial codes. `canDistributeToAll` reports the
+ * most-actionable code across all failing feeds: structural authoring errors
+ * first (a too-narrow spec is the most specific), then principal exclusion,
+ * then missing authentication.
+ */
+const denialCodePriority: { [code in DistributionDenialCode]: number } = {
+  'spec-more-restrictive-than-rule': 4,
+  'no-matching-rule': 3,
+  'principal-excluded': 2,
+  'not-authenticated': 1,
+};
 
 export class DistributionEngine {
   constructor(
@@ -59,17 +120,28 @@ export class DistributionEngine {
 
   async canDistributeToAll(targetFeeds: Specification[], namedStart: ReferencesByName, user: FactReference | null): Promise<DistributionResult> {
     // TODO: Minimize the number hits to the database.
-    const reasons: string[] = [];
+    const perFeed: DistributionPerFeedFailure[] = [];
     for (const targetFeed of targetFeeds) {
       const feedResult = await this.canDistributeTo(targetFeed, namedStart, user);
       if (feedResult.type === 'failure') {
-        reasons.push(feedResult.reason);
+        perFeed.push({
+          feed: computeFeedHash(targetFeed, namedStart),
+          code: feedResult.code,
+          reason: feedResult.reason
+        });
       }
     }
-    if (reasons.length > 0) {
+    if (perFeed.length > 0) {
+      // Pick the most-actionable code across all failing feeds while keeping
+      // the full per-feed detail for callers that want to inspect it.
+      const code = perFeed.reduce((most, f) =>
+        denialCodePriority[f.code] > denialCodePriority[most] ? f.code : most,
+        perFeed[0].code);
       return {
         type: 'failure',
-        reason: reasons.join('\n\n')
+        reason: perFeed.map(f => f.reason).join('\n\n'),
+        code,
+        perFeed
       };
     }
     else {
@@ -79,7 +151,7 @@ export class DistributionEngine {
     }
   }
 
-  private async canDistributeTo(targetFeed: Specification, namedStart: ReferencesByName, user: FactReference | null): Promise<DistributionResult> {
+  private async canDistributeTo(targetFeed: Specification, namedStart: ReferencesByName, user: FactReference | null): Promise<PerFeedResult> {
     const start = targetFeed.given.map(g => namedStart[g.label.name]);
     const targetSkeleton = skeletonOfSpecification(targetFeed);
     const reasons: string[] = [];
@@ -184,10 +256,35 @@ export class DistributionEngine {
     }
 
     if (reasons.length === 0) {
-      reasons.push("No rules apply to this feed.");
+      // No rule's shape matched the target at all. Run the diagnostic-only
+      // near-miss pass (W2, off the hot path): is the target a *narrower*
+      // version of some rule — i.e. does it contain all of a rule's facts,
+      // edges, and not-exists conditions plus additional positive structure
+      // the rule lacks? If so, the developer narrowed the spec past the rule
+      // rather than simply having no rule at all.
+      const nearMissRule = findNearMissRule(targetSkeleton, this.distributionRules);
+      if (nearMissRule !== null) {
+        return {
+          type: 'failure',
+          code: 'spec-more-restrictive-than-rule',
+          reason: `Cannot distribute to ${describeSpecification(targetFeed, 0)}` +
+            `The specification is more restrictive than the distribution rule ` +
+            `${describeSpecification(nearMissRule, 0)}`
+        };
+      }
+      return {
+        type: 'failure',
+        code: 'no-matching-rule',
+        reason: `Cannot distribute to ${describeSpecification(targetFeed, 0)}No rules apply to this feed.`
+      };
     }
+
+    // A rule's shape matched but authorization failed. When no user is logged
+    // in this is `not-authenticated`; otherwise the user is not among those the
+    // matching rule authorizes (`principal-excluded`).
     return {
       type: 'failure',
+      code: user === null ? 'not-authenticated' : 'principal-excluded',
       reason: `Cannot distribute to ${describeSpecification(targetFeed, 0)}${reasons.join('\n')}`
     };
 
@@ -419,6 +516,59 @@ function skeletonContains(ruleSkeleton: Skeleton, targetSkeleton: Skeleton): boo
   }
 
   return true;
+}
+
+/**
+ * Diagnostic-only near-miss classification (W2, issue #207). Runs only when no
+ * rule matched the target by shape (equal or sound sub-feed), so it is off the
+ * hot path. Returns the first rule feed whose skeleton is a *proper subset* of
+ * the target skeleton — meaning the target keeps every fact, edge, and
+ * not-exists condition of the rule and adds at least one positive fact, join,
+ * or condition the rule lacks. That is the "spec is more restrictive than the
+ * rule" signal; the engine is the only place it can originate because the
+ * client does not hold the replicator's distribution rules.
+ *
+ * This is deliberately distinct from `skeletonContains`: that predicate refuses
+ * to drop successor facts (it guards what the engine will *authorize*), whereas
+ * here we are diagnosing a target that *adds* them, so we test plain structural
+ * containment rather than sound-sub-feed containment.
+ */
+function findNearMissRule(targetSkeleton: Skeleton, distributionRules: DistributionRules): Specification | null {
+  for (const rule of distributionRules.rules) {
+    for (const ruleFeed of rule.feeds) {
+      const ruleSkeleton = skeletonOfSpecification(ruleFeed);
+      if (skeletonIsProperSubset(ruleSkeleton, targetSkeleton)) {
+        return ruleFeed;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * True when `subsetSkeleton` is contained in `supersetSkeleton` and the
+ * superset adds strictly more structure. Fact/edge indices are assigned by a
+ * deterministic outward walk from the givens, so a target that appends a join
+ * shares the rule's indices on the common prefix and the index-based equality
+ * predicates line up. A target that inserts a join mid-traversal shifts the
+ * indices and will not be detected — an acceptable limitation for a best-effort
+ * diagnostic.
+ */
+function skeletonIsProperSubset(subsetSkeleton: Skeleton, supersetSkeleton: Skeleton): boolean {
+  if (!isSubsetOf(subsetSkeleton.facts, supersetSkeleton.facts, factsEqual)) {
+    return false;
+  }
+  if (!isSubsetOf(subsetSkeleton.edges, supersetSkeleton.edges, edgesEqual)) {
+    return false;
+  }
+  if (!isSubsetOf(subsetSkeleton.notExistsConditions, supersetSkeleton.notExistsConditions, notExistsConditionsEqual)) {
+    return false;
+  }
+  // The target must add at least one fact, edge, or condition; otherwise the
+  // shapes are equal and would already have matched on the hot path.
+  return supersetSkeleton.facts.length > subsetSkeleton.facts.length ||
+    supersetSkeleton.edges.length > subsetSkeleton.edges.length ||
+    supersetSkeleton.notExistsConditions.length > subsetSkeleton.notExistsConditions.length;
 }
 
 function isSubsetOf<T>(subset: T[], superset: T[], equals: (a: T, b: T) => boolean): boolean {

--- a/src/http/messageParsers.ts
+++ b/src/http/messageParsers.ts
@@ -1,4 +1,4 @@
-import type { DistributionDenialCode } from "../distribution/distribution-engine";
+import { DistributionDenialCode, distributionDenialCodes } from "../distribution/distribution-engine";
 import { FactRecord, FactReference, PredecessorCollection } from "../storage";
 import { FeedDecision, FeedsResponse, LoadMessage, SaveMessage } from "./messages";
 
@@ -74,6 +74,9 @@ function parseFeedDecision(decision: any): FeedDecision {
   };
   if (decision.code !== undefined) {
     if (typeof decision.code !== 'string') throw new Error("Expected a string 'code' property.");
+    if (!(distributionDenialCodes as readonly string[]).includes(decision.code)) {
+      throw new Error(`Unknown denial 'code': ${decision.code}.`);
+    }
     result.code = decision.code as DistributionDenialCode;
   }
   return result;

--- a/src/http/messageParsers.ts
+++ b/src/http/messageParsers.ts
@@ -1,5 +1,6 @@
+import type { DistributionDenialCode } from "../distribution/distribution-engine";
 import { FactRecord, FactReference, PredecessorCollection } from "../storage";
-import { LoadMessage, SaveMessage } from "./messages";
+import { FeedDecision, FeedsResponse, LoadMessage, SaveMessage } from "./messages";
 
 function parseFactReference(factReference: any): FactReference {
   if (typeof factReference !== 'object') throw new Error("Expected FactReference to be an object.");
@@ -55,4 +56,42 @@ export function parseLoadMessage(message: any): LoadMessage {
   return {
     references: message.references.map(parseFactReference)
   };
+}
+
+const feedDecisionKinds = ['authorized', 'reactive', 'denied'];
+
+function parseFeedDecision(decision: any): FeedDecision {
+  if (typeof decision !== 'object' || decision === null) throw new Error("Expected FeedDecision to be an object.");
+  if (typeof decision.feed !== 'string') throw new Error("Expected a string 'feed' property.");
+  if (!feedDecisionKinds.includes(decision.decision)) {
+    throw new Error("Expected 'decision' to be 'authorized', 'reactive', or 'denied'.");
+  }
+  if (typeof decision.reason !== 'string') throw new Error("Expected a string 'reason' property.");
+  const result: FeedDecision = {
+    feed: decision.feed,
+    decision: decision.decision,
+    reason: decision.reason
+  };
+  if (decision.code !== undefined) {
+    if (typeof decision.code !== 'string') throw new Error("Expected a string 'code' property.");
+    result.code = decision.code as DistributionDenialCode;
+  }
+  return result;
+}
+
+export function parseFeedsResponse(message: any): FeedsResponse {
+  if (typeof message !== 'object' || message === null) throw new Error("Expected an object. Check the content type of the response.");
+  if (!Array.isArray(message.feeds)) throw new Error("Expected an array 'feeds' property.");
+  const feeds: string[] = message.feeds.map((feed: any) => {
+    if (typeof feed !== 'string') throw new Error("Expected 'feeds' to be an array of strings.");
+    return feed;
+  });
+  const response: FeedsResponse = { feeds };
+  // Old replicators omit `decisions`; when absent the client simply has
+  // nothing to report (graceful degradation).
+  if (message.decisions !== undefined) {
+    if (!Array.isArray(message.decisions)) throw new Error("Expected an array 'decisions' property.");
+    response.decisions = message.decisions.map(parseFeedDecision);
+  }
+  return response;
 }

--- a/src/http/messages.ts
+++ b/src/http/messages.ts
@@ -1,3 +1,4 @@
+import type { DistributionDenialCode } from '../distribution/distribution-engine';
 import { FactRecord, FactReference } from '../storage';
 
 export interface ProfileMessage {
@@ -21,8 +22,24 @@ export interface LoadResponse {
     facts: FactRecord[]
 };
 
+/**
+ * The replicator's per-feed distribution decision, returned on `POST /feeds`
+ * (issue #207). `feed` is the URL-safe feed hash. `decision: 'reactive'`
+ * corresponds to the authorized-via-intersection case: the feed is denied for
+ * the current user right now but will self-heal once the authorizing fact
+ * arrives, so it must never be treated as a hard failure. `code` and the
+ * human-readable `reason` describe why the feed was denied or made reactive.
+ */
+export interface FeedDecision {
+    feed: string;                                   // hash
+    decision: 'authorized' | 'reactive' | 'denied';
+    code?: DistributionDenialCode;
+    reason: string;
+}
+
 export interface FeedsResponse {
     feeds: string[];
+    decisions?: FeedDecision[];                      // optional; old replicators omit it
 }
 
 export interface FeedResponse {

--- a/src/http/web-client.ts
+++ b/src/http/web-client.ts
@@ -2,6 +2,7 @@ import { serializeSave } from "../fork/serialize";
 import { FactEnvelope } from "../storage";
 import { Trace } from "../util/trace";
 import { ContentTypeGraph, ContentTypeJson, ContentTypeText, PostAccept, PostContentType } from "./ContentType";
+import { parseFeedsResponse } from "./messageParsers";
 import { FeedResponse, FeedsResponse, LoadMessage, LoadResponse, LoginResponse } from "./messages";
 import { serializeGraph } from "./serializer";
 
@@ -106,7 +107,8 @@ export class WebClient {
     }
 
     async feeds(request: string): Promise<FeedsResponse> {
-        return <FeedsResponse> await this.post('/feeds', ContentTypeText, ContentTypeJson, request);
+        const response = await this.post('/feeds', ContentTypeText, ContentTypeJson, request);
+        return parseFeedsResponse(response);
     }
 
     async feed(feed: string, bookmark: string): Promise<FeedResponse> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export { AuthorizationNoOp } from "./authorization/authorization-noop";
 export { AuthorizationRules, describeAuthorizationRules } from "./authorization/authorizationRules";
 export { generateKeyPair, KeyPair, signFacts } from "./cryptography/key-pair";
 export { verifyEnvelopes } from "./cryptography/verify";
-export { DistributionEngine } from './distribution/distribution-engine';
+export { DistributionEngine, DistributionDenialCode, DistributionFailure, DistributionPerFeedFailure, DistributionResult, DistributionSuccess } from './distribution/distribution-engine';
 export { describeDistributionRules, DistributionRules } from './distribution/distribution-rules';
 export { canonicalizeFact, canonicalPredecessors, computeHash, computeObjectHash, verifyHash } from './fact/hash';
 export { dehydrateFact, dehydrateReference, Dehydration, HashMap, hydrate, hydrateFromTree, Hydration } from "./fact/hydrate";
@@ -20,8 +20,9 @@ export { AuthenticationProvider, HttpHeaders } from "./http/authenticationProvid
 export { GraphDeserializer, GraphSource } from "./http/deserializer";
 export { FetchConnection } from "./http/fetch";
 export { HttpNetwork } from "./http/httpNetwork";
-export { parseLoadMessage, parseSaveMessage } from './http/messageParsers';
+export { parseFeedsResponse, parseLoadMessage, parseSaveMessage } from './http/messageParsers';
 export {
+  FeedDecision,
   FeedResponse,
   FeedsResponse,
   LoadMessage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export { AuthorizationNoOp } from "./authorization/authorization-noop";
 export { AuthorizationRules, describeAuthorizationRules } from "./authorization/authorizationRules";
 export { generateKeyPair, KeyPair, signFacts } from "./cryptography/key-pair";
 export { verifyEnvelopes } from "./cryptography/verify";
-export { DistributionEngine, DistributionDenialCode, DistributionFailure, DistributionPerFeedFailure, DistributionResult, DistributionSuccess } from './distribution/distribution-engine';
+export { DistributionEngine, DistributionDenialCode, distributionDenialCodes, DistributionFailure, DistributionPerFeedFailure, DistributionResult, DistributionSuccess } from './distribution/distribution-engine';
 export { describeDistributionRules, DistributionRules } from './distribution/distribution-rules';
 export { canonicalizeFact, canonicalPredecessors, computeHash, computeObjectHash, verifyHash } from './fact/hash';
 export { dehydrateFact, dehydrateReference, Dehydration, HashMap, hydrate, hydrateFromTree, Hydration } from "./fact/hydrate";

--- a/src/specification/feed-cache.ts
+++ b/src/specification/feed-cache.ts
@@ -25,20 +25,11 @@ export class FeedCache {
 
     addFeeds(feeds: Specification[], namedStart: ReferencesByName): string[] {
         const feedsByHash = feeds.reduce((map, feed) => {
-            const skeleton = skeletonOfSpecification(feed);
-            const indexedStart = skeleton.inputs.map(input => ({
-                factReference: namedStart[feed.given[input.inputIndex].label.name],
-                index: input.inputIndex
-            }));
-            const feedIdentifier: FeedIdentifier = {
-                start: indexedStart,
-                skeleton
-            };
             const feedObject: FeedObject = {
                 namedStart,
                 feed
             };
-            const hash = urlSafe(computeObjectHash(feedIdentifier));
+            const hash = computeFeedHash(feed, namedStart);
             return ({
                 ...map,
                 [hash]: feedObject
@@ -55,6 +46,25 @@ export class FeedCache {
     getFeed(feed: string): FeedObject | undefined {
         return this.feedByHash[feed];
     }
+}
+
+/**
+ * Compute the URL-safe hash that identifies a feed on the wire. This is the
+ * same identifier the client sends to `GET /feeds/{hash}` and the same hash
+ * the distribution engine records in its per-feed diagnostics, so the two
+ * always agree.
+ */
+export function computeFeedHash(feed: Specification, namedStart: ReferencesByName): string {
+    const skeleton = skeletonOfSpecification(feed);
+    const indexedStart = skeleton.inputs.map(input => ({
+        factReference: namedStart[feed.given[input.inputIndex].label.name],
+        index: input.inputIndex
+    }));
+    const feedIdentifier: FeedIdentifier = {
+        start: indexedStart,
+        skeleton
+    };
+    return urlSafe(computeObjectHash(feedIdentifier));
 }
 
 function urlSafe(hash: string): string {

--- a/test/distribution/distributionDiagnosticsSpec.ts
+++ b/test/distribution/distributionDiagnosticsSpec.ts
@@ -1,0 +1,92 @@
+import { DistributionEngine, DistributionRules, MemoryStore, User, buildFeeds, dehydrateFact } from "@src";
+import { Blog, Post, Publish, distribution, model } from "../blogModel";
+
+describe("DistributionEngine diagnostics (issue #207 W1/W2)", () => {
+  const creator = new User("creator");
+  const reader = new User("reader");
+  const blog = new Blog(creator, "domain");
+
+  const blogPosts = model.given(Blog).match((blog, facts) =>
+    facts.ofType(Post).join(post => post.blog, blog)
+  );
+
+  function namedStartForBlog(specification = blogPosts.specification) {
+    const records = dehydrateFact(blog);
+    const blogReference = records[records.length - 1];
+    return { [specification.given[0].label.name]: blogReference };
+  }
+
+  it("codes a feed with no counterpart rule as no-matching-rule", async () => {
+    const store = new MemoryStore();
+    // No rules at all: nothing can be a near-miss, so this is purely missing.
+    const engine = new DistributionEngine(new DistributionRules([]), store, false);
+
+    const result = await engine.canDistributeToAll(
+      [blogPosts.specification], namedStartForBlog(), dehydrateFact(reader)[0]);
+
+    expect(result.type).toBe('failure');
+    if (result.type === 'failure') {
+      expect(result.code).toBe('no-matching-rule');
+      expect(result.perFeed).toHaveLength(1);
+      expect(result.perFeed[0].code).toBe('no-matching-rule');
+      expect(result.perFeed[0].feed).toEqual(expect.any(String));
+      expect(result.reason).toContain("No rules apply to this feed.");
+    }
+  });
+
+  it("codes a spec narrower than a rule as spec-more-restrictive-than-rule", async () => {
+    const store = new MemoryStore();
+    // The rule shares Blog -> Post with everyone.
+    const rules = new DistributionRules([]).share(blogPosts).withEveryone();
+    const engine = new DistributionEngine(rules, store, false);
+
+    // The target adds a positive Publish join the rule lacks, so it is a
+    // narrower version of the rule's feed.
+    const narrowerTarget = model.given(Blog).match((blog, facts) =>
+      facts.ofType(Post).join(post => post.blog, blog)
+        .selectMany(post => post.successors(Publish, publish => publish.post))
+    ).specification;
+
+    const result = await engine.canDistributeToAll(
+      buildFeeds(narrowerTarget), namedStartForBlog(narrowerTarget), dehydrateFact(reader)[0]);
+
+    expect(result.type).toBe('failure');
+    if (result.type === 'failure') {
+      expect(result.code).toBe('spec-more-restrictive-than-rule');
+      expect(result.perFeed[0].code).toBe('spec-more-restrictive-than-rule');
+      expect(result.reason).toContain("more restrictive than the distribution rule");
+    }
+  });
+
+  it("codes a shape-matched but unauthorized user as principal-excluded", async () => {
+    const store = new MemoryStore();
+    const engine = new DistributionEngine(distribution(new DistributionRules([])), store, false);
+
+    // Blog -> Post matches the "creator can see all posts" rule by shape, but
+    // the reader is not the creator.
+    const result = await engine.canDistributeToAll(
+      [blogPosts.specification], namedStartForBlog(), dehydrateFact(reader)[0]);
+
+    expect(result.type).toBe('failure');
+    if (result.type === 'failure') {
+      expect(result.code).toBe('principal-excluded');
+      expect(result.perFeed[0].code).toBe('principal-excluded');
+      expect(result.reason).toContain("The user does not match");
+    }
+  });
+
+  it("codes a shape-matched rule with no logged-in user as not-authenticated", async () => {
+    const store = new MemoryStore();
+    const engine = new DistributionEngine(distribution(new DistributionRules([])), store, false);
+
+    const result = await engine.canDistributeToAll(
+      [blogPosts.specification], namedStartForBlog(), null);
+
+    expect(result.type).toBe('failure');
+    if (result.type === 'failure') {
+      expect(result.code).toBe('not-authenticated');
+      expect(result.perFeed[0].code).toBe('not-authenticated');
+      expect(result.reason).toContain("User is not logged in.");
+    }
+  });
+});

--- a/test/http/feedsResponseParserSpec.ts
+++ b/test/http/feedsResponseParserSpec.ts
@@ -26,6 +26,13 @@ describe("parseFeedsResponse (issue #207 W3)", () => {
     expect(response.decisions![2].code).toBe("no-matching-rule");
   });
 
+  it("rejects an unknown denial code", () => {
+    expect(() => parseFeedsResponse({
+      feeds: [],
+      decisions: [{ feed: "abc", decision: "denied", code: "not-a-real-code", reason: "" }]
+    })).toThrow(/code/);
+  });
+
   it("rejects an unknown decision value", () => {
     expect(() => parseFeedsResponse({
       feeds: [],

--- a/test/http/feedsResponseParserSpec.ts
+++ b/test/http/feedsResponseParserSpec.ts
@@ -1,0 +1,43 @@
+import { parseFeedsResponse } from "@src";
+
+describe("parseFeedsResponse (issue #207 W3)", () => {
+  it("parses a response with only feeds (old replicator)", () => {
+    const response = parseFeedsResponse({ feeds: ["abc", "def"] });
+    expect(response.feeds).toEqual(["abc", "def"]);
+    expect(response.decisions).toBeUndefined();
+  });
+
+  it("parses per-feed decisions when present", () => {
+    const response = parseFeedsResponse({
+      feeds: ["abc", "def"],
+      decisions: [
+        { feed: "abc", decision: "authorized", reason: "" },
+        { feed: "def", decision: "reactive", reason: "pending authorization" },
+        { feed: "ghi", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }
+      ]
+    });
+    expect(response.feeds).toEqual(["abc", "def"]);
+    expect(response.decisions).toHaveLength(3);
+    expect(response.decisions![1]).toEqual({
+      feed: "def",
+      decision: "reactive",
+      reason: "pending authorization"
+    });
+    expect(response.decisions![2].code).toBe("no-matching-rule");
+  });
+
+  it("rejects an unknown decision value", () => {
+    expect(() => parseFeedsResponse({
+      feeds: [],
+      decisions: [{ feed: "abc", decision: "maybe", reason: "" }]
+    })).toThrow(/'decision'/);
+  });
+
+  it("rejects a non-array feeds property", () => {
+    expect(() => parseFeedsResponse({ feeds: "abc" })).toThrow(/'feeds'/);
+  });
+
+  it("rejects non-string feed entries", () => {
+    expect(() => parseFeedsResponse({ feeds: [1, 2] })).toThrow(/'feeds'/);
+  });
+});


### PR DESCRIPTION
## Summary
This PR enhances the distribution engine to provide detailed, actionable diagnostics when feeds cannot be distributed. It introduces a categorization system for denial reasons and per-feed failure details that help developers understand why distribution failed and whether the issue can self-heal.

## Key Changes

- **Distribution Denial Codes**: Added `DistributionDenialCode` type with four categories:
  - `no-matching-rule`: No rule covers the feed (structural authoring error)
  - `spec-more-restrictive-than-rule`: Target spec is narrower than a matching rule (developer error)
  - `principal-excluded`: Rule matched but user not authorized
  - `not-authenticated`: Rule matched but no user logged in

- **Per-Feed Failure Details**: 
  - New `DistributionPerFeedFailure` interface carries feed hash, denial code, and reason for each failing feed
  - `DistributionFailure` now includes `code` (most-actionable across all failures) and `perFeed` array
  - Clients can correlate denials with specific feeds using the URL-safe feed hash

- **Near-Miss Diagnostic (W2)**:
  - Added `findNearMissRule()` function to detect when a spec is more restrictive than an existing rule
  - Runs only when no rule matched by shape (off the hot path)
  - Helps distinguish between "no rule exists" vs "rule exists but spec is too narrow"

- **Feed Hash Consistency**:
  - Extracted `computeFeedHash()` to `feed-cache.ts` so distribution engine and client use identical hashing
  - Ensures per-feed diagnostics can be correlated with client-side feed requests

- **Response Parsing**:
  - Added `parseFeedsResponse()` to parse per-feed decisions from replicator responses
  - Gracefully handles old replicators that omit the `decisions` field
  - Validates decision kinds and denial codes

- **Denial Code Priority**:
  - When multiple feeds fail, reports the most-actionable code first (structural errors > authorization > authentication)
  - Preserves full per-feed details for callers that need them

## Implementation Details

- The `canDistributeTo()` method now returns `PerFeedResult` (internal type) with denial codes
- `canDistributeToAll()` aggregates results, selecting the highest-priority denial code while preserving all per-feed information
- `skeletonIsProperSubset()` performs structural containment checking distinct from `skeletonContains()` to detect narrower specs
- Tests verify all four denial code paths and per-feed detail accuracy

https://claude.ai/code/session_01FsUoqkFUx7TixXJ2v5FFqb