### PR TITLE
Distribution diagnostics: instance hook + observer channel + 403 body (#207 W5/W6/W10)

### DIFF
--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,0 +1,47 @@
+/**
+ * Thrown on an HTTP 403 from the replicator (issue #207 W10). The replicator
+ * sends the actual reason a `/read`/`/load`/`/feeds` request was forbidden in
+ * the *response body*, but the previous `new Error(statusMessage)` threw away
+ * everything but the status line (`"Forbidden"`). `reason` is the extracted
+ * human-readable message and `body` is the raw response body, so callers can
+ * surface or inspect the replicator's explanation.
+ */
+export class ForbiddenError extends Error {
+    constructor(
+        public readonly reason: string,
+        public readonly body: unknown
+    ) {
+        super(reason);
+        this.name = 'ForbiddenError';
+        // Restore the prototype chain so `instanceof ForbiddenError` works after
+        // TypeScript's down-level `extends Error` transpilation.
+        Object.setPrototypeOf(this, ForbiddenError.prototype);
+    }
+}
+
+/**
+ * Derive a human-readable reason from a 403 response body, preferring a
+ * `reason`/`message` field or a plain-string body, and falling back to the HTTP
+ * status line when the body carries nothing useful.
+ */
+export function forbiddenReason(body: unknown, fallback: string | undefined): string {
+    if (typeof body === 'string' && body.trim().length > 0) {
+        return body;
+    }
+    if (body !== null && typeof body === 'object') {
+        const record = body as Record<string, unknown>;
+        if (typeof record.reason === 'string' && record.reason.length > 0) {
+            return record.reason;
+        }
+        if (typeof record.message === 'string' && record.message.length > 0) {
+            return record.message;
+        }
+        try {
+            return JSON.stringify(body);
+        }
+        catch {
+            // Non-serializable body; fall through to the status line.
+        }
+    }
+    return fallback || 'Forbidden';
+}

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -22,7 +22,10 @@ export class ForbiddenError extends Error {
 /**
  * Derive a human-readable reason from a 403 response body, preferring a
  * `reason`/`message` field or a plain-string body, and falling back to the HTTP
- * status line when the body carries nothing useful.
+ * status line otherwise. An object body without a `reason`/`message` field is
+ * not stringified into the reason — that would yield noisy or oversized text
+ * like `"{}"`; the raw body is preserved on `ForbiddenError.body` for callers
+ * that want to inspect it.
  */
 export function forbiddenReason(body: unknown, fallback: string | undefined): string {
     if (typeof body === 'string' && body.trim().length > 0) {
@@ -35,12 +38,6 @@ export function forbiddenReason(body: unknown, fallback: string | undefined): st
         }
         if (typeof record.message === 'string' && record.message.length > 0) {
             return record.message;
-        }
-        try {
-            return JSON.stringify(body);
-        }
-        catch {
-            // Non-serializable body; fall through to the status line.
         }
     }
     return fallback || 'Forbidden';

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -1,6 +1,7 @@
 import { Trace } from "../util/trace";
 import { HttpHeaders } from "./authenticationProvider";
 import { PostAccept, PostContentType, ContentTypeJson } from "./ContentType";
+import { ForbiddenError, forbiddenReason } from "./errors";
 import { HttpConnection, HttpResponse } from "./web-client";
 
 interface FetchHttpResponse {
@@ -28,7 +29,12 @@ export class FetchConnection implements HttpConnection {
                     response = await this.httpGet(path, headers);
                 }
             }
-            if (response.statusCode >= 400) {
+            if (response.statusCode === 403) {
+                // Preserve the replicator's forbidden reason from the body
+                // instead of discarding it for the bare status line (W10).
+                throw new ForbiddenError(forbiddenReason(response.response, response.statusMessage), response.response);
+            }
+            else if (response.statusCode >= 400) {
                 throw new Error(response.statusMessage);
             }
             else if (response.statusCode === 200) {
@@ -202,7 +208,9 @@ export class FetchConnection implements HttpConnection {
                 }
             }
             if (response.statusCode === 403) {
-                throw new Error(response.statusMessage);
+                // Preserve the replicator's forbidden reason from the body
+                // instead of discarding it for the bare status line (W10).
+                throw new ForbiddenError(forbiddenReason(response.response, response.statusMessage), response.response);
             }
             else if (response.statusCode >= 400) {
                 return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export { PersistentFork } from "./fork/persistent-fork";
 export { TransientFork } from './fork/transient-fork';
 export { AuthenticationProvider, HttpHeaders } from "./http/authenticationProvider";
 export { GraphDeserializer, GraphSource } from "./http/deserializer";
+export { ForbiddenError } from "./http/errors";
 export { FetchConnection } from "./http/fetch";
 export { HttpNetwork } from "./http/httpNetwork";
 export { parseFeedsResponse, parseLoadMessage, parseSaveMessage } from './http/messageParsers';

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -1,8 +1,7 @@
 import { Authentication } from "./authentication/authentication";
-import { DistributionDenialCode } from './distribution/distribution-engine';
 import { dehydrateReference, Dehydration, HashMap, hashSymbol, hydrate, hydrateFromTree, lookupHash } from './fact/hydrate';
-import { FeedDecision } from './http/messages';
 import { SyncStatus, SyncStatusNotifier } from './http/web-client';
+import { DistributionDiagnostic, toDistributionDiagnostics } from './managers/distributionDiagnostic';
 import { FactManager } from './managers/factManager';
 import { User } from './model/user';
 import { ObservableCollection, Observer, ResultAddedFunc } from './observer/observer';
@@ -14,55 +13,10 @@ import { FactEnvelope, FactReference, ProjectedResult } from './storage';
 import { toJSON } from './util/obj';
 import { Trace } from './util/trace';
 
+export { DistributionDiagnostic } from './managers/distributionDiagnostic';
+
 export interface Profile {
     displayName: string;
-}
-
-/**
- * A developer-facing distribution diagnostic (issue #207). Emitted for a feed
- * that the replicator marked `reactive` or `denied`; authorized feeds produce
- * none.
- *
- * The single load-bearing field is `reactive`. When `true`, the decision is the
- * subscription race — the feed is denied for the current user *right now* but
- * will self-heal once the authorizing fact arrives — and must NEVER be treated
- * as fatal. When `false`, the denial is structural (a missing or narrowed-past
- * rule, or a principal the rule excludes) and will not self-heal on its own.
- *
- * `code` is optional because a `reactive` decision need not carry one (the
- * replicator may report the pending case without a denial code); a `denied`
- * decision always carries one.
- */
-export interface DistributionDiagnostic {
-    operation: 'query' | 'watch' | 'subscribe';
-    specification: string;            // describeSpecification(...)
-    decision: 'reactive' | 'denied';
-    code?: DistributionDenialCode;
-    reactive: boolean;                // true => will self-heal; NEVER treat as fatal
-    reason: string;
-}
-
-/**
- * Map the replicator's per-feed decisions (issue #207 W4) to developer-facing
- * diagnostics. Only `denied` and `reactive` feeds produce a diagnostic;
- * `authorized` feeds are silent. Old replicators report no decisions, so this
- * yields an empty array and the new APIs are inert.
- */
-function toDistributionDiagnostics(
-    operation: DistributionDiagnostic['operation'],
-    specification: string,
-    decisions: FeedDecision[]
-): DistributionDiagnostic[] {
-    return decisions
-        .filter(d => d.decision === 'denied' || d.decision === 'reactive')
-        .map(d => ({
-            operation,
-            specification,
-            decision: d.decision as 'reactive' | 'denied',
-            code: d.code,
-            reactive: d.decision === 'reactive',
-            reason: d.reason
-        }));
 }
 
 export type MakeObservable<T> =
@@ -78,7 +32,8 @@ export class Jinaga {
     private errorHandlers: ((message: string) => void)[] = [];
     private loadingHandlers: ((loading: boolean) => void)[] = [];
     private progressHandlers: ((count: number) => void)[] = [];
-    
+    private distributionDiagnosticHandlers: ((diagnostic: DistributionDiagnostic) => void)[] = [];
+
     constructor(
         private authentication: Authentication,
         private factManager: FactManager,
@@ -115,6 +70,43 @@ export class Jinaga {
 
     onSyncStatus(handler: (status: SyncStatus) => void) {
         this.syncStatusNotifier?.onSyncStatus(handler);
+    }
+
+    /**
+     * Register a callback to receive distribution diagnostics (issue #207 W5).
+     * Fires for `query`, `watch`, and `subscribe` alike — all three pass through
+     * the same per-feed decision capture — whenever a feed is `denied` or
+     * `reactive`. Authorized feeds and old replicators (which report no
+     * decisions) produce nothing, so this channel is inert until there is
+     * something to report.
+     *
+     * This is the always-on programmatic channel: route it to your own
+     * devtools/telemetry. Branch on `diagnostic.reactive` — a `reactive`
+     * diagnostic is the subscription race and must never be treated as fatal.
+     *
+     * @param handler A function to receive each distribution diagnostic
+     */
+    onDistributionDiagnostic(handler: (diagnostic: DistributionDiagnostic) => void) {
+        this.distributionDiagnosticHandlers.push(handler);
+    }
+
+    /**
+     * Deliver diagnostics to every registered handler. A throwing handler must
+     * not abort delivery to the others or bubble into the operation that
+     * produced the diagnostic (a diagnostic is never fatal), so each call is
+     * isolated.
+     */
+    private emitDistributionDiagnostics(diagnostics: DistributionDiagnostic[]) {
+        for (const diagnostic of diagnostics) {
+            for (const handler of this.distributionDiagnosticHandlers) {
+                try {
+                    handler(diagnostic);
+                }
+                catch (e) {
+                    Trace.error(e);
+                }
+            }
+        }
     }
 
     /**
@@ -196,7 +188,12 @@ export class Jinaga {
         }
 
         const references = given.map(g => this.prepareFactReference(g));
-        await this.factManager.fetch(references, innerSpecification);
+        const decisions = await this.factManager.fetch(references, innerSpecification);
+        this.emitDistributionDiagnostics(toDistributionDiagnostics(
+            'query',
+            describeSpecification(innerSpecification, 0),
+            decisions
+        ));
         const projectedResults = await this.factManager.read(references, innerSpecification);
         const extracted = extractResults(projectedResults, innerSpecification.projection);
         Trace.counter("facts_loaded", extracted.totalCount);
@@ -242,6 +239,10 @@ export class Jinaga {
             describeSpecification(innerSpecification, 0),
             decisions
         );
+        // Also drive the always-on instance hook so a caller that registered
+        // `onDistributionDiagnostic` sees these alongside the correlated return
+        // value, exactly as it would for a plain `query`.
+        this.emitDistributionDiagnostics(diagnostics);
         return { results: extracted.results, diagnostics };
     }
 
@@ -276,7 +277,8 @@ export class Jinaga {
 
         const references = given.map(g => this.prepareFactReference(g));
 
-        return this.factManager.startObserver<U>(references, innerSpecification, resultAdded, false);
+        return this.factManager.startObserver<U>(references, innerSpecification, resultAdded, false,
+            diagnostics => this.emitDistributionDiagnostics(diagnostics));
     }
 
     /**
@@ -308,7 +310,8 @@ export class Jinaga {
 
         const references = given.map(g => this.prepareFactReference(g));
 
-        return this.factManager.startObserver<U>(references, innerSpecification, resultAdded, true);
+        return this.factManager.startObserver<U>(references, innerSpecification, resultAdded, true,
+            diagnostics => this.emitDistributionDiagnostics(diagnostics));
     }
 
     /**

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -310,9 +310,9 @@ export class NetworkManager {
         return [{ start, specification }];
     }
 
-    async subscribe(start: FactReference[], specification: Specification): Promise<string[]> {
+    async subscribe(start: FactReference[], specification: Specification): Promise<CachedFeeds> {
         const reducedSpecification = reduceSpecification(specification);
-        const { feeds } = await this.getFeedsFromCache(start, reducedSpecification);
+        const { feeds, decisions } = await this.getFeedsFromCache(start, reducedSpecification);
 
         const subscribers = feeds.map(feed => {
             let subscriber = this.subscribers.get(feed);
@@ -337,7 +337,10 @@ export class NetworkManager {
             this.unsubscribe(feeds);
             throw e;
         }
-        return feeds;
+        // Return the feed hashes alongside the per-feed decisions so the observer
+        // can surface diagnostics (issue #207 W5/W6) while still using `feeds`
+        // for its keep-alive/unsubscribe bookkeeping.
+        return { feeds, decisions };
     }
 
     unsubscribe(feeds: string[]) {

--- a/src/managers/distributionDiagnostic.ts
+++ b/src/managers/distributionDiagnostic.ts
@@ -1,0 +1,53 @@
+import { DistributionDenialCode } from "../distribution/distribution-engine";
+import { FeedDecision } from "../http/messages";
+
+/**
+ * A developer-facing distribution diagnostic (issue #207). Emitted for a feed
+ * that the replicator marked `reactive` or `denied`; authorized feeds produce
+ * none.
+ *
+ * The single load-bearing field is `reactive`. When `true`, the decision is the
+ * subscription race — the feed is denied for the current user *right now* but
+ * will self-heal once the authorizing fact arrives — and must NEVER be treated
+ * as fatal. When `false`, the denial is structural (a missing or narrowed-past
+ * rule, or a principal the rule excludes) and will not self-heal on its own.
+ *
+ * `code` is optional because a `reactive` decision need not carry one (the
+ * replicator may report the pending case without a denial code); a `denied`
+ * decision always carries one.
+ *
+ * Defined here rather than in `jinaga.ts` so both the client (`Jinaga`) and the
+ * `Observer` can build diagnostics without an import cycle (`jinaga.ts` already
+ * imports from `observer.ts`).
+ */
+export interface DistributionDiagnostic {
+    operation: 'query' | 'watch' | 'subscribe';
+    specification: string;            // describeSpecification(...)
+    decision: 'reactive' | 'denied';
+    code?: DistributionDenialCode;
+    reactive: boolean;                // true => will self-heal; NEVER treat as fatal
+    reason: string;
+}
+
+/**
+ * Map the replicator's per-feed decisions (issue #207 W4) to developer-facing
+ * diagnostics. Only `denied` and `reactive` feeds produce a diagnostic;
+ * `authorized` feeds are silent. Old replicators report no decisions, so this
+ * yields an empty array and the new APIs are inert.
+ */
+export function toDistributionDiagnostics(
+    operation: DistributionDiagnostic['operation'],
+    specification: string,
+    decisions: FeedDecision[]
+): DistributionDiagnostic[] {
+    return decisions
+        .filter(d => d.decision === 'denied' || d.decision === 'reactive')
+        .map(d => ({
+            operation,
+            specification,
+            decision: d.decision as 'reactive' | 'denied',
+            code: d.code,
+            reactive: d.decision === 'reactive',
+            reason: d.reason
+        }));
+}

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -4,13 +4,14 @@ import { Fork } from "../fork/fork";
 import { PersistentFork } from "../fork/persistent-fork";
 import { DistributionIntersectionBranch } from "../distribution/distribution-engine";
 import { FeedDecision } from "../http/messages";
+import { DistributionDiagnostic } from "./distributionDiagnostic";
 import { ObservableSource, SpecificationListener } from "../observable/observable";
 import { Observer, ObserverImpl, ResultAddedFunc } from "../observer/observer";
 import { testSpecificationForCompliance } from "../purge/purgeCompliance";
 import { Specification } from "../specification/specification";
 import { FactEnvelope, FactRecord, FactReference, ProjectedResult, Storage } from "../storage";
 import { Trace } from "../util/trace";
-import { Network, NetworkManager } from "./NetworkManager";
+import { CachedFeeds, Network, NetworkManager } from "./NetworkManager";
 import { PurgeManager } from "./PurgeManager";
 
 export class FactManager {
@@ -121,7 +122,7 @@ export class FactManager {
         return await this.networkManager.fetch(start, specification);
     }
 
-    async subscribe(start: FactReference[], specification: Specification) {
+    async subscribe(start: FactReference[], specification: Specification): Promise<CachedFeeds> {
         this.purgeManager.checkCompliance(specification);
         return await this.networkManager.subscribe(start, specification);
     }
@@ -148,8 +149,8 @@ export class FactManager {
         return this.store.setMruDate(specificationHash, mruDate);
     }
 
-    startObserver<U>(references: FactReference[], specification: Specification, resultAdded: ResultAddedFunc<U>, keepAlive: boolean): Observer<U> {
-        const observer = new ObserverImpl<U>(this, references, specification, resultAdded);
+    startObserver<U>(references: FactReference[], specification: Specification, resultAdded: ResultAddedFunc<U>, keepAlive: boolean, onDiagnostics?: (diagnostics: DistributionDiagnostic[]) => void): Observer<U> {
+        const observer = new ObserverImpl<U>(this, references, specification, resultAdded, onDiagnostics);
         observer.start(keepAlive);
         return observer;
     }

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -1,4 +1,6 @@
 import { computeObjectHash } from "../fact/hash";
+import { FeedDecision } from "../http/messages";
+import { DistributionDiagnostic, toDistributionDiagnostics } from "../managers/distributionDiagnostic";
 import { FactManager } from "../managers/factManager";
 import { SpecificationListener } from "../observable/observable";
 import { describeDeclaration, describeSpecification } from "../specification/description";
@@ -29,6 +31,23 @@ export interface Observer<T> {
      */
     processed(): Promise<void>;
     stop(): void;
+    /**
+     * The distribution diagnostics (issue #207 W6) captured for this observer's
+     * feeds while loading. This is where a developer holding the observer handle
+     * looks to learn that a feed is `denied` or `reactive`.
+     *
+     * Non-fatal by contract: a denied/reactive feed never rejects `loaded()` and
+     * never puts the observer into an error state — that is what keeps `watch`
+     * and `subscribe` correct through the subscription race.
+     */
+    diagnostics(): DistributionDiagnostic[];
+    /**
+     * Register a callback for distribution diagnostics. Any diagnostics already
+     * captured are replayed to the handler immediately, and future ones are
+     * delivered as they are captured. A throwing handler is isolated and never
+     * disturbs the observer.
+     */
+    onDiagnostic(handler: (diagnostic: DistributionDiagnostic) => void): void;
 }
 
 interface ObserverBranch {
@@ -138,12 +157,25 @@ export class ObserverImpl<T> implements Observer<T> {
      * collapses identical rows across branches for `votesByRow`.
      */
     private rowIdentityLabels: string[];
+    /**
+     * Distribution diagnostics captured for this observer's feeds (issue #207
+     * W6), plus the handlers registered via `onDiagnostic`. `specificationString`
+     * is the developer's pre-intersection spec, so diagnostics name the query
+     * they wrote rather than an internally rewritten branch.
+     */
+    private readonly _diagnostics: DistributionDiagnostic[] = [];
+    private readonly diagnosticHandlers: ((diagnostic: DistributionDiagnostic) => void)[] = [];
+    private readonly specificationString: string;
 
     constructor(
         private factManager: FactManager,
         private given: FactReference[],
         specification: Specification,
-        resultAdded: ResultAddedFunc<T>
+        resultAdded: ResultAddedFunc<T>,
+        // Instance-level sink (issue #207 W5): forwards this observer's
+        // diagnostics to `j.onDistributionDiagnostic`. Optional so the observer
+        // works standalone (e.g. in tests) without the client hook.
+        private readonly onDiagnostics?: (diagnostics: DistributionDiagnostic[]) => void
     ) {
         // Capture the original spec's labels. These are stable across any
         // future branch fan-out from `applySubscribeIntersection`.
@@ -183,6 +215,8 @@ export class ObserverImpl<T> implements Observer<T> {
         const specificationString = describeSpecification(specification, 0);
         const request = `${declarationString}\n${specificationString}`;
         this.specificationHash = computeStringHash(request);
+        // Retain the pre-intersection spec description for diagnostics.
+        this.specificationString = specificationString;
     }
 
     public start(keepAlive: boolean) {
@@ -376,9 +410,13 @@ export class ObserverImpl<T> implements Observer<T> {
     }
 
     private async fetch(keepAlive: boolean) {
+        // Collect the per-feed decisions across all branches so they can be
+        // surfaced as diagnostics (issue #207 W5/W6). Array.push from the
+        // concurrent branch callbacks is safe on JS's single thread.
+        const decisions: FeedDecision[] = [];
         if (keepAlive) {
             await Promise.all(this.branches.map(async branch => {
-                const feeds = await this.factManager.subscribe(this.given, branch.specification);
+                const { feeds, decisions: branchDecisions } = await this.factManager.subscribe(this.given, branch.specification);
                 if (this.stopped) {
                     // If stop() was called while we were awaiting subscribe(),
                     // clean up the feeds that were just registered so the
@@ -389,11 +427,71 @@ export class ObserverImpl<T> implements Observer<T> {
                     return;
                 }
                 branch.feeds = feeds;
+                decisions.push(...branchDecisions);
             }));
         }
         else {
-            await Promise.all(this.branches.map(branch =>
-                this.factManager.fetch(this.given, branch.specification)));
+            await Promise.all(this.branches.map(async branch => {
+                const branchDecisions = await this.factManager.fetch(this.given, branch.specification);
+                decisions.push(...branchDecisions);
+            }));
+        }
+        this.captureDiagnostics(keepAlive ? 'subscribe' : 'watch', decisions);
+    }
+
+    /**
+     * Map the fetch/subscribe decisions to diagnostics and deliver them to the
+     * observer-level handlers (W6) and the instance-level sink (W5). This must
+     * never throw into the load flow — a distribution diagnostic is not fatal —
+     * so the whole body is guarded and a throwing handler is isolated.
+     */
+    private captureDiagnostics(operation: 'watch' | 'subscribe', decisions: FeedDecision[]) {
+        try {
+            const diagnostics = toDistributionDiagnostics(operation, this.specificationString, decisions);
+            if (diagnostics.length === 0) {
+                return;
+            }
+            this._diagnostics.push(...diagnostics);
+            for (const diagnostic of diagnostics) {
+                for (const handler of this.diagnosticHandlers) {
+                    this.safelyInvokeDiagnostic(handler, diagnostic);
+                }
+            }
+            if (this.onDiagnostics) {
+                try {
+                    this.onDiagnostics(diagnostics);
+                }
+                catch (e) {
+                    Trace.error(e);
+                }
+            }
+        }
+        catch (e) {
+            Trace.error(e);
+        }
+    }
+
+    private safelyInvokeDiagnostic(handler: (diagnostic: DistributionDiagnostic) => void, diagnostic: DistributionDiagnostic) {
+        try {
+            handler(diagnostic);
+        }
+        catch (e) {
+            Trace.error(e);
+        }
+    }
+
+    public diagnostics(): DistributionDiagnostic[] {
+        return [...this._diagnostics];
+    }
+
+    public onDiagnostic(handler: (diagnostic: DistributionDiagnostic) => void): void {
+        this.diagnosticHandlers.push(handler);
+        // Replay diagnostics already captured before this handler registered —
+        // the observer starts as soon as it is created, so a caller wiring up
+        // `onDiagnostic` right after `watch`/`subscribe` returns would otherwise
+        // miss any diagnostic captured during that same tick.
+        for (const diagnostic of this._diagnostics) {
+            this.safelyInvokeDiagnostic(handler, diagnostic);
         }
     }
 

--- a/test/distribution/distributionDiagnosticHooksSpec.ts
+++ b/test/distribution/distributionDiagnosticHooksSpec.ts
@@ -1,0 +1,217 @@
+import {
+  AuthenticationNoOp,
+  DistributionDiagnostic,
+  FactEnvelope,
+  FactManager,
+  FactReference,
+  FeedResponse,
+  FeedsResponse,
+  Jinaga,
+  MemoryStore,
+  ObservableSource,
+  PassThroughFork,
+  Specification,
+  User,
+} from "@src";
+import { Network } from "../../src/managers/NetworkManager";
+import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
+import { Blog, Post, model } from "../blogModel";
+
+// A Network double that reports caller-configured feed hashes and per-feed
+// decisions from `feeds()` (issue #207 W3/W4), and resolves subscriptions
+// immediately so watch/subscribe complete. Drives the W5 instance hook and the
+// W6 observer channel the way a real replicator would.
+class DecisionNetwork implements Network {
+  public response: FeedsResponse = { feeds: [] };
+
+  feeds(_start: FactReference[], _specification: Specification): Promise<FeedsResponse> {
+    return Promise.resolve(this.response);
+  }
+
+  fetchFeed(_feed: string, bookmark: string): Promise<FeedResponse> {
+    return Promise.resolve({ references: [], bookmark });
+  }
+
+  streamFeed(
+    _feed: string,
+    bookmark: string,
+    onResponse: (factReferences: FactReference[], nextBookmark: string) => Promise<void>,
+    _onError: (err: Error) => void,
+    _feedRefreshIntervalSeconds: number
+  ): () => void {
+    // Deliver an empty response so the subscriber's start() promise resolves.
+    Promise.resolve().then(() => onResponse([], bookmark));
+    return () => {};
+  }
+
+  load(_factReferences: FactReference[]): Promise<FactEnvelope[]> {
+    return Promise.resolve([]);
+  }
+
+  intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+    return Promise.resolve([{ start, specification }]);
+  }
+}
+
+describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
+  const creator = new User("creator");
+  const blog = new Blog(creator, "domain");
+
+  const blogPosts = model.given(Blog).match((blog, facts) =>
+    facts.ofType(Post).join(post => post.blog, blog)
+  );
+
+  const FEED = "feed-hash";
+
+  let network: DecisionNetwork;
+  let store: MemoryStore;
+  let j: Jinaga;
+
+  beforeEach(() => {
+    network = new DecisionNetwork();
+    store = new MemoryStore();
+    const observableSource = new ObservableSource(store);
+    const fork = new PassThroughFork(store);
+    const factManager = new FactManager(fork, observableSource, store, network, []);
+    j = new Jinaga(new AuthenticationNoOp(), factManager, null);
+  });
+
+  function deniedResponse(): FeedsResponse {
+    return {
+      feeds: [],
+      decisions: [
+        { feed: "denied-feed", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." },
+      ],
+    };
+  }
+
+  function reactiveResponse(): FeedsResponse {
+    return {
+      feeds: [FEED],
+      decisions: [
+        { feed: FEED, decision: "reactive", reason: "pending authorization" },
+      ],
+    };
+  }
+
+  describe("W5 — j.onDistributionDiagnostic", () => {
+    it("fires for query with operation 'query'", async () => {
+      network.response = deniedResponse();
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      await j.query(blogPosts, blog);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].operation).toBe("query");
+      expect(received[0].decision).toBe("denied");
+      expect(received[0].reactive).toBe(false);
+      expect(received[0].code).toBe("no-matching-rule");
+    });
+
+    it("fires for watch with operation 'watch'", async () => {
+      network.response = deniedResponse();
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      const observer = j.watch(blogPosts, blog, () => {});
+      await observer.loaded();
+      observer.stop();
+
+      expect(received).toHaveLength(1);
+      expect(received[0].operation).toBe("watch");
+      expect(received[0].decision).toBe("denied");
+    });
+
+    it("fires for subscribe with operation 'subscribe' and reactive:true, without throwing", async () => {
+      network.response = reactiveResponse();
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      const observer = j.subscribe(blogPosts, blog, () => {});
+      await expect(observer.loaded()).resolves.toBeUndefined();
+      observer.stop();
+
+      expect(received).toHaveLength(1);
+      expect(received[0].operation).toBe("subscribe");
+      expect(received[0].decision).toBe("reactive");
+      expect(received[0].reactive).toBe(true);
+    });
+
+    it("does not fire for authorized-only feeds", async () => {
+      network.response = {
+        feeds: [FEED],
+        decisions: [{ feed: FEED, decision: "authorized", reason: "" }],
+      };
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      await j.query(blogPosts, blog);
+
+      expect(received).toEqual([]);
+    });
+
+    it("is inert against an old replicator that omits decisions", async () => {
+      network.response = { feeds: [FEED] };
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      await j.query(blogPosts, blog);
+      const observer = j.watch(blogPosts, blog, () => {});
+      await observer.loaded();
+      observer.stop();
+
+      expect(received).toEqual([]);
+    });
+
+    it("isolates a throwing handler so the operation still succeeds", async () => {
+      network.response = deniedResponse();
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(() => { throw new Error("handler boom"); });
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+      expect(received).toHaveLength(1);
+    });
+  });
+
+  describe("W6 — observer.diagnostics() / onDiagnostic", () => {
+    it("exposes captured diagnostics via observer.diagnostics()", async () => {
+      network.response = reactiveResponse();
+
+      const observer = j.subscribe(blogPosts, blog, () => {});
+      await observer.loaded();
+
+      const diagnostics = observer.diagnostics();
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].operation).toBe("subscribe");
+      expect(diagnostics[0].reactive).toBe(true);
+      observer.stop();
+    });
+
+    it("delivers to onDiagnostic and replays already-captured diagnostics", async () => {
+      network.response = deniedResponse();
+
+      const observer = j.watch(blogPosts, blog, () => {});
+      await observer.loaded();
+
+      // Registered after load — the already-captured diagnostic must replay.
+      const received: DistributionDiagnostic[] = [];
+      observer.onDiagnostic(d => received.push(d));
+
+      expect(received).toHaveLength(1);
+      expect(received[0].operation).toBe("watch");
+      expect(received[0].code).toBe("no-matching-rule");
+      observer.stop();
+    });
+
+    it("never rejects loaded() for a denied feed", async () => {
+      network.response = deniedResponse();
+
+      const observer = j.watch(blogPosts, blog, () => {});
+      await expect(observer.loaded()).resolves.toBeUndefined();
+      expect(observer.diagnostics()).toHaveLength(1);
+      observer.stop();
+    });
+  });
+});

--- a/test/http/forbiddenErrorSpec.ts
+++ b/test/http/forbiddenErrorSpec.ts
@@ -1,0 +1,76 @@
+import { FetchConnection, ForbiddenError } from "@src";
+import { ContentTypeJson } from "../../src/http/ContentType";
+
+// Build a minimal fetch Response stand-in with the shape FetchConnection reads.
+function fakeResponse(status: number, contentType: string, body: unknown) {
+  return {
+    status,
+    statusText: status === 403 ? "Forbidden" : "Error",
+    headers: { get: (h: string) => (h.toLowerCase() === "content-type" ? contentType : null) },
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  };
+}
+
+describe("ForbiddenError (issue #207 W10)", () => {
+  it("carries reason and raw body, and is an Error", () => {
+    const body = { reason: "no dice" };
+    const err = new ForbiddenError("no dice", body);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ForbiddenError);
+    expect(err.name).toBe("ForbiddenError");
+    expect(err.message).toBe("no dice");
+    expect(err.reason).toBe("no dice");
+    expect(err.body).toBe(body);
+  });
+
+  describe("FetchConnection surfaces the 403 body", () => {
+    const realFetch = global.fetch;
+    afterEach(() => { global.fetch = realFetch; });
+
+    function connection() {
+      return new FetchConnection(
+        "http://localhost",
+        () => Promise.resolve({}),
+        () => Promise.resolve(false)
+      );
+    }
+
+    it("throws ForbiddenError with the reason field from a JSON body (POST)", async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(403, "application/json", { reason: "The user does not match the distribution rule." })
+      ) as any;
+
+      const conn = connection();
+      await expect(conn.post("/read", ContentTypeJson, ContentTypeJson, "{}", 30))
+        .rejects.toMatchObject({
+          name: "ForbiddenError",
+          reason: "The user does not match the distribution rule.",
+          body: { reason: "The user does not match the distribution rule." },
+        });
+    });
+
+    it("throws ForbiddenError with a plain-string body (GET)", async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(403, "text/plain", "Forbidden: no rule applies")
+      ) as any;
+
+      const conn = connection();
+      const error = await conn.get("/feeds/abc").catch(e => e);
+      expect(error).toBeInstanceOf(ForbiddenError);
+      expect(error.reason).toBe("Forbidden: no rule applies");
+      expect(error.body).toBe("Forbidden: no rule applies");
+    });
+
+    it("falls back to the status line when the body is empty (POST)", async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(403, "text/plain", "")
+      ) as any;
+
+      const conn = connection();
+      const error = await conn.post("/read", ContentTypeJson, ContentTypeJson, "{}", 30).catch(e => e);
+      expect(error).toBeInstanceOf(ForbiddenError);
+      expect(error.reason).toBe("Forbidden");
+    });
+  });
+});

--- a/test/http/forbiddenErrorSpec.ts
+++ b/test/http/forbiddenErrorSpec.ts
@@ -72,5 +72,20 @@ describe("ForbiddenError (issue #207 W10)", () => {
       expect(error).toBeInstanceOf(ForbiddenError);
       expect(error.reason).toBe("Forbidden");
     });
+
+    it("falls back to the status line for an object body without reason/message, keeping the raw body", async () => {
+      const body = { code: "denied", detail: { feed: "abc" } };
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(403, "application/json", body)
+      ) as any;
+
+      const conn = connection();
+      const error = await conn.get("/feeds/abc").catch(e => e);
+      expect(error).toBeInstanceOf(ForbiddenError);
+      // Not stringified into a noisy reason...
+      expect(error.reason).toBe("Forbidden");
+      // ...but the full body is preserved for inspection.
+      expect(error.body).toEqual(body);
+    });
   });
 });


