### PR TITLE
Specify the WebSocket subscription protocol (documentation only)

### DIFF
--- a/documentation/graph-protocol.md
+++ b/documentation/graph-protocol.md
@@ -315,6 +315,12 @@ The deserializer processes facts in batches (default: 20 facts) for efficiency.
 
 ## WebSocket Transport
 
+> **Note.** This section is a summary. The authoritative definition of the WebSocket
+> transport — including the complete frame set (`ACK`, `PING`/`PONG`, structured
+> `ERR` codes), connection negotiation, liveness, reconnection, and the protocol
+> invariants — is [`websocket-protocol-spec.md`](./websocket-protocol-spec.md). The
+> graph block format defined in this document is unchanged over WebSockets.
+
 ### Overview
 
 When transported over WebSockets, the graph is a single, continuous stream of fact blocks and public key declarations. There is no special framing to begin or end a graph. The stream may also contain control frames that manage feed subscriptions and bookmarks. Facts are global and not scoped to any one feed; only bookmarks are per-feed.

--- a/documentation/websocket-deployment.md
+++ b/documentation/websocket-deployment.md
@@ -1,0 +1,161 @@
+# WebSocket Subscription Protocol — Cloud Deployment Guide
+
+The protocol in [`websocket-protocol-spec.md`](./websocket-protocol-spec.md) must run
+behind the load balancers and ingresses of Azure, AWS, and GCP — App Service,
+Container Apps, AKS, ALB, Cloud Run, GKE, VMs, and the rest. This document records
+the platform constraints that drove the protocol's liveness and reconnection
+parameters, and gives operators a per-platform checklist. Research date: July 2026;
+all cited limits were verified against vendor documentation then — recheck before
+relying on a specific number.
+
+## 1. How platform constraints shaped the protocol
+
+Three classes of intermediary behavior matter to a long-lived multiplexed WebSocket:
+
+1. **Idle timeouts.** Every platform severs a connection that carries no bytes for
+   some window — often silently (Azure Load Balancer drops without TCP RST by
+   default). The protocol's server heartbeat (§5.6 of the spec: protocol ping +
+   `PING` frame, default every 20 s) exists to keep every surveyed idle timer fed and
+   to detect the silent drops. Non-configurable idle floors: Azure App Service ≈
+   230 s, Azure Container Apps 240 s (default ingress), Azure Front Door 5 min, AWS
+   NLB-TLS 350 s. Configurable-but-forgotten defaults are much tighter — 20–60 s
+   (§3's knob checklist).
+2. **Maximum connection lifetimes.** Some platforms cap even an active connection:
+   Cloud Run 60 min (request-timeout ceiling), App Engine flexible 1 h, AWS API
+   Gateway WebSocket APIs 2 h, Azure Front Door 4 h, GCP global external ALB 24 h.
+   The protocol's **connection lease** (§7 of the spec) turns these forced cuts into
+   planned, bookmark-resumed reconnects. Default `leaseSeconds`: **50 minutes**
+   ±10 % jitter — under every cap above, and conveniently near typical 60-minute
+   token TTLs (renew via in-band `AUTH`, §4.1). Operators on platforms with no cap
+   MAY disable the lease; the cost of keeping it is one round trip of catch-up per
+   cycle.
+3. **Drain windows.** Scale-in and deploys deliver SIGTERM with short grace:
+   Kubernetes 30 s default, Azure Container Apps 30 s fixed, ECS 30 s (Fargate max
+   120 s). Removing an endpoint from a target group stops *new* traffic only;
+   established WebSockets survive until the process dies and are then severed with
+   no close frame. Hence the spec's drain rule: on SIGTERM, stop accepting
+   upgrades, send `1012` staggered across the grace window, exit early when sockets
+   close.
+
+The heartbeat interval, watchdog, lease, and drain behavior are therefore not
+tunables to rediscover per deployment — they are derived from this matrix and safe
+everywhere; only the ingress knobs in §3 need per-platform action.
+
+## 2. Platform support matrix
+
+"Idle" = idle timeout (default → max). "Lifetime" = maximum connection lifetime even
+when active. Blank = none documented.
+
+### Azure
+
+| Platform | Enable WS | Idle | Lifetime | Notes |
+|---|---|---|---|---|
+| App Service (Windows) | `webSocketsEnabled` (default **off**) | ≈230 s, fixed | — | Idle-based: heartbeats keep it alive indefinitely. WS concurrency by SKU (Basic 350; Standard+ unlimited). ARR affinity irrelevant to WS; needed only for HTTP fallback. |
+| App Service (Linux) | always on | ≈240 s, fixed | — | Disable `perMessageDeflate` in Node (platform guidance). |
+| Container Apps | native (Envoy) | 240 s fixed; premium ingress 4→30 min | — | WS and gRPC mutually exclusive per app. Assume scale-in drops WS with only the 30 s SIGTERM grace. |
+| AKS + ingress-nginx | works via upgrade | `proxy-read/send-timeout` **60 s default** → raise | — | If exposed through an Azure LB Service, the LB's 4-min TCP idle also applies (annotation raises to 100 min; silent drop unless TCP Reset enabled). |
+| AKS + App Gateway (AGIC) | native | request timeout **20–30 s default** → max 24 h — applies to the whole WS session | ≤ request timeout | The classic "connects then dies in 30 s with code 1006" signature. 30 k WS per instance; health probes must be HTTP. |
+| Front Door Std/Premium | GA (2025); **not** on Classic | 5 min, fixed | **4 h hard** | Disable caching on WS routes; SSE not supported at all (relevant to fallback choice); 3 000 concurrent per profile. |
+| VM + Azure LB | L4 passthrough | TCP idle 4 min → 100 min | — | Silent drop by default — enable TCP Reset; heartbeats are the only detection. |
+
+### AWS
+
+| Platform | Enable WS | Idle | Lifetime | Notes |
+|---|---|---|---|---|
+| ALB | native | **60 s default** → 4 000 s | — (keep-alive attribute's applicability to upgraded WS unverified) | Any byte resets the idle timer — ping/pong suffices. Deregistration delay default 300 s; WS surviving past it are cut abruptly. Post-upgrade the connection is inherently sticky. |
+| NLB | L4 | TCP 350 s → 60–6 000 s (TLS listeners fixed 350 s) | — | RST on expiry; also check target conntrack timeouts. |
+| API Gateway (WebSocket APIs) | managed product | **10 min hard** | **2 h hard** | 32 KB frames / 128 KB messages. Poor fit for one multiplexed connection per client; prefer ALB. |
+| CloudFront | supported (HTTP/1.1) | ~10 min (community-reported, not adjustable) | — | Forward `Sec-WebSocket-*` headers via origin request policy. |
+| ECS / EKS behind ALB | via ALB | ALB rules | ALB rules | SIGTERM → `stopTimeout` 30 s (Fargate ≤ 120 s) → SIGKILL: send closes within the window. |
+| App Runner | **no WS** | — | — | Service closed to new customers (2026); target ECS instead. |
+| Elastic Beanstalk | ALB + nginx conf | instance nginx 60 s **and** ALB 60 s stack | — | Raise `proxy_read_timeout` via `.platform/nginx/conf.d/`. |
+
+### GCP
+
+| Platform | Enable WS | Idle | Lifetime | Notes |
+|---|---|---|---|---|
+| Cloud Run | native | request timeout governs | **request timeout: 5 min default → 60 min max** | An open WS is an active request: instance stays billed; counts toward concurrency (≤1000). Session affinity is best-effort only — keep the protocol stateless (it is: bookmarks). |
+| GKE + GCLB (Ingress/Gateway) | native | backend service timeout **30 s default** → raise via `BackendConfig`/`GCPBackendPolicy` `timeoutSec` | global external ALB: **24 h hard** for active WS; classic ALB: backend timeout bounds the session | GFE restarts can cut connections anytime; `drainingTimeoutSec` default 0 (off) — set it. |
+| App Engine standard | **no WS** | — | — | Use flexible or Cloud Run. |
+| App Engine flexible | native | — | **1 h hard** | Optional `session_affinity` for fallback only. |
+
+## 3. Operator checklist
+
+Per environment, before enabling the WS transport:
+
+1. **Raise the four commonly-forgotten knobs** (each defaults below the heartbeat
+   headroom): ALB `idle_timeout` (60 s → ≥ 300 s), nginx `proxy_read_timeout` /
+   `proxy_send_timeout` (60 s → ≥ 3600 s), Azure App Gateway request timeout
+   (20–30 s → ≥ 3600 s), GCLB backend `timeoutSec` (30 s → ≥ 3600 s).
+2. **Enable WS where it's a switch**: App Service Windows `webSocketsEnabled`;
+   CloudFront header forwarding; Front Door: Std/Premium only, caching off.
+3. **Align drain windows**: LB deregistration delay / `drainingTimeoutSec` ≥ the
+   server's SIGTERM grace; verify the platform's grace (30 s typical) exceeds the
+   time to send staggered `1012` closes.
+4. **Platforms with hard lifetime caps** (Cloud Run, App Engine flex, API GW, Front
+   Door): keep the connection lease at ≤ 50 min (default). Everywhere else the
+   default is still safe; disabling is an optimization.
+5. **Scale-out**: fact fan-out is in-process (`ObservableSource`), so replicas do
+   not see each other's saves. Until a pub/sub backplane exists, route all writers
+   and subscribers of a shared dataset to one replica (or run one replica). This is
+   a pre-existing constraint of the HTTP streaming path, not new to WS — but WS's
+   longer connections make it more visible. Bookmark resume keeps this safe: a
+   missed notification is healed by the next resume, never lost.
+6. **No sticky sessions needed for WS** (the TCP connection pins itself). The HTTP
+   long-poll fallback is also stateless by design (bookmarks in every request), so
+   affinity is not required there either — do not enable ARR affinity / cookie
+   stickiness for Jinaga's sake.
+
+## 4. Fallback triggers on real platforms
+
+The §8 transport-selection rules map to concrete platform failures:
+
+- **Handshake never succeeds** (no 101: Front Door Classic, App Runner, App Engine
+  standard, corporate proxies stripping `Upgrade`): falls back after
+  `wsFailureThreshold` attempts. This is the "WS is unavailable here" case.
+- **Connects, then dies within seconds repeatedly** (unraised App Gateway 20–30 s or
+  GCLB 30 s timeout — close code 1006 shortly after subscribe): also counts toward
+  the pre-healthy failure threshold because the connection never survives to
+  `stableSeconds`. The deployment fix is checklist item 1; the client meanwhile
+  degrades gracefully instead of flapping.
+- **Long-poll fallback holds must stay short (~30 s)** and be bounded server-side:
+  on Azure App Service, client aborts of streaming HTTP responses are *not reliably
+  propagated* to the app (documented in multiple Microsoft Q&A threads —
+  `res.on('close')` may never fire), so the server must bound each hold with its own
+  timer rather than trusting abort events. Note: the field report on issue #127
+  observed the same non-propagation behind Azure Container Apps ingress
+  (`Client disconnected: false` in production logs); public documentation of ACA's
+  Envoy ingress suggests aborts *should* propagate, and no public issue corroborates
+  the ACA attribution — treat ACA abort propagation as unverified either way and
+  bound holds server-side regardless. WebSocket closes, by contrast, are explicit
+  in-band frames and propagate reliably through every surveyed ingress; half-open
+  TCP drops remain detectable only by heartbeat, which the protocol provides.
+
+## 5. Parameter summary (spec defaults vs platform limits)
+
+| Parameter | Default | Binding constraint |
+|---|---|---|
+| `pingIntervalSeconds` | 20 s | ≤ 75 % of the tightest *raised* idle timer; clears the ~230 s non-configurable Azure floors ~10× over |
+| `pongTimeoutSeconds` | 30 s | server-side dead-peer bound; replaces the HTTP path's 5-minute timeout |
+| `watchdogSeconds` (client) | 45 s | ≈ 2× ping + margin (SignalR's 2× rule) |
+| `leaseSeconds` | 50 min ±10 % | Cloud Run 60 min / App Engine flex 1 h are the lowest hard caps |
+| backoff | 0–500 ms first, then full jitter to 30 s cap | ALB/Front Door reconnect storms; IANA guidance for 1012 is a 5–30 s randomized delay |
+| drain | staggered `1012` within grace | 30 s SIGTERM grace on ACA/K8s/ECS |
+| fallback hold | ~30 s per long-poll | fits under every default request timer; App Service abort non-propagation |
+
+## 6. Sources
+
+Key vendor documents verified during research (July 2026): Azure App Service
+configuration and troubleshooting (230 s idle), Azure Container Apps ingress and
+lifecycle (240 s idle, 30 s grace, premium ingress timeouts), Application Gateway
+WebSocket support and HTTP settings (request timeout applies to WS; 86 400 s max),
+Front Door WebSocket GA notes (5 min idle, 4 h cap, no SSE), Azure Load Balancer TCP
+reset/idle timeout; AWS ALB attributes (60 s idle, byte-based reset, deregistration
+delay), NLB connection idle timeout (configurable since 2024), API Gateway WS quotas
+(10 min / 2 h), CloudFront WebSocket behavior, ECS graceful shutdown; GCP Cloud Run
+WebSockets and request timeout (60 min max), Cloud Load Balancing backend-service
+timeouts (30 s default; 24 h active-WS cap on global external ALB), GKE
+BackendConfig/GCPBackendPolicy, App Engine environment comparison and flexible WS
+(1 h). Community-sourced (lower confidence, flagged above): CloudFront ~10 min WS
+idle cap; ACA scale-to-zero behavior with open WS; ALB keep-alive applicability to
+upgraded connections.

--- a/documentation/websocket-design-evaluation.md
+++ b/documentation/websocket-design-evaluation.md
@@ -1,0 +1,245 @@
+# WebSocket Subscription Design: Critical Evaluation
+
+This document critically evaluates the design in
+[`websocket-graph-integration.md`](./websocket-graph-integration.md) and the current
+implementation under `src/ws/`, against the requirements of
+[issue #127](https://github.com/jinaga/jinaga.js/issues/127) and industry practice for
+reliable WebSocket protocols. It is the motivation for the formal specification in
+[`websocket-protocol-spec.md`](./websocket-protocol-spec.md) and the plan in
+[`websocket-implementation-plan.md`](./websocket-implementation-plan.md).
+
+## 1. What the design gets right
+
+The core ideas in the existing design are sound and are retained:
+
+- **Single multiplexed connection.** One WebSocket carrying many feed subscriptions
+  eliminates the per-feed connection churn that starves servers today (issue #127,
+  field report from Azure Container Apps: ~60 lingering long-poll streams per feed).
+- **Graph protocol reuse.** Streaming facts in the `application/x-jinaga-graph-v1`
+  format ([`graph-protocol.md`](./graph-protocol.md)) preserves signatures, deduplicates
+  facts and public keys on the wire, and reuses hardened serializer/deserializer code.
+- **Bookmark-driven resume.** Feeds resume from opaque per-feed bookmarks, so a
+  reconnect is a stateless re-subscribe — no server-side session state must survive.
+- **Facts before bookmark.** The rule that `BOOK` may only follow the facts required to
+  reach it is the load-bearing ordering invariant; it makes crash recovery correct
+  (see Theorem 1 in [`websocket-protocol-spec.md`](./websocket-protocol-spec.md)).
+- **Store-level idempotence.** `save` is insert-if-absent keyed by `(type, hash)`,
+  which turns at-least-once delivery into effectively exactly-once application.
+
+## 2. Divergences between the documented protocol and the implementation
+
+The implementation in `src/ws/` and the documents disagree in ways that make the
+current docs unusable as a specification. Each divergence is resolved in the new spec.
+
+| # | Divergence | Where | Resolution in spec |
+|---|---|---|---|
+| D1 | `ACK` frame is implemented (client `src/ws/control-frame-handler.ts:29`, server `src/ws/authorization-websocket-handler.ts:187`) but appears in neither `websocket-graph-integration.md` nor `graph-protocol.md`. | code vs docs | `ACK` is specified, with a defined position in the frame order (immediately after validation, before catch-up). |
+| D2 | Framing asymmetry: the client sends one WebSocket message per line (`ws-graph-client.ts:253-264` — a `SUB` is four `send()` calls); the server sends one message per frame. Neither doc states a chunking contract. | code vs docs | The spec defines the logical stream as the concatenation of message payloads (message boundaries carry no meaning) and recommends senders align messages to frame boundaries. |
+| D3 | Deserializer batch size: docs say "batches (default 20)"; the WS client constructs `GraphDeserializer(readLine, 1)` (`ws-graph-client.ts:176`) because a WS stream has no natural end. | code vs docs | Spec states flush threshold 1 for WS transport and why. |
+| D4 | Server `handleSub` hardcodes `start = []` (`authorization-websocket-handler.ts:118`): the given facts of a feed are never resolved, so any feed whose specification requires given facts cannot be served correctly. | server gap | Feed resolution is specified to go through `FeedCache.getFeed(hash)` → `{ feed, namedStart }`, exactly as the HTTP route does (`jinaga-server` `router.ts:678`). |
+| D5 | Bookmark fabrication: `BookmarkManager.advanceBookmark` mints `Date.now():counter` tokens (`src/ws/bookmark-manager.ts:13-17`) unrelated to the store's cursor. `MemoryStore.feed` still returns an empty bookmark (TODO at `memory/memory-store.ts:98-103`). | server gap | Bookmarks are specified as the storage layer's opaque cursor — the same value the HTTP feed returns — never invented by the transport. |
+| D6 | `ERR` handling is undefined: the client only logs it (`ws-graph-client.ts:127-129`); no per-feed `onError`, no retry/fatal distinction. The old doc lists this as an open consideration. | both | `ERR` carries a structured error code; codes are partitioned into retryable and fatal, with specified client behavior for each. |
+| D7 | Redundant identity injection in both `ws-graph-client.ts:92-104` and `wsGraphNetwork.ts:36-46`. | code | Authentication is specified once, at the connection layer (§4.1 below). |
+| D8 | The BOOK-after-persist guarantee is implemented against a single `lastSavePromise` (`ws-graph-client.ts:113-126`), not per feed. Correct only because the flush threshold is 1. | code | The spec states the client-side invariant (I6) explicitly so the implementation constraint is visible and testable. |
+
+## 3. Design defects (gaps in the design itself, not just the implementation)
+
+### 3.1 The refresh-churn problem is reintroduced through the back door
+
+`Subscriber.start` installs a `setInterval` that disconnects and reconnects every
+`feedRefreshIntervalSeconds` (default 90; `src/observer/subscriber.ts:30-43`,
+`NetworkManager.ts:176`). Over the WS transport this issues `UNSUB` + `SUB` for every
+feed every 90 seconds — periodic churn on a connection whose entire purpose is to
+eliminate periodic churn. Worse, `WsGraphClient.scheduleReconnect` suppresses
+reconnection while `activeFeeds.size === 0` (`ws-graph-client.ts:230-232`), so a
+transient close during the refresh gap can leave a feed unsubscribed until the next
+timer tick.
+
+**Resolution.** Connection liveness becomes the transport's responsibility
+(heartbeats, §3.2), not the subscriber's. The `Network` contract is extended so a
+transport can declare that its streams are persistent; `Subscriber` installs the
+refresh timer only for transports that need it (HTTP long-poll). See core change C1 in
+the implementation plan.
+
+### 3.2 No liveness mechanism at all
+
+Neither the design nor the implementation has ping/pong or heartbeats. This is the
+single most important reliability gap, because it recreates the exact failure from the
+field report on issue #127: a half-open connection (ingress didn't propagate the
+peer's disconnect) looks healthy forever. Consequences today:
+
+- The server cannot distinguish a dead client from a quiet one; subscriptions and
+  inverse listeners leak until the process restarts (there is no 5-minute timeout on
+  the WS path — the one safety net the HTTP path had).
+- The client cannot detect a dead server: browsers do not surface protocol-level
+  ping/pong to JavaScript, and a dead TCP peer produces no `close` event for minutes.
+- Idle connections are silently severed by intermediary idle timeouts (commonly
+  60–240 s across cloud load balancers), and neither side notices.
+
+**Resolution.** Two complementary mechanisms, specified in §5 of the protocol spec:
+server-initiated protocol-level pings (RFC 6455 §5.5.2) for server-side dead-peer
+detection, plus an application-level `PING` frame server→client so browser clients can
+run a receive-watchdog. Intervals are chosen against the cloud platform timeout matrix
+in [`websocket-deployment.md`](./websocket-deployment.md).
+
+### 3.3 Authentication is an afterthought
+
+The implementation puts the bearer token in an `authorization` query parameter
+(`wsGraphNetwork.ts:24-29`) plus a `uid` parameter. Query strings are logged by
+proxies, load balancers, and access logs — this leaks credentials in every environment
+the user cares about (App Service, ALB, Cloud Run access logging all record URLs).
+There is also no story for token expiry on a connection that lives for hours, and no
+origin check at upgrade time.
+
+**Resolution.** Specified in §4 of the protocol spec: first-message authentication —
+the client's first frame is `AUTH token` (the pattern proven by graphql-ws's
+`ConnectionInit`), keeping credentials out of URLs, headers, and access logs
+entirely; the server enforces an auth timeout (`4408`) and derives the same
+middleware-derived identity as HTTP. Token expiry on a long-lived connection is
+handled by **in-band renewal** (re-send `AUTH` with a fresh token; no reconnect),
+and the server closes with `4401` when credentials lapse anyway. `4401` is
+fatal-with-same-token: the client must obtain a fresh token before reconnecting
+(`reauthenticate()` hook already exists on `AuthenticationProvider`).
+
+### 3.4 No protocol versioning
+
+`graph-protocol.md` explicitly states the format has no version markers. On a
+multiplexed long-lived transport that will evolve (new frame types, compression), the
+absence of negotiation means every change is a silent breaking change. WebSocket has a
+built-in negotiation mechanism — the subprotocol.
+
+**Resolution.** The client requests subprotocol `jinaga-graph-v1`; the server must
+select it or the client treats the connection as failed (this also protects against
+talking to a non-Jinaga endpoint through a misconfigured proxy). Future revisions add
+`jinaga-graph-v2` while the server keeps serving v1.
+
+### 3.5 No backpressure on either side
+
+- **Server → client:** `socket.send()` is called without ever consulting
+  `bufferedAmount`/the `ws` backpressure callback. A slow consumer (mobile client on a
+  bad network) causes unbounded buffering in the server process — the same
+  resource-exhaustion class the HTTP path suffered, relocated into memory.
+- **Client:** `pendingLines` grows without bound if store saves are slower than the
+  network delivers lines (`ws-graph-client.ts:200-226`).
+
+**Resolution.** Specified slow-consumer policy: the server suspends producing
+catch-up pages for a connection while `bufferedAmount` exceeds a high-water mark and
+closes with `4408 Slow consumer` if it stays above the mark past a deadline. This is
+safe precisely because of the resume design: a killed client reconnects and resumes
+from its last persisted bookmarks with no data loss (Theorem 1). Live-notification
+paths coalesce: while suspended, only the latest pending delta per feed is retained.
+Client-side, the receive loop stops reading (lets TCP flow control push back) rather
+than queueing unboundedly — `pendingLines` is bounded by pausing `pushChunk`
+consumption until the deserializer drains.
+
+### 3.6 Error semantics and close codes are unspecified
+
+The old doc's "Open Considerations" defers retry behavior on `ERR` vs connection
+errors; the implementation logs and continues. There is no allocation of WebSocket
+close codes, so every disconnect looks the same to the client — including ones that
+must not be retried with the same credentials (auth failure) or the same feed
+(distribution denial).
+
+**Resolution.** §6 of the protocol spec defines the full error taxonomy: per-feed
+`ERR` codes (fatal per feed: `FEED_UNKNOWN`, `DISTRIBUTION_DENIED`,
+`BOOKMARK_INVALID`; the last instructs the client to clear its bookmark and restart
+the feed from empty — the recovery path when a server is restored from backup), and
+connection close codes with the retry policy encoded in the code range (44xx fatal,
+41xx backoff, 42xx prompt — after Pusher's protocol), so even unknown future codes
+have a defined client reaction.
+
+### 3.7 Reconnection is half-designed
+
+The current backoff is `min(30s, 1s·2^n)` with a hard cap of 15 attempts and **no
+jitter** (`ws-graph-client.ts:228-243`). No jitter means synchronized reconnect storms
+after a server restart — the thundering herd that takes freshly deployed replicas back
+down. A hard attempt cap means a laptop that sleeps through 15 backoff cycles never
+reconnects. And there is no integration with Page Visibility / `online` events, which
+[`connection-lifecycle-analysis.md`](./connection-lifecycle-analysis.md) already
+identified as the top mobile gap.
+
+**Resolution.** Full-jitter exponential backoff, no attempt cap (the cap is on delay,
+not attempts), immediate reconnect on `online`/`visibilitychange`, and planned
+reconnection before platform-imposed maximum connection lifetimes ("connection
+lease"). Parameters in §7 of the protocol spec.
+
+### 3.8 Fallback to long-polling is named but not designed
+
+Issue #127's acceptance criteria require long-polling fallback. The old design says
+`WsGraphNetwork` delegates `fetchFeed`/`load` to HTTP but never says when the client
+gives up on WS for `streamFeed`. Corporate proxies and some ingress configurations
+break WS while HTTP works; without a designed fallback, those users get no
+subscriptions at all.
+
+**Resolution.** A transport-selection layer (§8 of the protocol spec): try WS; if the
+connection fails before ever becoming healthy N consecutive times (default 3), fall
+back to the existing HTTP `streamFeed` path for all feeds; re-probe WS periodically
+(default every 5 minutes) and migrate back when it succeeds. Once a WS connection has
+been healthy, connection loss goes through backoff, not fallback — distinguishing
+"WS is broken here" from "the network blipped" is what keeps behavior stable.
+
+### 3.9 Server integration gaps (jinaga-server)
+
+The design document describes server behavior against the `Authorization` interface,
+but the shipped handler misses the parts that make the HTTP path correct. The HTTP
+`streamFeed` (`jinaga-server` `router.ts:699-848`) does four things the WS handler
+does not:
+
+1. **Paged initial drain** — `streamAllInitialResults` pages through the store
+   until the bookmark stabilizes; the WS handler does a single `authorization.feed`
+   call, silently truncating catch-up to one page.
+2. **Given-fact resolution** via `FeedCache` (D4 above).
+3. **Anchor listeners** for subscriptions whose given fact hasn't arrived yet
+   (jinaga.js#129).
+4. **Distribution intersection** (`verifyDistributionOrIntersect`, jinaga.js#130) —
+   the WS path only supports the all-or-nothing distribution check.
+
+In addition, fan-out relies on the in-process `ObservableSource`; that constraint
+(subscriptions see only saves that arrive through the same process) must be documented
+as a deployment constraint until a pub/sub layer exists, and it interacts with cloud
+scale-out (see [`websocket-deployment.md`](./websocket-deployment.md)).
+
+**Resolution.** The WS `handleSub` is specified to reuse the same building blocks as
+the HTTP route — `FeedCache.getFeed`, `SubscriptionAuthorizer.feedWithDistribution` /
+`feedPreVerified`, paged drain, inverse + anchor listeners — so the two transports
+cannot drift. The implementation plan sequences this as a refactor-to-shared-core
+before the WS handler lands in jinaga-server.
+
+### 3.10 No graceful shutdown
+
+Nothing sends a close frame on deploy/scale-in. Cloud platforms deliver SIGTERM with a
+grace period (typically 30 s); a server that just dies strands every client in
+half-open state until their watchdogs fire.
+
+**Resolution.** On drain, the server stops accepting upgrades, sends close code
+`1012 (Service Restart)` to every connection — staggered across the drain window so
+the reconnect wave is spread — and exits when sockets are closed or the grace period
+elapses. Clients reconnect after a uniformly random delay (no backoff growth),
+because the fleet is restarting, not failing.
+
+## 4. Evaluation against issue #127 acceptance criteria
+
+| Acceptance criterion | Old design + current code | With this revision |
+|---|---|---|
+| Client can establish a WS connection for subscriptions | ✅ works | ✅ plus versioned subprotocol and upgrade-time auth |
+| Server pushes new matching facts in real time | ⚠️ works for feeds without given facts, single page only | ✅ full parity with HTTP path (paged drain, anchors, intersection) |
+| Resilient to interruptions; reestablishes subscriptions | ⚠️ backoff without jitter, capped attempts, no liveness detection, churned by refresh timer | ✅ heartbeats, watchdog, uncapped jittered backoff, lifecycle events, connection lease |
+| Fallback to long polling remains available | ❌ not designed | ✅ transport selection with re-probe |
+
+## 5. Summary of protocol changes proposed
+
+Relative to the wire format the code implements today:
+
+1. `ACK` is documented and moved to immediately after validation (before catch-up).
+2. `ERR` gains a machine-readable error code line: `ERR / feed / code / message`.
+3. New server→client `PING` frame (empty payload); new client→server `PONG`.
+4. New client→server `AUTH` frame (first-message authentication with in-band
+   renewal); subprotocol negotiation `jinaga-graph-v1`; no token in the query string.
+5. Close-code allocation with range-encoded retry policy (44xx/41xx/42xx).
+6. Bookmarks are store cursors; `BOOKMARK_INVALID` error resets a feed.
+7. Framing contract stated explicitly (byte-stream semantics; alignment recommended).
+
+Everything else — graph blocks, `SUB`/`UNSUB`/`BOOK` shapes, facts-before-BOOK — is
+unchanged from the current implementation, deliberately: the migration cost of items
+1–7 is one coordinated minor release of `jinaga` and `jinaga-server`, before any
+external deployment of the WS transport exists.

--- a/documentation/websocket-design-evaluation.md
+++ b/documentation/websocket-design-evaluation.md
@@ -124,7 +124,7 @@ talking to a non-Jinaga endpoint through a misconfigured proxy). Future revision
 
 **Resolution.** Specified slow-consumer policy: the server suspends producing
 catch-up pages for a connection while `bufferedAmount` exceeds a high-water mark and
-closes with `4408 Slow consumer` if it stays above the mark past a deadline. This is
+closes with `4101 Slow consumer` if it stays above the mark past a deadline. This is
 safe precisely because of the resume design: a killed client reconnects and resumes
 from its last persisted bookmarks with no data loss (Theorem 1). Live-notification
 paths coalesce: while suspended, only the latest pending delta per feed is retained.

--- a/documentation/websocket-graph-integration.md
+++ b/documentation/websocket-graph-integration.md
@@ -1,3 +1,14 @@
+> **Status: superseded.** This early design sketch has been superseded by the formal
+> specification and supporting documents:
+> [`websocket-protocol-spec.md`](./websocket-protocol-spec.md) (wire grammar, state
+> machines, invariants, proofs),
+> [`websocket-design-evaluation.md`](./websocket-design-evaluation.md) (critical
+> evaluation of this design and the `src/ws/` prototype),
+> [`websocket-implementation-plan.md`](./websocket-implementation-plan.md) (TDD plan),
+> and [`websocket-deployment.md`](./websocket-deployment.md) (cloud deployment).
+> It is retained for historical context; where it disagrees with the specification,
+> the specification wins.
+
 ## WebSocket Graph Transport: Single-Connection Multiplexed Design
 
 ### Goals

--- a/documentation/websocket-implementation-plan.md
+++ b/documentation/websocket-implementation-plan.md
@@ -1,0 +1,261 @@
+# WebSocket Subscription Protocol — Test-Driven Implementation Plan
+
+This plan implements the protocol in
+[`websocket-protocol-spec.md`](./websocket-protocol-spec.md) across **jinaga.js**
+(client + shared codec) and **jinaga-server** (server), replacing the prototype under
+`src/ws/`. Every phase starts with tests derived from the spec's invariants (the
+tags — W1, C3, S4, T1 … — refer to §10–§12 of the spec). A phase is done when its
+tests pass and all previous phases' tests still pass.
+
+## Guiding decisions
+
+1. **Code placement.** The wire codec (frame parser/emitter, graph integration) and
+   the client live in `jinaga.js`. The server handler moves to `jinaga-server`: it
+   needs `ws`, `FeedCache`, and `SubscriptionAuthorizer`, all of which live there.
+   `jinaga.js` stops exporting `AuthorizationWebSocketHandler`, `BookmarkManager`,
+   and `InverseSpecificationEngine` (currently exported but unusable without the
+   server's building blocks — and `BookmarkManager` fabricates bookmarks, violating
+   S2).
+2. **Shared conformance fixtures.** A set of golden wire transcripts (text files:
+   valid streams, malformed streams, chunk-split variants) lives in
+   `jinaga.js/test/ws/fixtures/` and is copied verbatim into jinaga-server's test
+   tree. Both sides must parse/emit identically; the fixtures are the cross-repo
+   contract.
+3. **Deterministic tests.** All timing behavior (pings, watchdogs, backoff, lease)
+   is driven through an injectable clock/timer so tests use fake timers; no test
+   sleeps. All randomness (jitter) through an injectable RNG.
+4. **The existing prototype is scaffolding.** `src/ws/protocol-router.ts`,
+   `control-frame-handler.ts`, `ws-graph-client.ts`, `wsGraphNetwork.ts` are
+   rewritten in place, keeping names where the responsibility is unchanged. Existing
+   tests (`test/ws/*Spec.ts`) are ported to the new frame order (ACK before data) in
+   Phase 1 and extended, not deleted.
+
+---
+
+## Part A — jinaga.js (client and codec)
+
+### Phase A1 — Frame codec (parser + emitter)
+
+Rewrite `protocol-router.ts` as a pure, transport-independent codec:
+`FrameReader` (push chunks in, complete frames out) and `FrameWriter`.
+
+Tests first (`test/ws/frameCodecSpec.ts`):
+
+- Golden parse of every frame type incl. `PING`/`PONG` and 3-payload `ERR` [W2].
+- **Chunk invariance property test**: for each golden transcript, parse results are
+  identical for every re-chunking (byte-by-byte, random splits, all-in-one) [W1, T3].
+- Partial trailing frame retained across pushes; completed on next chunk [W1].
+- Unknown uppercase keyword skipped through blank line (forward compat, §3).
+- Malformed input (non-keyword non-JSON line, binary flag, oversized line) → single
+  fatal codec error, not silent skip [§6.2 `4400` path].
+- Interleaving: control frames never split fact blocks; graph lines pass through to
+  the graph sink untouched (fixtures with PK decls between blocks).
+- Emitter golden tests: emitted bytes match fixtures exactly, one frame per message
+  (sender alignment, §1).
+
+### Phase A2 — Connection state machine
+
+New `ws-connection.ts`: owns socket lifecycle, negotiation, liveness, backoff —
+no feed knowledge. Consumes the codec; exposes `connect/close/send`, `onFrame`,
+`onEpoch` (new connection generation), `onDegrade`.
+
+Tests (`test/ws/connectionSpec.ts`, fake timers, mock WebSocket):
+
+- Subprotocol: offers `jinaga-graph-v1`; rejects connection whose accepted
+  subprotocol differs → transport failure, not backoff [§2].
+- AUTH-first: `AUTH` emitted as the first frame when credentials exist; SUBs
+  pipelined immediately after; in-band renewal re-sends `AUTH` before token expiry
+  without dropping the connection [§4.1].
+- Watchdog: no inbound frame for `watchdogSeconds` → close + reconnect [W10, L3].
+- `PING` frame answered with `PONG`; any inbound frame resets the watchdog [§5.6].
+- Backoff: full jitter within `[0, min(30s, 2ⁿs)]` via injected RNG; `n` resets
+  after 30 s stable or first ACK; no attempt cap (attempt 50 still schedules) [§7].
+- Immediate-reconnect triggers: `online`, `visibilitychange→visible`, close 1001,
+  close 1012 — all skip the pending delay [§7]; Node build registers none of the
+  browser listeners (environment isolation).
+- Close-code matrix [§6.2]: 4401 → calls `reauthenticate()` before next attempt and
+  does not retry if it fails; 4403 → degrade signal; range classification — unknown
+  44xx fatal, 41xx backoff (4129 with doubled base), 42xx prompt.
+- Lease: planned reconnect at `leaseSeconds` (default 50 min) ±10 % jitter; new
+  epoch announced; feeds resume seamlessly; configurable off [§7].
+- No reconnect while no feeds subscribed; connect on first subscribe [§7].
+
+### Phase A3 — Subscription multiplexer
+
+New `ws-subscriptions.ts`: per-feed FSM (§10.2) over the connection, plus the graph
+sink → store pipeline.
+
+Tests (`test/ws/subscriptionSpec.ts`):
+
+- SUB sent with persisted bookmark on subscribe; exactly one SUB per feed per epoch;
+  epoch change resends the full subscribed set [C3].
+- ACK resolves feed start; frames for unknown/unsubscribed feeds ignored [W9 client
+  side, §5.2].
+- ERR taxonomy [§6.1]: `DISTRIBUTION_DENIED`/`FEED_UNKNOWN` → feed Failed, error
+  surfaced to observer path, no resubscribe; `INTERNAL` → resubscribe with backoff;
+  `BOOKMARK_INVALID` → bookmark reset to `""`, single resubscribe, second failure
+  fatal; unknown code treated as `INTERNAL`.
+- **Persist-before-advance**: facts delivered, then BOOK — bookmark saved only after
+  `store.save` resolves; with a store whose `save` is delayed, BOOK processing awaits
+  it [C1, C4]. Crash-injection variant: simulated teardown between save and
+  saveBookmark, then resubscribe re-receives facts, store converges [T1].
+- Bookmark never regresses across reconnect storms (property test with random
+  disconnect injection) [C2].
+- Dedup: same fact arriving in two feeds / two epochs saved once; observer notified
+  once (store-delta driven) [T2].
+- UNSUB sent on unsubscribe; late BOOK after UNSUB ignored without error [W9].
+
+### Phase A4 — Network integration and the Subscriber core change
+
+Rewrite `wsGraphNetwork.ts` on top of A2/A3; make the minimal core changes:
+
+- **C1 (core):** `Network` gains `readonly persistentStreams?: boolean`.
+  `Subscriber` installs its refresh `setInterval` only when the network does **not**
+  declare persistent streams; reconnection is then entirely the transport's job.
+  (`src/observer/subscriber.ts`, `src/managers/NetworkManager.ts`.)
+- Auth: token provided once via connection layer (subprotocol); remove the duplicate
+  `uid`/`authorization` query injection from both files [D7, §4.1].
+
+Tests (`test/observer/subscriberSpec.ts` additions, `test/ws/wsNetworkSpec.ts`):
+
+- With `persistentStreams: true`, no interval is created; `stop()` still tears down
+  [T6]. With HTTP network, existing refresh behavior unchanged (regression).
+- `streamFeed` bridge: BOOK → `onResponse([], bookmark)`; existing empty-reference
+  bookmark-advance handling in `Subscriber` covered by regression tests.
+- Existing `test/ws/graphWebSocketSpec.ts` E2E ported: subscribe → facts persisted →
+  bookmark advanced; extended with reconnect-and-resume against a restartable stub
+  server [C3, T1].
+
+### Phase A5 — Transport selection and fallback
+
+New `transport-selector.ts` implementing §8.
+
+Tests (`test/ws/fallbackSpec.ts`):
+
+- No `WebSocket` global → HTTP path used, no error.
+- 3 consecutive pre-Open failures → all feeds on HTTP long-poll (existing
+  `streamFeed`), refresh timer active for them; WS probe every `probeIntervalSeconds`;
+  probe success migrates feeds back make-before-break (HTTP stream torn down only
+  after WS ACK) [§8].
+- Close 4403 → immediate degrade, no probe retry of WS with same identity.
+- After a connection has been Open once, repeated losses stay in backoff (never
+  degrade) [§8.4].
+
+### Phase A6 — Client backpressure
+
+- Receive loop pauses socket consumption while the store pipeline is busy (bounded
+  buffer), resumes on drain [§9].
+
+Tests: slow store stub → buffered line count stays under bound; no facts lost;
+ordering preserved [§9, C4].
+
+---
+
+## Part B — jinaga-server
+
+### Phase B0 — Extract the shared subscription core (refactor, no behavior change)
+
+Extract from `src/http/router.ts` into a transport-neutral `FeedSubscriptionCore`:
+feed resolution (`FeedCache.getFeed`), distribution check / intersection
+(`SubscriptionAuthorizer`), **paged initial drain** (`streamAllInitialResults`),
+inverse-listener + **anchor-listener** registration, delta production per
+notification. The HTTP streaming route is re-implemented on the core.
+
+Tests first: characterize current HTTP behavior with the existing integration tests
+plus new ones (paged drain > 1 page; anchor listener fires when given fact arrives
+late; intersection path) so the refactor is provably behavior-preserving. This
+closes D4/D5 and gaps §3.9(1–4) once for both transports.
+
+Change relative to today's code, spec-mandated: listeners attach **before** the
+drain, with notification queueing during catch-up [S3]; add test: fact saved between
+first and last drain page is delivered exactly once [S3, L2, T2].
+
+### Phase B1 — Upgrade endpoint, negotiation, identity
+
+Add `ws` dependency. New `src/ws/upgrade.ts`: `noServer` WebSocketServer +
+`server.on('upgrade')` handler exported from `JinagaServer` as
+`attachWebSocket(httpServer, options)`; `JinagaServer.create` additionally exposes
+the objects the handler needs (authorization, feedCache, factManager listeners).
+
+Tests (`test/ws/upgradeSpec.ts`, real `http.Server` on ephemeral port):
+
+- Subprotocol echo `jinaga-graph-v1`; missing/foreign offer → 400/close 1002 [§2].
+- First-message auth: `AUTH` validated via the host-supplied token hook; identity
+  bound = same `UserIdentity` the HTTP middleware would produce; bad token → close
+  4401 before pipelined SUBs are processed; no `AUTH` within `authTimeoutSeconds`
+  when auth required → close 4408; in-band renewal rebinds credentials, identity
+  change → 4401 [§4.1].
+- Origin allow-list enforced when cookie auth enabled [§4.1].
+
+### Phase B2 — Server subscription handler on the shared core
+
+New `src/ws/handler.ts` replacing the prototype `AuthorizationWebSocketHandler`:
+per-connection context (identity, subscriptions, serializer dedup state), SUB/UNSUB
+processing per §5.1–§5.2, honest bookmarks from the store [S2] (delete
+`BookmarkManager`).
+
+Tests (`test/ws/handlerSpec.ts` + shared fixtures):
+
+- Frame order per subscription: ACK → (graph* BOOK)* [W7]; ERR codes for unknown
+  feed / denial [§6.1]; given facts resolved via FeedCache (feed with given fact
+  serves correct results — the D4 regression test).
+- Multi-page catch-up: each page graph*+BOOK, strictly advancing store cursors
+  [W8, S2, T4]; page-cap → `ERR INTERNAL`.
+- Cross-feed dedup: two overlapping feeds on one connection, shared facts sent once
+  [W5]; PK density and topological order asserted by running the client codec over
+  captured output [W3, W4].
+- Distribution-denied feed leaks nothing even when another feed on the same
+  connection is allowed the same facts — assert S1 by construction: sends go through
+  a per-feed authorization check.
+- UNSUB and connection close detach every listener; listener count returns to
+  baseline (hook into `ObservableSource` counts) [S4, T5].
+
+### Phase B3 — Liveness and drain
+
+- Server protocol ping every `pingIntervalSeconds`; reap on pong silence
+  [L3]; app-level `PING` frame when output idle [W10].
+- SIGTERM → stop accepting upgrades, close all with 1012 staggered across the drain
+  window, exit on close-or-grace [§3.10 of the evaluation].
+
+Tests: fake-timer reap test (dead socket's listeners removed within bound — the
+issue #127 regression test) [T5]; drain test asserts 1012 received and process exits
+before grace expiry.
+
+### Phase B4 — Backpressure
+
+- Pause catch-up while `bufferedAmount > highWaterMark`; coalesce live deltas per
+  feed while paused; close 4101 after `slowConsumerSeconds` [§9].
+
+Tests: throttled socket → catch-up pauses (memory bounded), resumes on drain;
+sustained stall → 4101; reconnect-and-resume recovers all facts [§9, T1].
+
+### Phase B5 — Cross-repo integration and chaos
+
+In jinaga-server (which depends on the published/linked jinaga package):
+
+- Full-stack test: `JinagaServer.create` + `attachWebSocket` + real jinaga client
+  (`JinagaBrowser.create({ httpEndpoint, wsEndpoint })`) over loopback: subscribe,
+  save on server, observe on client; latency has no polling component [T6].
+- Resume: kill server mid-stream, restart, client reconnects and converges [T1, L4].
+- **Chaos test** (single seed-reproducible run): N feeds, random saves, random
+  disconnects/server restarts/slow-consumer injections for M virtual minutes; assert
+  final client store equals server projection per feed, bookmarks monotone, listener
+  baseline restored [T1, T2, C2, T5].
+- Fallback E2E: WS endpoint blocked → client converges via HTTP long-poll; unblock →
+  probe migrates back [§8].
+
+### Rollout
+
+1. Ship jinaga.js first (codec, client, `persistentStreams`, fallback) — inert
+   without a WS endpoint; long-poll behavior unchanged (regression suites A4).
+2. Ship jinaga-server with `attachWebSocket` opt-in; replicator image enables it
+   behind config.
+3. Enable in a staging replicator; verify with the deployment checklist in
+   [`websocket-deployment.md`](./websocket-deployment.md) (per-platform ingress
+   config); watch the issue #127 metrics (lingering streams, login latency).
+4. Default `wsEndpoint` on in clients once server releases are current; long-poll
+   remains the automatic fallback (§8), satisfying the last acceptance criterion of
+   issue #127.
+
+Deferred (tracked, out of scope): horizontal fan-out across server replicas
+(pub/sub for `ObservableSource`), permessage-deflate evaluation, binary framing v2.

--- a/documentation/websocket-protocol-spec.md
+++ b/documentation/websocket-protocol-spec.md
@@ -1,0 +1,628 @@
+# Jinaga WebSocket Subscription Protocol — Formal Specification
+
+Version: `jinaga-graph-v1` (draft). Status: specification for implementation; the wire
+format extends the format currently implemented under `src/ws/` as described in
+[`websocket-design-evaluation.md`](./websocket-design-evaluation.md) §5.
+
+This document defines the protocol precisely enough that each requirement is
+verifiable: every normative statement is tied to an invariant (§10) and every
+invariant to a test obligation (§12). Correctness arguments are in §11.
+
+Requirement keywords MUST / MUST NOT / SHOULD / MAY are per RFC 2119.
+
+---
+
+## 1. Overview and layering
+
+A client multiplexes many **feed subscriptions** over a single WebSocket connection.
+The server streams **facts** (in the graph format of
+[`graph-protocol.md`](./graph-protocol.md)) interleaved with **control frames**.
+Per-feed progress is tracked by opaque, durable **bookmarks**; a reconnect is a
+stateless re-subscribe from the last persisted bookmarks.
+
+```
+┌────────────────────────────────────────────────────────┐
+│ Layer 3  Subscription semantics (feeds, bookmarks)     │
+│ Layer 2  Frames (SUB/UNSUB/ACK/BOOK/ERR/PING/PONG,     │
+│          graph blocks)                                 │
+│ Layer 1  Line stream (JSON lines, blank-line framing)  │
+│ Layer 0  WebSocket (RFC 6455), text messages           │
+└────────────────────────────────────────────────────────┘
+```
+
+**Byte-stream semantics (Layer 0→1).** In each direction, the logical character
+stream is the concatenation of the payloads of all text messages, in order. WebSocket
+message boundaries carry **no protocol meaning**: a frame MAY span messages and a
+message MAY contain several frames. Receivers MUST reassemble by buffering.
+Senders SHOULD align messages to frame boundaries (one frame per message) for
+debuggability, but receivers MUST NOT rely on it.
+
+Binary messages MUST NOT be sent in v1; a receiver MUST close with `4400` on
+receiving one.
+
+**Delivery model.** The protocol provides **at-least-once** delivery of facts with
+**exactly-once application**, because facts are content-addressed (`(type, hash)`) and
+persistence is insert-if-absent (Theorem T2). Duplicates across reconnects are
+expected and harmless.
+
+## 2. Connection establishment and negotiation
+
+1. The client opens a WebSocket to the server's subscription endpoint
+   (`{httpEndpoint with ws(s) scheme}/ws`).
+2. The client MUST request subprotocol `jinaga-graph-v1` via
+   `Sec-WebSocket-Protocol`. The server MUST select it. If the accepted subprotocol
+   is absent or different, the client MUST close with `1002` and treat the attempt as
+   a **transport failure** (§8), not a retryable network error. This guards against
+   proxies that terminate WS but do not speak this protocol.
+3. A connection is **Open** after a successful upgrade with the negotiated
+   subprotocol. Authentication happens in-band as the first frame (§4.1).
+
+Future protocol revisions define new subprotocol tokens (`jinaga-graph-v2`); a client
+MAY offer several; the server selects the newest it supports.
+
+## 3. Wire grammar
+
+The grammar is given in ABNF (RFC 5234). Terminals `json-string` and `json-object`
+are JSON values per RFC 8259, serialized with no embedded unescaped newlines.
+
+```abnf
+; ---- Layer 1: lines -------------------------------------------------
+EOL             = [CR] LF                ; receivers accept CRLF, emit LF
+blank           = EOL                    ; an empty line: frame terminator
+
+; ---- Layer 2: the two directional streams ---------------------------
+client-stream   = *client-frame
+client-frame    = auth / sub / unsub / pong
+
+server-stream   = *server-frame
+server-frame    = ack / book / err / ping / graph-block
+
+; ---- Client → server frames ------------------------------------------
+auth            = %s"AUTH"   EOL token-line blank
+sub             = %s"SUB"    EOL feed-line bookmark-line blank
+unsub           = %s"UNSUB"  EOL feed-line blank
+pong            = %s"PONG"   EOL blank
+
+; ---- Server → client frames ------------------------------------------
+ack             = %s"ACK"    EOL feed-line blank
+book            = %s"BOOK"   EOL feed-line bookmark-line blank
+err             = %s"ERR"    EOL feed-line code-line message-line blank
+ping            = %s"PING"   EOL blank
+
+; ---- Graph blocks (unchanged from graph-protocol.md) ------------------
+graph-block     = pk-declaration / fact-block
+pk-declaration  = %s"PK" pk-index EOL json-string EOL blank
+fact-block      = type-line pred-line field-line *signature blank
+type-line       = json-string EOL        ; fact type
+pred-line       = json-object EOL        ; role → index | index[]
+field-line      = json-object EOL        ; fields
+signature       = %s"PK" pk-index EOL json-string EOL
+
+; ---- Payload lines ----------------------------------------------------
+feed-line       = json-string EOL        ; feed identifier (URL-safe hash)
+bookmark-line   = json-string EOL        ; opaque bookmark; "" = beginning
+token-line      = json-string EOL        ; bearer credential
+code-line       = json-string EOL        ; error code, §6.1
+message-line    = json-string EOL        ; human-readable description
+pk-index        = 1*DIGIT
+```
+
+**Lexical disjointness.** The first line of every frame determines its type:
+
+| First line matches | Frame |
+|---|---|
+| `AUTH`, `SUB`, `UNSUB`, `PONG`, `ACK`, `BOOK`, `ERR`, `PING` (exact) | that control frame |
+| `PK` followed by digits | public-key declaration (or, inside a fact block, a signature line) |
+| begins with `"` (a JSON string) | fact block |
+
+These sets are pairwise disjoint: control keywords are unquoted; JSON strings begin
+with `"`; `PK`-lines begin with `PK`. A single line of lookahead therefore suffices
+(Theorem T3). Unknown all-uppercase keywords (`ALPHA` up to 16 chars alone on a line)
+MUST be skipped with their payload through the next blank line — this is the v1
+forward-compatibility rule for frame types added in minor revisions. Any other
+unparseable line is a protocol error: close with `4400`.
+
+**Graph block rules** (restating [`graph-protocol.md`](./graph-protocol.md), which
+remains authoritative for block content):
+
+- PK indexes are declared densely, in order (0, 1, 2, …), each before first use.
+- Predecessor indexes refer to fact blocks earlier on **this connection** (indexes are
+  per-connection, reset at reconnect).
+- Control frames never appear inside a block; blocks are never split by frames.
+
+## 4. Authentication and authorization
+
+### 4.1 First-message authentication (`AUTH`)
+
+Browsers cannot set an `Authorization` header on a WebSocket, and tokens in query
+strings leak into access logs (OWASP WebSocket guidance). The protocol therefore
+authenticates **in-band**, following the pattern proven by graphql-ws
+(`ConnectionInit` / `connectionInitWaitTimeout`):
+
+- The client's first frame after open MUST be `AUTH token` when it has credentials.
+  The client MAY pipeline `SUB` frames immediately after `AUTH` without waiting for
+  a response — silence is success; on failure the server closes with `4401` before
+  processing the pipelined frames.
+- If the deployment requires authentication and no `AUTH` arrives within
+  `authTimeoutSeconds` (default **10 s**) of open, the server closes with `4408`.
+  Deployments permitting anonymous access process `SUB` frames without `AUTH`.
+- **In-band renewal**: the client MAY send `AUTH` again at any time with a fresh
+  token (e.g., shortly before expiry, from `AuthenticationProvider`). The server
+  rebinds the credential without dropping the connection — a long-lived connection
+  never needs to churn just because a token expired. If the identity (subject)
+  changes, the server MUST instead close with `4401`; subscriptions authorized for
+  one identity never continue under another.
+- The server derives the same `UserIdentity` an HTTP request would (in
+  jinaga-server, the host app supplies a token-validation hook equivalent to its
+  HTTP middleware) and binds it to the connection.
+- Cookie authentication MAY be used where the app already relies on it; the server
+  MUST then enforce an `Origin` allow-list at upgrade to prevent cross-site
+  WebSocket hijacking. `Origin` checks are hijacking mitigation, never
+  authentication.
+- If credentials expire mid-connection and renewal does not occur, the server
+  closes with `4401`; the client refreshes its token before reconnecting.
+
+### 4.2 During the connection
+
+- Every `SUB` is authorized: the server resolves the feed and enforces distribution
+  rules for the bound identity (jinaga-server:
+  `SubscriptionAuthorizer.feedWithDistribution` / `verifyDistributionOrIntersect`).
+  Denial produces `ERR` with code `DISTRIBUTION_DENIED`; the connection stays open.
+- Every fact serialized to the connection MUST be authorized for distribution to the
+  bound identity under at least one active subscription (invariant S1).
+- If the identity's credentials expire without in-band renewal (§4.1) and the
+  deployment requires revocation, the server closes with `4401`. The client MUST
+  refresh credentials (`AuthenticationProvider.reauthenticate()`) before
+  reconnecting.
+
+## 5. Frame semantics and ordering
+
+### 5.1 SUB (client → server)
+
+`SUB feed bookmark` requests a subscription to `feed` resuming after `bookmark`
+(`""` means from the beginning). For each feed, at most one subscription exists per
+connection; a `SUB` for an already-subscribed feed replaces the bookmark only if the
+subscription is not yet acknowledged, otherwise it is ignored (idempotence).
+
+Server processing order for a valid `SUB` (normative):
+
+1. **Resolve** the feed hash to `{ specification, namedStart }` (jinaga-server:
+   `FeedCache.getFeed`). Unknown → `ERR FEED_UNKNOWN`.
+2. **Authorize** distribution (§4.2). Denied → `ERR DISTRIBUTION_DENIED`.
+3. **Acknowledge**: send `ACK feed`. From this point until removal, the server may
+   send graph blocks and `BOOK` frames for this feed (invariant W7).
+4. **Attach listeners** for the feed's inverse specifications and anchor facts
+   **before** the catch-up read (invariant S3). Notifications arriving during
+   catch-up are queued and processed after it; duplicates are absorbed by wire-level
+   dedup and store idempotence.
+5. **Catch up**: page through the store from `bookmark`; for each page, send the
+   facts (graph blocks, deduplicated per connection) then `BOOK feed pageBookmark`.
+   Repeat until the bookmark stabilizes.
+6. **Live**: on each queued or subsequent notification, send the delta's facts then
+   `BOOK feed newBookmark`.
+
+If the client's bookmark is not a valid cursor for this feed (server restored from
+backup, feed re-keyed), the server sends `ERR BOOKMARK_INVALID`; the client resets its
+persisted bookmark to `""` and re-subscribes.
+
+### 5.2 UNSUB (client → server)
+
+Removes the subscription and its listeners. The server MUST NOT initiate new frames
+for the feed after processing `UNSUB`, but frames already in flight may still arrive;
+the client MUST ignore frames for feeds it has no Pending/Active subscription for
+(invariant C-ignore, W9 tolerance). `UNSUB` for an unknown feed is a no-op.
+
+### 5.3 ACK (server → client)
+
+Confirms that the subscription is validated and attached. Exactly one `ACK` per
+accepted `SUB` (per connection epoch). The client uses `ACK` to resolve subscription
+start-up and to arm per-feed failure handling.
+
+### 5.4 BOOK (server → client)
+
+`BOOK feed bookmark` asserts: *all facts required for `feed` up to `bookmark`, that
+were not already covered by the client's subscribed-from bookmark, have appeared
+earlier in this connection's stream* (invariant W6). Bookmarks for a feed advance
+monotonically within a connection (W8) and are exactly the storage layer's cursor
+values (S2) — the transport never fabricates them.
+
+Client processing: persist all facts received so far, **then** persist the bookmark
+(invariants C1/C4), then notify the local subscriber (`onResponse([], bookmark)`).
+
+### 5.5 ERR (server → client)
+
+`ERR feed code message` reports a per-feed failure; the connection remains open and
+other feeds are unaffected. Codes and required client reactions are in §6.1. After a
+fatal `ERR`, the server removes the subscription (as if `UNSUB` were received).
+
+### 5.6 PING / PONG (liveness)
+
+Two complementary mechanisms:
+
+- **Protocol-level ping (RFC 6455)**: the server sends a protocol ping every
+  `pingIntervalSeconds` (default **20 s**) on an otherwise idle connection. Browser
+  and `ws` peers answer pongs automatically. If no pong (or any other traffic)
+  arrives within `pongTimeoutSeconds` (default **30 s**) of a ping, the server MUST
+  close the socket (`1011` or TCP abort) and release all subscriptions. This is the
+  server's half-open detection and replaces the HTTP path's 5-minute timeout.
+- **Application-level PING (server → client)**: browsers cannot observe protocol
+  pings, so the server also sends a `PING` frame whenever it has sent no frame for
+  `pingIntervalSeconds`. The client answers with `PONG` (which doubles as inbound
+  traffic for the server's check, making protocol pings redundant where app frames
+  flow). The client runs a **receive watchdog**: if no frame of any kind arrives for
+  `watchdogSeconds` (default **45 s** ≈ 2×ping + margin), the client MUST assume the
+  connection is dead, close it, and reconnect via §7.
+
+The 20 s cadence is chosen to sit safely under the most aggressive common
+intermediary idle timeouts (see [`websocket-deployment.md`](./websocket-deployment.md)
+for the platform matrix); both values are configurable.
+
+### 5.7 Frame ordering summary (per feed, one connection epoch)
+
+```
+SUB → ( ERR fatal )
+    | ( ACK → { graph* BOOK }* → [ ERR fatal ] )      with UNSUB possible anytime
+```
+
+Graph blocks belonging to different feeds interleave freely; facts are deduplicated
+per connection, so a fact "belonging" to two feeds is sent once, before the first
+`BOOK` that needs it.
+
+## 6. Errors and close codes
+
+### 6.1 Per-feed error codes (`ERR`)
+
+| Code | Meaning | Client reaction |
+|---|---|---|
+| `FEED_UNKNOWN` | Feed hash not resolvable | Fatal for feed: re-derive feeds via `feeds()` (HTTP), then re-subscribe |
+| `DISTRIBUTION_DENIED` | Distribution rules deny this user | Fatal for feed: surface to observer's error path; do not retry with same identity |
+| `BOOKMARK_INVALID` | Bookmark is not a valid cursor | Reset persisted bookmark to `""`, re-subscribe (once; repeated failure is fatal) |
+| `INTERNAL` | Transient server failure for this feed | Retryable: re-subscribe with backoff |
+
+Unknown codes MUST be treated as `INTERNAL` (retryable) — forward compatibility.
+
+### 6.2 Connection close codes
+
+Application codes use the RFC 6455 private range (4000–4999) and encode the retry
+policy in the code's hundreds digit (after Pusher's protocol): **44xx = fatal with
+the same inputs**, **41xx = transient, reconnect with full backoff**, **42xx =
+reconnect promptly (jitter only)**. Unknown codes are classified by range — the
+forward-compatibility rule for close codes.
+
+| Code | Sender | Meaning | Client reaction |
+|---|---|---|---|
+| `1000` | either | Normal close (client stopped, no active feeds) | none |
+| `1001` | server | Endpoint going away (scale-in) | reconnect after `random(0, cap)` |
+| `1012` | server | Service restart / drain | reconnect after `random(0, cap)` — the fleet is restarting; spreading the herd matters more than latency |
+| `1013` | server | Try again later | reconnect with full backoff |
+| `1002` | either | WebSocket protocol error | as `4400` |
+| **44xx — fatal** | | | |
+| `4400` | either | Jinaga protocol violation (malformed frame, binary message, oversized frame) | do not blind-retry; count toward transport failure (§8); report |
+| `4401` | server | Unauthenticated (invalid/expired token, identity change on renewal) | refresh token, then retry once; without a fresh token, surface |
+| `4403` | server | Forbidden (identity may not use the WS transport) | fall back to HTTP transport (§8); do not retry WS |
+| `4408` | server | Authentication timeout (no `AUTH` within `authTimeoutSeconds`, §4.1) | retry with credentials ready before connecting |
+| `4413` | server | Message too big (client frame exceeded cap, §9) | do not retry; client bug |
+| **41xx — transient, full backoff** | | | |
+| `4100` | server | Overloaded / shedding load | full-jitter backoff |
+| `4101` | server | Slow consumer (backpressure overflow, §9) | full-jitter backoff; resume covers the gap |
+| `4129` | server | Too many connections/subscriptions | full-jitter backoff with doubled base |
+| **42xx — reconnect promptly** | | | |
+| `4200` | server | Generic "please reconnect" | immediate + small jitter |
+
+All state needed to resume lives in the client's store (bookmarks) — every close is
+recoverable by the resume path; the codes only tune *when and how* to retry.
+
+## 7. Reconnection and resume
+
+- **Backoff**: the first retry after a loss is fast (`random(0, 500 ms)` — most
+  drops are transient blips), then full-jitter exponential:
+  `delay = random(0, min(cap, base·2ⁿ))` with `base = 1 s`, `cap = 30 s`,
+  `n` = consecutive failed attempts. No attempt cap. `n` resets when a connection
+  has been Open for `stableSeconds` (default 30 s) or on the first `ACK` —
+  never merely on open, or a flapping link churns at full speed.
+- **Immediate reconnect triggers** (skip remaining delay, keep `n`): browser `online`
+  event; `visibilitychange` to visible; close code `4200`. Close codes
+  `1001`/`1012` reconnect after `random(0, cap)` (§6.2) so a restarting fleet is not
+  met by a synchronized reconnect wave.
+- **Resume**: on (re)open, the client sends `SUB` for every feed that is subscribed
+  locally, using the **last persisted bookmark** of each (invariant C3). Predecessor
+  and PK indexes reset with the connection; the server's dedup set also resets, so
+  some facts may be re-sent — absorbed by idempotence (T2).
+- **Connection lease**: the client bounds each connection's lifetime to
+  `leaseSeconds` (default **50 minutes**, ±10 % jitter). At lease expiry it performs
+  a planned reconnect (close `1000`, then connect and resume) — turning
+  platform-imposed lifetime caps (Cloud Run 60 min, App Engine flex 1 h, Front Door
+  4 h…) into graceful bookmark-resumed handoffs instead of abrupt cuts, and aligning
+  with typical token TTLs. Deployments without lifetime caps MAY disable it; the
+  cost of keeping it is one round trip of catch-up per cycle. See
+  [`websocket-deployment.md`](./websocket-deployment.md).
+- The client MUST NOT reconnect while it has no subscribed feeds, and MUST connect
+  on the first subscription.
+
+## 8. Transport selection and graceful degradation
+
+The client maintains a transport preference per endpoint:
+
+1. **WS preferred**: if `WebSocket` is available, try WS for `streamFeed`.
+2. **Fallback trigger**: if `wsFailureThreshold` (default 3) consecutive connection
+   attempts fail **before any connection reaches Open with the correct subprotocol**,
+   or the server closed with `4403`, switch all feeds to the HTTP long-poll
+   `streamFeed` (the existing `HttpNetwork` path, including its refresh timer).
+3. **Re-probe**: while degraded, retry a WS connection every `probeIntervalSeconds`
+   (default 300 s). On success, migrate feeds back to WS (HTTP streams are torn down
+   after the WS subscriptions ACK — make-before-break).
+4. Once a WS connection has ever been healthy on this endpoint, subsequent losses go
+   through §7 backoff, **not** fallback: a broken network is not a broken transport.
+5. The client SHOULD persist the last successful transport per endpoint (the
+   socket.io `rememberUpgrade` pattern) so a returning client skips the failure
+   dance.
+
+`feeds()`, `fetchFeed()` (backfill), and `load()` always use HTTP regardless of the
+streaming transport.
+
+## 9. Flow control and backpressure
+
+- **Server → client**: before writing catch-up pages, the server checks the socket's
+  buffered amount. If it exceeds `highWaterMark` (default 1 MiB), the server pauses
+  catch-up for that connection until drained. Live-notification deltas coalesce per
+  feed while paused (only the newest pending bookmark's delta is kept — earlier facts
+  are re-derivable from the store on the next page). If the buffer stays above the
+  mark for `slowConsumerSeconds` (default 60 s), the server closes with `4101`.
+  Disconnect — not drop — is the correct slow-consumer policy for this protocol:
+  dropping frames would corrupt a feed, while a disconnected client resumes from its
+  bookmarks losslessly (Theorem T1).
+- **Client → server**: the client's receive loop MUST NOT buffer unboundedly; it
+  stops consuming WebSocket messages while the deserializer/store pipeline is busy
+  (letting TCP flow control push back on the server) rather than queueing lines
+  without limit.
+- **Message size**: servers SHOULD cap inbound messages (default 1 MiB, enforced
+  cumulatively across fragments) — client frames are tiny; anything larger closes
+  with `4413`.
+
+## 10. State machines and invariants
+
+### 10.1 Client connection state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Connecting : first subscribe()
+    Connecting --> Open : upgrade ok, subprotocol jinaga-graph-v1
+    Connecting --> Backoff : error / wrong subprotocol / close
+    Connecting --> Degraded : failure threshold reached (§8)
+    Open --> Backoff : close / watchdog timeout
+    Open --> Connecting : lease expiry (planned reconnect)
+    Backoff --> Connecting : delay elapsed / online / visible / 1001 / 1012
+    Backoff --> Degraded : failure threshold reached (never Open yet)
+    Degraded --> Connecting : probe timer (§8.3)
+    Open --> Idle : last unsubscribe (close 1000)
+    Backoff --> Idle : last unsubscribe
+    Degraded --> Idle : last unsubscribe
+    Idle --> [*] : stop()
+```
+
+State variables: `activeFeeds: Map<feed, {bookmark, state}>`, `attempt n`,
+`epoch` (increments per Open), `lastInboundAt` (watchdog), transport preference.
+
+### 10.2 Client per-feed state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unsubscribed
+    Unsubscribed --> Pending : subscribe → send SUB(bookmark)
+    Pending --> Active : ACK
+    Pending --> Failed : ERR (fatal code)
+    Active --> Active : graph blocks persisted; BOOK → persist bookmark, notify
+    Active --> Failed : ERR (fatal code)
+    Active --> Pending : ERR INTERNAL → resubscribe (backoff)
+    Pending --> Pending : connection epoch change → resend SUB(persisted bookmark)
+    Active --> Pending : connection epoch change → resend SUB(persisted bookmark)
+    Pending --> Unsubscribed : unsubscribe → send UNSUB (if Open)
+    Active --> Unsubscribed : unsubscribe → send UNSUB
+    Failed --> Unsubscribed : unsubscribe / error surfaced
+    Failed --> Pending : BOOKMARK_INVALID → reset bookmark, resubscribe once
+```
+
+Frames referencing feeds in `Unsubscribed`/`Failed` are ignored (UNSUB race
+tolerance).
+
+### 10.3 Server connection state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Upgrading
+    Upgrading --> Open : subprotocol selected
+    Open --> Open : AUTH binds/renews identity; SUB/UNSUB/PONG processed; pings on schedule
+    Open --> Closed : AUTH invalid → 4401 / auth timeout → 4408
+    Open --> Draining : SIGTERM / deploy → close 1012, staggered across connections
+    Open --> Closed : pong timeout / protocol error 4400 / slow consumer 4101 / client close
+    Draining --> Closed : socket closed or grace period elapsed
+    Closed --> [*] : all listeners removed (S4)
+```
+
+Connection context: bound `UserIdentity`, `subscriptions: Map<feed, SubState>`,
+per-connection serializer state (fact index map, PK index map = dedup sets),
+`bufferedAmount` watermark state, ping timer.
+
+### 10.4 Server per-subscription state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Validating : SUB received
+    Validating --> Denied : unknown feed / distribution denied → ERR, remove
+    Validating --> CatchingUp : ACK sent, listeners attached (S3)
+    CatchingUp --> CatchingUp : page → graph* + BOOK (bookmark advances)
+    CatchingUp --> Live : bookmark stable; replay queued notifications
+    Live --> Live : notification → graph* + BOOK
+    CatchingUp --> Removed : UNSUB / connection closed → detach listeners
+    Live --> Removed : UNSUB / connection closed → detach listeners
+    Denied --> [*]
+    Removed --> [*]
+```
+
+### 10.5 Invariants
+
+**Wire invariants** (checkable by observing one direction of one connection):
+
+- **W1 (Prefix parseability).** Every finite prefix of the logical stream parses to a
+  sequence of complete frames plus at most one incomplete trailing frame.
+- **W2 (Determinism).** The first line of a frame uniquely determines its production
+  in the grammar (§3 lexical disjointness).
+- **W3 (PK density).** The k-th `pk-declaration` on a connection carries index k−1;
+  every `PK` reference is to an already-declared index.
+- **W4 (Topological order).** Every predecessor index in a fact block is the index of
+  an earlier fact block on the connection.
+- **W5 (Wire dedup).** No two fact blocks on one connection have the same
+  `(type, hash)`.
+- **W6 (Facts before BOOK).** For every `BOOK f b`: every fact in the feed-delta of
+  `f` from the subscription's starting bookmark to `b` appears as a fact block
+  earlier in the stream.
+- **W7 (ACK first).** For each subscription epoch of feed f, `ACK f` precedes every
+  graph block sent on behalf of f and every `BOOK f _`; only `ERR f _` may occur
+  instead.
+- **W8 (Bookmark monotonicity).** Within a subscription epoch, successive `BOOK f bᵢ`
+  carry strictly advancing store cursors.
+- **W9 (Relevance).** The server emits `ACK`/`BOOK`/`ERR` only for feeds with a
+  subscription in {Validating, CatchingUp, Live} (frames in flight across an `UNSUB`
+  are excused; the client ignores them).
+- **W10 (Ping cadence).** While Open, the gap between consecutive server frames
+  (any type) never exceeds `pingIntervalSeconds` + scheduling slack.
+
+**Client-state invariants:**
+
+- **C1 (Persist before advance).** The client persists a bookmark `b` for feed `f`
+  only after every fact received before the corresponding `BOOK f b` has been
+  persisted to the store.
+- **C2 (No regression).** The persisted bookmark of a feed never moves backward,
+  except to `""` on `BOOKMARK_INVALID`.
+- **C3 (Faithful resume).** On each connection epoch, the client sends exactly one
+  `SUB f b` for every locally subscribed feed f, where b is f's persisted bookmark.
+- **C4 (Receive-order barrier).** Fact persistence and bookmark persistence for a
+  connection are applied in stream order (a `BOOK` never overtakes the facts that
+  preceded it).
+
+**Server-state invariants:**
+
+- **S1 (Authorized distribution).** Every fact block sent is authorized for the
+  connection's bound identity under some subscription in {CatchingUp, Live} at send
+  time.
+- **S2 (Honest bookmarks).** Every bookmark in a `BOOK` is a cursor value returned by
+  the storage layer for that feed; the transport never synthesizes bookmarks.
+- **S3 (Listeners before read).** Inverse and anchor listeners are attached before
+  the catch-up read begins; notifications during catch-up are queued, not dropped.
+- **S4 (No leaks).** When a subscription reaches Removed/Denied, or the connection
+  reaches Closed, all listeners attached for it are removed; when a connection
+  closes, its dedup sets and buffers are released.
+
+**Liveness properties** (under fairness: messages sent on a live connection are
+eventually delivered; the store eventually serves reads):
+
+- **L1.** Every `SUB` on a connection that stays Open is answered by `ACK` or `ERR`.
+- **L2.** Every fact saved at the server that matches a Live subscription is
+  eventually followed on the connection by that fact and a `BOOK` covering it — or
+  the connection closes.
+- **L3.** A half-open connection is detected within `pongTimeoutSeconds` +
+  `pingIntervalSeconds` by the server and within `watchdogSeconds` by the client.
+- **L4 (Eventual delivery).** Across arbitrary connect/disconnect sequences, every
+  fact in a subscribed feed is eventually persisted at the client, provided the
+  client retries indefinitely (§7) and the server remains available infinitely often.
+
+## 11. Correctness arguments
+
+**Theorem T1 (No lost facts).** *Under W6, W8, S2, S3, C1–C4, every fact in a
+subscribed feed's delta is eventually persisted by the client (L4).*
+
+*Proof sketch.* Consider feed f with persisted client bookmark b₀. By C3, each
+connection epoch opens with `SUB f b₀`. By S2 and W8 the server's `BOOK` sequence
+b₁ < b₂ < … enumerates store cursors; by W6 all facts in (b₀, bᵢ] precede `BOOK f bᵢ`
+on the wire. By C4/C1 the client persists those facts before persisting bᵢ, so at
+every moment the persisted bookmark under-approximates persisted facts. Failure
+cases: (i) crash after facts persisted, before bookmark persisted — next epoch resumes
+from b₀ and re-receives the facts; duplicates absorbed (T2); (ii) crash mid-block —
+the partial block was never persisted and is re-sent; (iii) missed live notification
+impossible while Live by S3 (listeners precede the read, queue during catch-up);
+(iv) connection loss anywhere — reduces to case (i) by induction on epochs, which
+terminates because each epoch either advances the persisted bookmark (finite delta by
+T4) or the retry discipline (§7) starts a new epoch. ∎
+
+**Theorem T2 (Exactly-once application).** *Facts are applied to the client store at
+most once, hence delivery is effectively exactly-once.*
+
+*Proof sketch.* A fact's identity is `(type, hash)` where hash is recomputed from
+content on deserialization (`computeHash`), so identity is content-derived and
+transport-independent. Store `save` is insert-if-absent on that key, merging only
+signatures. Within one connection W5 already prevents duplicates; across connections
+re-sends hit the insert-if-absent guard. Observer notification fires only for facts
+the store reports as newly added, so downstream effects also occur once. ∎
+
+**Theorem T3 (Deterministic single-pass parsing).** *The grammar of §3 is parseable
+by a deterministic single-pass line reader with one line of lookahead, and W1 holds.*
+
+*Proof sketch.* Frame type is decided by the first line (W2, lexical disjointness).
+Each production is a fixed count of lines terminated by a blank line except
+`fact-block`'s `*signature`, disambiguated line-by-line: after the field line, a line
+starting `PK` is a signature, a blank line ends the block. No production is a prefix
+of another with the same first line. Buffering until the terminating blank line gives
+W1: incomplete input is exactly one partial frame retained in the buffer. ∎
+
+**Theorem T4 (Catch-up terminates).** *For a fixed store state, the CatchingUp phase
+of a subscription completes in finitely many pages.*
+
+*Proof sketch.* The delta between the subscribed bookmark and the store's current
+head is finite. Each page either strictly advances the cursor (W8/S2, so progress in
+a finite chain) or returns an unchanged bookmark, which is the exit condition. Saves
+that occur during catch-up are handled by queued notifications (S3) after the phase
+exits, so they cannot extend it unboundedly. A page-count backstop (as in the HTTP
+path's 1000-page cap) turns pathological store behavior into `ERR INTERNAL` rather
+than an infinite loop. ∎
+
+**Theorem T5 (No resource leaks).** *Every listener attached by a subscription is
+detached in finite time after the subscription ends.*
+
+*Proof sketch.* Listeners are attached only in Validating→CatchingUp (S3). Every
+path out of CatchingUp/Live (UNSUB, fatal ERR, connection close) runs the detach
+(S4). Connection death without a close frame is detected by L3 (server pong timeout),
+which triggers the same close path. Hence the leak window is bounded by
+`pingIntervalSeconds + pongTimeoutSeconds`. This is the property whose absence caused
+the production incident in issue #127. ∎
+
+**Theorem T6 (Bounded staleness).** *While a connection is Open and healthy, a fact
+saved at the server for a Live feed is visible to the client within notification +
+serialization + one round trip; there is no polling interval in the latency path.*
+Follows from L2 with the push pipeline; the periodic-refresh path is eliminated for
+WS transports (core change C1 in the implementation plan).
+
+## 12. Conformance test obligations
+
+Every invariant maps to at least one required test (detailed in
+[`websocket-implementation-plan.md`](./websocket-implementation-plan.md)):
+
+| Invariant | Test obligation (summary) |
+|---|---|
+| W1/W2/T3 | Parser golden tests; fuzzed chunk-boundary re-splits of valid streams; property test: parse(concat(chunks)) independent of chunking |
+| W3–W5 | Serializer round-trip + duplicate-fact injection across feeds |
+| W6/C1/C4 | Interleaving test: BOOK withheld until dependent facts persisted; crash-injection between save and saveBookmark |
+| W7 | Server unit: no graph/BOOK before ACK per subscription |
+| W8/S2 | Bookmark sequence strictly advancing; equals store cursors |
+| W9 | UNSUB race: late frames ignored without error |
+| W10/L3 | Fake-timer tests: ping cadence, watchdog fires, server reaps dead peer |
+| C2 | Reconnect storm property test: persisted bookmark monotone |
+| C3 | Reconnect resends exactly the subscribed set with persisted bookmarks |
+| §4.1 | AUTH-first ordering; auth timeout → 4408; in-band renewal keeps connection; identity change → 4401 |
+| S1 | Distribution-denied feed never leaks facts (negative test) |
+| S3/L2 | Save during catch-up is delivered (no-gap test) |
+| S4/T5 | Listener count returns to baseline after UNSUB/close/kill |
+| L1 | Every SUB answered under fault injection |
+| T1/T2/L4 | End-to-end chaos test: random disconnects, duplicate delivery, final store equality |
+| T4 | Multi-page catch-up terminates; page-cap produces ERR INTERNAL |
+| §6 | Close-code matrix: client reaction per code and per range class (token refresh on 4401, fallback on 4403, backoff on 41xx, prompt on 42xx, unknown codes by range) |
+| §8 | Transport fallback: N failures → HTTP; probe migrates back; healthy-loss ≠ fallback |
+| §9 | Slow-consumer: catch-up pauses at watermark; 4101 after deadline; client resumes losslessly |
+
+---
+
+*Related documents:*
+[`graph-protocol.md`](./graph-protocol.md) (graph block format, authoritative),
+[`websocket-design-evaluation.md`](./websocket-design-evaluation.md) (rationale),
+[`websocket-implementation-plan.md`](./websocket-implementation-plan.md) (TDD plan),
+[`websocket-deployment.md`](./websocket-deployment.md) (cloud platform guidance).

--- a/documentation/websocket-protocol-spec.md
+++ b/documentation/websocket-protocol-spec.md
@@ -210,7 +210,8 @@ persisted bookmark to `""` and re-subscribes.
 Removes the subscription and its listeners. The server MUST NOT initiate new frames
 for the feed after processing `UNSUB`, but frames already in flight may still arrive;
 the client MUST ignore frames for feeds it has no Pending/Active subscription for
-(invariant C-ignore, W9 tolerance). `UNSUB` for an unknown feed is a no-op.
+(the per-feed FSM ignore rule, §10.2; this is the client-side tolerance that makes
+W9's in-flight exception safe). `UNSUB` for an unknown feed is a no-op.
 
 ### 5.3 ACK (server → client)
 


### PR DESCRIPTION
## Summary

Documentation-only PR for #127 (improve subscription performance and reliability with WebSockets). It critically evaluates the existing WebSocket design and `src/ws/` prototype, replaces the informal design sketch with a formal, verifiable protocol specification, and lays out a test-driven implementation plan spanning this repository and jinaga-server.

### New documents

- **`documentation/websocket-design-evaluation.md`** — what the current design gets right; eight documented-vs-implemented divergences (undocumented `ACK`, fabricated bookmarks, `start = []`, framing asymmetry…); ten design defects with resolutions (refresh-timer churn reintroduced over WS, no liveness mechanism, token-in-query-string auth, no versioning, no backpressure, unspecified error/close semantics, jitterless capped backoff, undesigned long-poll fallback, server parity gaps, no graceful drain).
- **`documentation/websocket-protocol-spec.md`** — the formal `jinaga-graph-v1` spec: ABNF wire grammar with a lexical-disjointness argument; first-message `AUTH` with in-band token renewal (graphql-ws pattern); server ping + application `PING`/watchdog liveness; range-encoded close codes (44xx fatal / 41xx backoff / 42xx prompt); full-jitter reconnection with bookmark resume and a 50-minute connection lease; transport fallback rules; backpressure policy; four state machines (client/server × connection/feed); **18 invariants** and **6 theorems** with proof sketches (no lost facts, exactly-once application, deterministic parsing, catch-up termination, no listener leaks, bounded staleness); a conformance table mapping every invariant to a test obligation.
- **`documentation/websocket-implementation-plan.md`** — TDD plan: six phases in jinaga.js (frame codec → connection FSM → subscription multiplexer → `Network`/`Subscriber` core change → fallback → backpressure) and six in jinaga-server (extract a transport-neutral subscription core from the HTTP router first — paged drain, inverse + anchor listeners, distribution intersection — then upgrade/auth, handler, liveness/drain, backpressure, cross-repo chaos tests). Shared golden wire fixtures are the cross-repo contract; every test is tagged with the invariant it verifies.
- **`documentation/websocket-deployment.md`** — Azure/AWS/GCP constraint matrix (App Service, Container Apps, AKS ingresses, App Gateway, Front Door, ALB/NLB, API Gateway, CloudFront, ECS, Cloud Run, GKE/GCLB, App Engine): idle timeouts, hard connection-lifetime caps, and drain windows from which the heartbeat (20 s), watchdog (45 s), lease (50 min), and staggered-1012 drain defaults are derived; operator checklist of the four commonly-forgotten ingress knobs; fallback triggers on real platforms.

### Updated documents

- `websocket-graph-integration.md` — marked superseded, pointing at the new set.
- `graph-protocol.md` — WebSocket transport section now defers to the spec as authoritative (graph block format unchanged).

### Notable design decisions (vs the current prototype)

1. `ACK` documented and reordered to precede catch-up; `ERR` gains a machine-readable code (`FEED_UNKNOWN`, `DISTRIBUTION_DENIED`, `BOOKMARK_INVALID`, `INTERNAL`).
2. Credentials move out of the query string into a first-message `AUTH` frame with in-band renewal, so long-lived connections survive token expiry.
3. Liveness by server-initiated pings plus a client receive-watchdog — the half-open-connection failure from the #127 field report becomes detectable on both sides within a bounded window (Theorem T5).
4. Bookmarks are exclusively store cursors; the transport never fabricates them.
5. The `Subscriber` refresh timer is scoped to non-persistent transports (`Network.persistentStreams`), eliminating periodic UNSUB/SUB churn over WS.
6. Slow consumers are disconnected, not throttled by unbounded buffering — safe because resume is lossless (Theorem T1).
7. Long-poll fallback is specified (failure threshold, periodic re-probe, make-before-break migration), satisfying the last acceptance criterion of #127.

Refs #127. Server-side counterpart tracked for jinaga-server (cross-refs jinaga-server#85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJkE9rNcVBdqQYqXn1YY9Q