### PR TITLE
Distribution diagnostics: thread decisions through NetworkManager + queryWithDiagnostics (#207 W4/W8b)

### DIFF
--- a/src/http/httpNetwork.ts
+++ b/src/http/httpNetwork.ts
@@ -10,12 +10,14 @@ export class HttpNetwork implements Network {
         private readonly webClient: WebClient
     ) { }
 
-    async feeds(start: FactReference[], specification: Specification): Promise<string[]> {
+    async feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse> {
         const declarationString = describeDeclaration(start, specification.given.map(g => g.label));
         const specificationString = describeSpecification(specification, 0);
         const request = `${declarationString}\n${specificationString}`;
+        // Return the full response so the NetworkManager can capture the
+        // replicator's per-feed distribution decisions (issue #207 W4).
         const response: FeedsResponse = await this.webClient.feeds(request);
-        return response.feeds;
+        return response;
     }
 
     async fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export { GraphSerializer, serializeGraph } from "./http/serializer";
 export { HttpConnection, HttpResponse, SyncStatus, SyncStatusNotifier, WebClient } from "./http/web-client";
 export * as driver from './indexeddb/driver';
 export { IndexedDBQueue } from './indexeddb/indexeddb-queue';
-export { Fact, Jinaga, MakeObservable, Profile } from './jinaga';
+export { DistributionDiagnostic, Fact, Jinaga, MakeObservable, Profile } from './jinaga';
 export { JinagaBrowser, JinagaBrowserConfig } from "./jinaga-browser";
 export { JinagaTest, JinagaTestConfig } from "./jinaga-test";
 export { FactManager } from "./managers/factManager";

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -1,18 +1,68 @@
 import { Authentication } from "./authentication/authentication";
+import { DistributionDenialCode } from './distribution/distribution-engine';
 import { dehydrateReference, Dehydration, HashMap, hashSymbol, hydrate, hydrateFromTree, lookupHash } from './fact/hydrate';
+import { FeedDecision } from './http/messages';
 import { SyncStatus, SyncStatusNotifier } from './http/web-client';
 import { FactManager } from './managers/factManager';
 import { User } from './model/user';
 import { ObservableCollection, Observer, ResultAddedFunc } from './observer/observer';
+import { describeSpecification } from './specification/description';
 import { FactConstructor, SpecificationOf } from './specification/model';
 import { Projection } from './specification/specification';
 import { detectDisconnectedSpecification } from "./specification/UnionFind";
 import { FactEnvelope, FactReference, ProjectedResult } from './storage';
 import { toJSON } from './util/obj';
 import { Trace } from './util/trace';
-    
+
 export interface Profile {
     displayName: string;
+}
+
+/**
+ * A developer-facing distribution diagnostic (issue #207). Emitted for a feed
+ * that the replicator marked `reactive` or `denied`; authorized feeds produce
+ * none.
+ *
+ * The single load-bearing field is `reactive`. When `true`, the decision is the
+ * subscription race — the feed is denied for the current user *right now* but
+ * will self-heal once the authorizing fact arrives — and must NEVER be treated
+ * as fatal. When `false`, the denial is structural (a missing or narrowed-past
+ * rule, or a principal the rule excludes) and will not self-heal on its own.
+ *
+ * `code` is optional because a `reactive` decision need not carry one (the
+ * replicator may report the pending case without a denial code); a `denied`
+ * decision always carries one.
+ */
+export interface DistributionDiagnostic {
+    operation: 'query' | 'watch' | 'subscribe';
+    specification: string;            // describeSpecification(...)
+    decision: 'reactive' | 'denied';
+    code?: DistributionDenialCode;
+    reactive: boolean;                // true => will self-heal; NEVER treat as fatal
+    reason: string;
+}
+
+/**
+ * Map the replicator's per-feed decisions (issue #207 W4) to developer-facing
+ * diagnostics. Only `denied` and `reactive` feeds produce a diagnostic;
+ * `authorized` feeds are silent. Old replicators report no decisions, so this
+ * yields an empty array and the new APIs are inert.
+ */
+function toDistributionDiagnostics(
+    operation: DistributionDiagnostic['operation'],
+    specification: string,
+    decisions: FeedDecision[]
+): DistributionDiagnostic[] {
+    return decisions
+        .filter(d => d.decision === 'denied' || d.decision === 'reactive')
+        .map(d => ({
+            operation,
+            specification,
+            decision: d.decision as 'reactive' | 'denied',
+            code: d.code,
+            reactive: d.decision === 'reactive',
+            reason: d.reason
+        }));
 }
 
 export type MakeObservable<T> =
@@ -151,6 +201,48 @@ export class Jinaga {
         const extracted = extractResults(projectedResults, innerSpecification.projection);
         Trace.counter("facts_loaded", extracted.totalCount);
         return extracted.results;
+    }
+
+    /**
+     * Execute a query and return, alongside the results, the distribution
+     * diagnostics correlated to this exact fetch (issue #207 W8b). This is the
+     * one-shot, correlated channel deliberate callers (e.g. the factual MCP)
+     * use to distinguish "denied by distribution" from "authorized but empty"
+     * in a single call — without a `POST /feeds/explain` endpoint.
+     *
+     * Unlike `query`, this never throws on a distribution decision. A `reactive`
+     * decision (the subscription race — the current user is not yet authorized
+     * but the feed will self-heal when the authorizing fact arrives) is reported
+     * as a diagnostic, not an error; the results stay silently empty. Against an
+     * old replicator that omits decisions, `diagnostics` is always empty.
+     *
+     * @param specification Use Model.given().match() to create a specification
+     * @param given The fact or facts from which to begin the query
+     * @returns A promise resolving to the projected results and the diagnostics
+     */
+    async queryWithDiagnostics<T extends unknown[], U>(specification: SpecificationOf<T, U>, ...given: T): Promise<{ results: U[]; diagnostics: DistributionDiagnostic[] }> {
+        const innerSpecification = specification.specification;
+
+        detectDisconnectedSpecification(innerSpecification);
+
+        if (!given || given.some(g => !g)) {
+            return { results: [], diagnostics: [] };
+        }
+        if (given.length !== innerSpecification.given.length) {
+            throw new Error(`Expected ${innerSpecification.given.length} given facts, but received ${given.length}.`);
+        }
+
+        const references = given.map(g => this.prepareFactReference(g));
+        const decisions = await this.factManager.fetch(references, innerSpecification);
+        const projectedResults = await this.factManager.read(references, innerSpecification);
+        const extracted = extractResults(projectedResults, innerSpecification.projection);
+        Trace.counter("facts_loaded", extracted.totalCount);
+        const diagnostics = toDistributionDiagnostics(
+            'query',
+            describeSpecification(innerSpecification, 0),
+            decisions
+        );
+        return { results: extracted.results, diagnostics };
     }
 
     /**

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -236,6 +236,18 @@ class LoadBatch {
  * downstream diagnostic channel inert. This is the single choke point the
  * instance hook (W5), the observer (W6), and `queryWithDiagnostics` (W8b) all
  * draw from.
+ *
+ * Both fields are cached under the same specification key. Feed hashes are
+ * deterministic in the specification, but decisions depend on the requester's
+ * authorization state and can change over time — most notably a `reactive`
+ * feed becoming `authorized` once the authorizing fact arrives. Caching the
+ * decision keeps a non-self-healing denial (`denied`) reported on repeated
+ * calls, which is correct; the only staleness is a `reactive` decision that
+ * should stop being reported once data begins to flow. Clearing a diagnostic
+ * on that transition is W9's responsibility (re-emit only on transition; fire
+ * a clearing diagnostic when a `reactive`/`denied` feed starts delivering),
+ * which is deferred to a later tranche. Within a single `queryWithDiagnostics`
+ * call the decisions are correlated to that fetch's specification and start.
  */
 export interface CachedFeeds {
     feeds: string[];

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -1,5 +1,5 @@
 import { DistributionEngine, DistributionIntersectionBranch } from "../distribution/distribution-engine";
-import { FeedResponse } from "../http/messages";
+import { FeedDecision, FeedResponse, FeedsResponse } from "../http/messages";
 import { Subscriber } from "../observer/subscriber";
 import { describeDeclaration, describeSpecification } from "../specification/description";
 import { buildFeeds } from "../specification/feed-builder";
@@ -10,7 +10,14 @@ import { computeStringHash } from "../util/encoding";
 import { Trace } from "../util/trace";
 
 export interface Network {
-    feeds(start: FactReference[], specification: Specification): Promise<string[]>;
+    /**
+     * Request the feed hashes for a specification from the replicator's
+     * `POST /feeds`. The response carries the feed hashes and, from
+     * replicator 3.7.0 onward, the per-feed distribution `decisions`
+     * (issue #207). Old replicators omit `decisions`, which degrades
+     * gracefully to no diagnostics.
+     */
+    feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse>;
     fetchFeed(feed: string, bookmark: string): Promise<FeedResponse>;
     streamFeed(feed: string, bookmark: string, onResponse: (factReferences: FactReference[], nextBookmark: string) => Promise<void>, onError: (err: Error) => void, feedRefreshIntervalSeconds: number): () => void;
     load(factReferences: FactReference[]): Promise<FactEnvelope[]>;
@@ -28,8 +35,8 @@ export interface Network {
 }
 
 export class NetworkNoOp implements Network {
-    feeds(start: FactReference[], specification: Specification): Promise<string[]> {
-        return Promise.resolve([]);
+    feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse> {
+        return Promise.resolve({ feeds: [] });
     }
 
     fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
@@ -67,7 +74,7 @@ export class NetworkDistribution implements Network {
         private readonly user: FactReference | null
     ) { }
 
-    async feeds(start: FactReference[], specification: Specification): Promise<string[]> {
+    async feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse> {
         const feeds = buildFeeds(specification);
         const namedStart = specification.given.reduce((map, given, index) => ({
             ...map,
@@ -87,7 +94,10 @@ export class NetworkDistribution implements Network {
                 throw new Error(`Not authorized: ${canDistribute.reason}`);
             }
         }
-        return feedHashes;
+        // The in-process engine either authorizes (returns the feed hashes) or
+        // throws above; it does not surface per-feed decisions. Diagnostics
+        // originate from the real replicator's `POST /feeds` response.
+        return { feeds: feedHashes };
     }
 
     async fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
@@ -219,8 +229,21 @@ class LoadBatch {
     }
 }
 
+/**
+ * The feed hashes for a specification together with the replicator's per-feed
+ * distribution decisions (issue #207 W4). `decisions` is empty when the
+ * replicator does not report them (old replicators), which makes every
+ * downstream diagnostic channel inert. This is the single choke point the
+ * instance hook (W5), the observer (W6), and `queryWithDiagnostics` (W8b) all
+ * draw from.
+ */
+export interface CachedFeeds {
+    feeds: string[];
+    decisions: FeedDecision[];
+}
+
 export class NetworkManager {
-    private readonly feedsCache = new Map<string, string[]>();
+    private readonly feedsCache = new Map<string, CachedFeeds>();
     private readonly activeFeeds = new Map<string, Promise<void>>();
     private fetchCount = 0;
     private currentBatch: LoadBatch | null = null;
@@ -236,9 +259,15 @@ export class NetworkManager {
         this.feedRefreshIntervalSeconds = feedRefreshIntervalSeconds || 90; // Default to 90 seconds
     }
 
-    async fetch(start: FactReference[], specification: Specification) {
+    /**
+     * Fetch all feeds for a specification and return the replicator's per-feed
+     * distribution decisions correlated to this exact fetch (issue #207 W4).
+     * Callers that don't need diagnostics (plain `query`/`watch`) ignore the
+     * return value; `queryWithDiagnostics` (W8b) maps it to diagnostics.
+     */
+    async fetch(start: FactReference[], specification: Specification): Promise<FeedDecision[]> {
         const reducedSpecification = reduceSpecification(specification);
-        const feeds: string[] = await this.getFeedsFromCache(start, reducedSpecification);
+        const { feeds, decisions } = await this.getFeedsFromCache(start, reducedSpecification);
 
         // Fork to fetch from each feed.
         const promises = feeds.map(feed => {
@@ -259,6 +288,7 @@ export class NetworkManager {
             this.removeFeedsFromCache(start, reducedSpecification);
             throw e;
         }
+        return decisions;
     }
 
     async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
@@ -270,7 +300,7 @@ export class NetworkManager {
 
     async subscribe(start: FactReference[], specification: Specification): Promise<string[]> {
         const reducedSpecification = reduceSpecification(specification);
-        const feeds: string[] = await this.getFeedsFromCache(start, reducedSpecification);
+        const { feeds } = await this.getFeedsFromCache(start, reducedSpecification);
 
         const subscribers = feeds.map(feed => {
             let subscriber = this.subscribers.get(feed);
@@ -311,15 +341,21 @@ export class NetworkManager {
         }
     }
 
-    private async getFeedsFromCache(start: FactReference[], specification: Specification): Promise<string[]> {
+    private async getFeedsFromCache(start: FactReference[], specification: Specification): Promise<CachedFeeds> {
         const hash = getSpecificationHash(start, specification);
         const cached = this.feedsCache.get(hash);
         if (cached) {
             return cached;
         }
-        const feeds = await this.network.feeds(start, specification);
-        this.feedsCache.set(hash, feeds);
-        return feeds;
+        const response = await this.network.feeds(start, specification);
+        // Old replicators omit `decisions`; normalize to an empty array so every
+        // downstream diagnostic channel is simply inert rather than undefined.
+        const cachedFeeds: CachedFeeds = {
+            feeds: response.feeds,
+            decisions: response.decisions ?? []
+        };
+        this.feedsCache.set(hash, cachedFeeds);
+        return cachedFeeds;
     }
 
     private removeFeedsFromCache(start: FactReference[], specification: Specification) {

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -3,6 +3,7 @@ import { computeHash } from "../fact/hash";
 import { Fork } from "../fork/fork";
 import { PersistentFork } from "../fork/persistent-fork";
 import { DistributionIntersectionBranch } from "../distribution/distribution-engine";
+import { FeedDecision } from "../http/messages";
 import { ObservableSource, SpecificationListener } from "../observable/observable";
 import { Observer, ObserverImpl, ResultAddedFunc } from "../observer/observer";
 import { testSpecificationForCompliance } from "../purge/purgeCompliance";
@@ -115,9 +116,9 @@ export class FactManager {
         return await this.store.read(start, specification);
     }
 
-    async fetch(start: FactReference[], specification: Specification) {
+    async fetch(start: FactReference[], specification: Specification): Promise<FeedDecision[]> {
         this.purgeManager.checkCompliance(specification);
-        await this.networkManager.fetch(start, specification);
+        return await this.networkManager.fetch(start, specification);
     }
 
     async subscribe(start: FactReference[], specification: Specification) {

--- a/src/ws/wsGraphNetwork.ts
+++ b/src/ws/wsGraphNetwork.ts
@@ -1,7 +1,7 @@
 import { Network } from "../managers/NetworkManager";
 import { Specification } from "../specification/specification";
 import { FactEnvelope, FactReference, Storage } from "../storage";
-import { FeedResponse } from "../http/messages";
+import { FeedResponse, FeedsResponse } from "../http/messages";
 import { HttpNetwork } from "../http/httpNetwork";
 import { WsGraphClient } from "./ws-graph-client";
 import { UserIdentity } from "../user-identity";
@@ -60,7 +60,7 @@ export class WsGraphNetwork implements Network {
     );
   }
 
-  feeds(start: FactReference[], specification: Specification): Promise<string[]> {
+  feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse> {
     return this.httpNetwork.feeds(start, specification);
   }
 

--- a/test/distribution/queryWithDiagnosticsSpec.ts
+++ b/test/distribution/queryWithDiagnosticsSpec.ts
@@ -1,0 +1,192 @@
+import {
+  AuthenticationNoOp,
+  FactEnvelope,
+  FactManager,
+  FactReference,
+  FeedDecision,
+  FeedResponse,
+  FeedsResponse,
+  Jinaga,
+  MemoryStore,
+  ObservableSource,
+  PassThroughFork,
+  Specification,
+  User,
+  dehydrateFact,
+} from "@src";
+import { Network } from "../../src/managers/NetworkManager";
+import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
+import { Blog, Post, model } from "../blogModel";
+
+// A Network double that returns the caller-configured feed hashes and
+// per-feed decisions from `feeds()` (issue #207 W3/W4), so we can drive
+// `queryWithDiagnostics` (W8b) the way a real replicator would.
+class DecisionNetwork implements Network {
+  public response: FeedsResponse = { feeds: [] };
+  public feedsCalls = 0;
+
+  feeds(_start: FactReference[], _specification: Specification): Promise<FeedsResponse> {
+    this.feedsCalls++;
+    return Promise.resolve(this.response);
+  }
+
+  fetchFeed(_feed: string, bookmark: string): Promise<FeedResponse> {
+    // Every feed is at its end: the replicator delivers no references, so
+    // results come purely from the local store (silent-empty for denials).
+    return Promise.resolve({ references: [], bookmark });
+  }
+
+  streamFeed(): () => void {
+    return () => {};
+  }
+
+  load(_factReferences: FactReference[]): Promise<FactEnvelope[]> {
+    return Promise.resolve([]);
+  }
+
+  intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+    return Promise.resolve([{ start, specification }]);
+  }
+}
+
+describe("queryWithDiagnostics (issue #207 W8b)", () => {
+  const creator = new User("creator");
+  const blog = new Blog(creator, "domain");
+
+  const blogPosts = model.given(Blog).match((blog, facts) =>
+    facts.ofType(Post).join(post => post.blog, blog)
+  );
+
+  let network: DecisionNetwork;
+  let store: MemoryStore;
+  let j: Jinaga;
+
+  // The feed hash `feeds()` reports for the blogPosts spec. `query` fetches
+  // whatever hashes are in `feeds`, and `feed`/`decision` correlate by hash.
+  const AUTHORIZED_FEED = "authorized-feed-hash";
+
+  // Seed the local store with a couple of posts so an authorized read returns
+  // rows. When a feed is denied, nothing was ever synced locally, so the
+  // corresponding read stays silently empty — modeled by leaving the store
+  // unseeded in that test.
+  async function seedPosts() {
+    const posts = [
+      new Post(blog, creator, "2020-01-01T00:00:00Z"),
+      new Post(blog, creator, "2020-01-02T00:00:00Z"),
+    ];
+    const dehydration = posts.flatMap(p => dehydrateFact(p));
+    await store.save(dehydration.map(fact => (<FactEnvelope>{ fact, signatures: [] })));
+  }
+
+  beforeEach(() => {
+    network = new DecisionNetwork();
+    store = new MemoryStore();
+    const observableSource = new ObservableSource(store);
+    const fork = new PassThroughFork(store);
+    const factManager = new FactManager(fork, observableSource, store, network, []);
+    j = new Jinaga(new AuthenticationNoOp(), factManager, null);
+  });
+
+  it("returns results with no diagnostics when every feed is authorized", async () => {
+    await seedPosts();
+    network.response = {
+      feeds: [AUTHORIZED_FEED],
+      decisions: [
+        { feed: AUTHORIZED_FEED, decision: "authorized", reason: "" },
+      ],
+    };
+
+    const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
+
+    expect(results).toHaveLength(2);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("surfaces a no-matching-rule feed as a non-reactive denied diagnostic", async () => {
+    // A denied feed is not listed in `feeds` (nothing to fetch); its decision
+    // still arrives so the caller learns why the result is empty.
+    network.response = {
+      feeds: [],
+      decisions: [
+        {
+          feed: "denied-feed-hash",
+          decision: "denied",
+          code: "no-matching-rule",
+          reason: "No rules apply to this feed.",
+        },
+      ],
+    };
+
+    const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
+
+    // Results stay silently empty (no authorized feed fetched).
+    expect(results).toHaveLength(0);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].operation).toBe("query");
+    expect(diagnostics[0].decision).toBe("denied");
+    expect(diagnostics[0].reactive).toBe(false);
+    expect(diagnostics[0].code).toBe("no-matching-rule");
+    expect(diagnostics[0].reason).toContain("No rules apply to this feed.");
+    expect(diagnostics[0].specification).toContain("Post");
+  });
+
+  it("surfaces a reactive feed as a reactive diagnostic without throwing", async () => {
+    // Scenario (c): the feed is registered and kept alive (present in `feeds`),
+    // but the current user is not yet authorized. It must never be fatal.
+    network.response = {
+      feeds: [AUTHORIZED_FEED],
+      decisions: [
+        {
+          feed: AUTHORIZED_FEED,
+          decision: "reactive",
+          reason: "pending authorization",
+        },
+      ],
+    };
+
+    const promise = j.queryWithDiagnostics(blogPosts, blog);
+    await expect(promise).resolves.toBeDefined();
+    const { diagnostics } = await promise;
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].decision).toBe("reactive");
+    expect(diagnostics[0].reactive).toBe(true);
+    expect(diagnostics[0].reason).toBe("pending authorization");
+  });
+
+  it("reports only denied/reactive feeds, never authorized ones", async () => {
+    network.response = {
+      feeds: [AUTHORIZED_FEED],
+      decisions: [
+        { feed: AUTHORIZED_FEED, decision: "authorized", reason: "" },
+        { feed: "reactive-feed", decision: "reactive", reason: "pending" },
+        { feed: "denied-feed", decision: "denied", code: "principal-excluded", reason: "excluded" },
+      ],
+    };
+
+    const { diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map(d => d.decision).sort()).toEqual(["denied", "reactive"]);
+    expect(diagnostics.every(d => d.operation === "query")).toBe(true);
+  });
+
+  it("is inert against an old replicator that omits decisions", async () => {
+    await seedPosts();
+    network.response = { feeds: [AUTHORIZED_FEED] };
+
+    const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
+
+    expect(results).toHaveLength(2);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it("returns empty results and no diagnostics for a null given", async () => {
+    const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, null as any);
+
+    expect(results).toEqual([]);
+    expect(diagnostics).toEqual([]);
+    // The network is never consulted for an invalid given.
+    expect(network.feedsCalls).toBe(0);
+  });
+});

--- a/test/managers/NetworkManagerSpec.ts
+++ b/test/managers/NetworkManagerSpec.ts
@@ -1,6 +1,6 @@
 import { Network, NetworkManager } from "../../src/managers/NetworkManager";
 import { MemoryStore } from "../../src/memory/memory-store";
-import { FeedResponse } from "../../src/http/messages";
+import { FeedDecision, FeedResponse, FeedsResponse } from "../../src/http/messages";
 import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
 import { FactEnvelope, FactReference } from "../../src/storage";
 import { Specification } from "../../src/specification/specification";
@@ -11,8 +11,8 @@ class FlakyNetwork implements Network {
     public fetchFeedShouldFail = true;
     public fetchFeedCalls = 0;
 
-    feeds(start: FactReference[], specification: Specification): Promise<string[]> {
-        return Promise.resolve(["feed1"]);
+    feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse> {
+        return Promise.resolve({ feeds: ["feed1"] });
     }
 
     fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
@@ -55,6 +55,53 @@ describe("NetworkManager", () => {
         ).specification;
     });
 
+    describe("distribution decisions (issue #207 W4)", () => {
+        // A network that reports its configured feeds response, so we can
+        // assert the NetworkManager threads decisions to callers.
+        class DecisionNetwork implements Network {
+            public response: FeedsResponse = { feeds: ["feed1"] };
+            feeds(): Promise<FeedsResponse> {
+                return Promise.resolve(this.response);
+            }
+            fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
+                return Promise.resolve({ references: [], bookmark });
+            }
+            streamFeed(): () => void {
+                return () => {};
+            }
+            load(): Promise<FactEnvelope[]> {
+                return Promise.resolve([]);
+            }
+            intersectForSubscribe(start: FactReference[], specification: Specification) {
+                return Promise.resolve([{ start, specification }]);
+            }
+        }
+
+        it("returns the per-feed decisions from fetch", async () => {
+            const decisionNetwork = new DecisionNetwork();
+            const decisions: FeedDecision[] = [
+                { feed: "feed1", decision: "authorized", reason: "" },
+                { feed: "feed2", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." },
+            ];
+            decisionNetwork.response = { feeds: ["feed1"], decisions };
+            const decisionManager = new NetworkManager(decisionNetwork, store, async () => {});
+
+            const result = await decisionManager.fetch([], spec);
+
+            expect(result).toEqual(decisions);
+        });
+
+        it("returns an empty decisions array when the replicator omits them", async () => {
+            const decisionNetwork = new DecisionNetwork();
+            decisionNetwork.response = { feeds: ["feed1"] };
+            const decisionManager = new NetworkManager(decisionNetwork, store, async () => {});
+
+            const result = await decisionManager.fetch([], spec);
+
+            expect(result).toEqual([]);
+        });
+    });
+
     describe("transient fetch failure recovery", () => {
         it("should retry the network after a transient failure", async () => {
             // First fetch fails.
@@ -65,7 +112,7 @@ describe("NetworkManager", () => {
             const callsBeforeRetry = network.fetchFeedCalls;
 
             // Second fetch should succeed and call fetchFeed again.
-            await expect(manager.fetch([], spec)).resolves.toBeUndefined();
+            await expect(manager.fetch([], spec)).resolves.toEqual([]);
             expect(network.fetchFeedCalls).toBeGreaterThan(callsBeforeRetry);
         });
 
@@ -77,7 +124,7 @@ describe("NetworkManager", () => {
             network.fetchFeedShouldFail = false;
 
             // Second fetch must not replay the stale rejected promise.
-            await expect(manager.fetch([], spec)).resolves.toBeUndefined();
+            await expect(manager.fetch([], spec)).resolves.toEqual([]);
         });
     });
 });

--- a/test/single-use/singleUseForkSpec.ts
+++ b/test/single-use/singleUseForkSpec.ts
@@ -41,7 +41,7 @@ describe('SingleUse with FakeFork', () => {
         const observableSource = new ObservableSource(store);
         const authentication = new AuthenticationTest(store, null, null, null);
         const factManager = new FactManager(fakeFork, observableSource, store, {
-            feeds: async () => [],
+            feeds: async () => ({ feeds: [] }),
             fetchFeed: async () => ({ references: [], bookmark: '' }),
             streamFeed: () => () => {},
             load: async () => []
@@ -65,7 +65,7 @@ describe('SingleUse with FakeFork', () => {
         const observableSource = new ObservableSource(store);
         const authentication = new AuthenticationTest(store, null, null, null);
         const factManager = new FactManager(fakeFork, observableSource, store, {
-            feeds: async () => [],
+            feeds: async () => ({ feeds: [] }),
             fetchFeed: async () => ({ references: [], bookmark: '' }),
             streamFeed: () => () => {},
             load: async () => []

--- a/test/single-use/singleUseStoreSpec.ts
+++ b/test/single-use/singleUseStoreSpec.ts
@@ -19,7 +19,7 @@ describe('SingleUse with Store', () => {
     const observableSource = new ObservableSource(store);
     const authentication = new AuthenticationTest(store, null, null, null);
     const factManager = new FactManager(fork, observableSource, store, {
-      feeds: async () => [],
+      feeds: async () => ({ feeds: [] }),
       fetchFeed: async () => ({ references: [], bookmark: '' }),
       streamFeed: () => () => {},
       load: async () => []

--- a/test/specification/observerSettlesSpec.ts
+++ b/test/specification/observerSettlesSpec.ts
@@ -24,6 +24,7 @@ import {
     FactManager,
     FactReference,
     FeedResponse,
+    FeedsResponse,
     MemoryStore,
     Network,
     NetworkNoOp,
@@ -46,9 +47,9 @@ import {
  *  stop() is called before the delay fires (e.g. via subscriber.stop()).
  */
 class HangingNetwork implements Network {
-    feeds(_start: FactReference[], _spec: Specification): Promise<string[]> {
+    feeds(_start: FactReference[], _spec: Specification): Promise<FeedsResponse> {
         // Return one synthetic feed so subscribe() actually creates a Subscriber.
-        return Promise.resolve(["test-feed"]);
+        return Promise.resolve({ feeds: ["test-feed"] });
     }
 
     fetchFeed(_feed: string, bookmark: string): Promise<FeedResponse> {


### PR DESCRIPTION
Implements the first client-consumption tranche of #207 (distribution diagnostics): **W4** and **W8b**. Builds on the engine + type foundation (W1–W3) shipped in 6.9.0.

## W4 — thread decisions through `NetworkManager`
- `Network.feeds()` now returns the full `FeedsResponse` (feeds + optional `decisions`) instead of `string[]`. Updated all implementers: `NetworkNoOp`, `NetworkDistribution`, `HttpNetwork`, `WsGraphNetwork`.
- `NetworkManager.getFeedsFromCache` — the single choke point serving `query`/`watch` (via `fetch`) and `subscribe` — captures the parsed decisions into a `CachedFeeds` cache. Absent decisions (old replicators) normalize to `[]`, so every downstream channel is inert.
- `NetworkManager.fetch` / `FactManager.fetch` return the per-feed `FeedDecision[]` correlated to that exact fetch. `query`/`watch` ignore the value.

## W8b — `queryWithDiagnostics` (the factual-mcp #116-facing API)
- `Jinaga.queryWithDiagnostics<T, U>(spec, ...given): Promise<{ results, diagnostics }>`, implemented over the same `factManager.fetch` path as `query`.
- New exported `DistributionDiagnostic` type (`operation`, `specification` via `describeSpecification`, `decision`, `code`, `reactive`, `reason`).
- Diagnostics are produced **only** for `denied`/`reactive` feeds (authorized produce none).

## Load-bearing constraints (from the issue)
- **Branches on `reactive`, not on "denied".** A `reactive` decision is the subscription race and is never treated as fatal.
- `queryWithDiagnostics` **never throws** on any decision — results stay silent-empty.
- **Old replicators omit decisions → new code is inert.**
- `DistributionDiagnostic.code` is optional (deviates from the W5 sketch): the wire type `FeedDecision.code` is optional and a `reactive` decision may omit it. Documented in-code.

## Verification
Full suite: **528 passing** (6 new `queryWithDiagnosticsSpec` + 2 new `NetworkManagerSpec` W4 tests; existing test doubles migrated to the new interface).

End-to-end against the **real replicator 3.7.0** Docker image with a generated policy (`share(Blog→Post).with(creator)`, no rule for others) and anonymous access:

| Spec | decision | code | reactive | threw? |
|---|---|---|---|---|
| Blog→Follow (no rule) | `denied` | `no-matching-rule` | false | no |
| Blog→Comment (narrower than Post rule) | `denied` | `spec-more-restrictive-than-rule` | false | no |
| Blog→Post (rule matches, requester unauthorized) | `reactive` | `not-authenticated` | **true** | no |

All results silent-empty, none threw — denied structural cases surface loud-but-non-fatal, the pending case surfaces as reactive.

Downstream items (W5–W10) are out of scope for this tranche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)