### PR DESCRIPTION
Second tranche of #207 (distribution diagnostics), building on W4/W8b (#220, released in 6.10.0). This is **PR 1 of 3** for the W5–W10 follow-on; W7/W8 (dev-mode + query strict-throw) and W9 (lifecycle dedup) follow.

## W5 — `j.onDistributionDiagnostic(cb)`
- New instance hook mirroring the existing `onError`/`onLoading`/`onProgress`/`onSyncStatus` pattern. Fires for **query, watch, and subscribe** — all three now carry per-feed decisions — whenever a feed is `denied` or `reactive`. Authorized feeds and old replicators produce nothing (inert).
- A throwing handler is isolated (`Trace.error`) and never bubbles into the operation that produced the diagnostic.
- Completes the W4 plumbing: `NetworkManager.subscribe` / `factManager.subscribe` now return feeds **and** decisions (previously feeds only), so the subscribe path can emit. The `operation` label is threaded from the API layer since query and watch both go through `fetch`.

## W6 — observer diagnostics
- `Observer.diagnostics(): DistributionDiagnostic[]` and `Observer.onDiagnostic(cb)`. The observer captures its feeds' decisions during load, exposes them, and delivers to handlers — replaying already-captured diagnostics on late registration (the observer starts as soon as it is created).
- **Race-safety contract:** capture is fully guarded — a `denied`/`reactive` feed never rejects `loaded()` and never puts the observer in an error state.

## W10 — capture the 403 body (independent)
- New typed `ForbiddenError { reason, body }` thrown on HTTP 403 (GET + POST) instead of `new Error(statusMessage)`, preserving the reason the replicator sends in the body (previously discarded for the bare `"Forbidden"` status line). Reason is extracted from a `reason`/`message` field or a string body, falling back to the status line.

## Refactor
`DistributionDiagnostic` + the decision→diagnostic mapping move to `managers/distributionDiagnostic.ts` so both `Jinaga` and `Observer` build diagnostics without an import cycle (`jinaga.ts` already imports from `observer.ts`). Re-exported from `./jinaga` so the public API path is unchanged.

## Load-bearing constraint (unchanged from the issue)
Everything branches on `reactive`, never on "denied". A `reactive` diagnostic is the subscription race and is never fatal — the hook fires, the observer captures it, `loaded()` still resolves, `query` still returns.

## Tests
Full suite: **541 passing** (+13: 9 hook/observer, 4 ForbiddenError). The W5/W6 tests drive the real `Observer`/`FactManager`/`NetworkManager` stack (only the HTTP boundary is doubled); the W10 test drives the real `FetchConnection` with a mocked `fetch`.

Verified **end-to-end against replicator 3.7.0**: the instance hook fires for `query` (denied/`no-matching-rule`) and `watch` (reactive/`not-authenticated`), and `observer.diagnostics()` surfaces the watch diagnostic — none throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)