### PR TITLE
Distribution diagnostics: developmentMode + query strict-throw (#207 W7/W8)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export { GraphSerializer, serializeGraph } from "./http/serializer";
 export { HttpConnection, HttpResponse, SyncStatus, SyncStatusNotifier, WebClient } from "./http/web-client";
 export * as driver from './indexeddb/driver';
 export { IndexedDBQueue } from './indexeddb/indexeddb-queue';
-export { DistributionDiagnostic, Fact, Jinaga, MakeObservable, Profile } from './jinaga';
+export { DistributionDeniedError, DistributionDiagnostic, Fact, Jinaga, MakeObservable, Profile } from './jinaga';
 export { JinagaBrowser, JinagaBrowserConfig } from "./jinaga-browser";
 export { JinagaTest, JinagaTestConfig } from "./jinaga-test";
 export { FactManager } from "./managers/factManager";

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -14,6 +14,7 @@ import { IndexedDBLoginStore } from "./indexeddb/indexeddb-login-store";
 import { IndexedDBQueue } from "./indexeddb/indexeddb-queue";
 import { IndexedDBStore } from "./indexeddb/indexeddb-store";
 import { Jinaga } from "./jinaga";
+import { createDevelopmentDiagnosticHandler } from "./managers/developmentDiagnosticHandler";
 import { FactManager } from "./managers/factManager";
 import { Network, NetworkNoOp } from "./managers/NetworkManager";
 import { MemoryStore } from "./memory/memory-store";
@@ -32,7 +33,15 @@ export type JinagaBrowserConfig = {
     httpAuthenticationProvider?: AuthenticationProvider,
     queueProcessingDelayMs?: number,
     feedRefreshIntervalSeconds?: number,
-    purgeConditions?: (p: PurgeConditions) => PurgeConditions
+    purgeConditions?: (p: PurgeConditions) => PurgeConditions,
+    /**
+     * Enable development-mode distribution diagnostics (issue #207 W7/W8). When
+     * true, `query` throws a typed `DistributionDeniedError` for structural
+     * denials, and a default handler logs deduplicated, actionable messages to
+     * the console. A library cannot reliably read `NODE_ENV`, so the app passes
+     * this explicitly, e.g. `developmentMode: process.env.NODE_ENV !== 'production'`.
+     */
+    developmentMode?: boolean
 }
 
 export class JinagaBrowser {
@@ -46,7 +55,7 @@ export class JinagaBrowser {
         const network = createNetwork(config, webClient, store);
         const purgeConditions = createPurgeConditions(config);
         const factManager = new FactManager(fork, observableSource, store, network, purgeConditions, config.feedRefreshIntervalSeconds);
-        
+
         // Phase 3.4: Connect observer notification bridge if network supports it
         if (network && 'setFactsAddedListener' in network && typeof network.setFactsAddedListener === 'function') {
             (network as any).setFactsAddedListener(async (envelopes: FactEnvelope[]) => {
@@ -54,8 +63,15 @@ export class JinagaBrowser {
                 (factManager as any).factsAdded(envelopes);
             });
         }
-        
-        return new Jinaga(authentication, factManager, syncStatusNotifier);
+
+        const developmentMode = config.developmentMode === true;
+        const jinaga = new Jinaga(authentication, factManager, syncStatusNotifier, developmentMode);
+        // In development mode, surface otherwise-silent distribution denials as
+        // deduplicated, actionable console messages (issue #207 W7).
+        if (developmentMode) {
+            jinaga.onDistributionDiagnostic(createDevelopmentDiagnosticHandler());
+        }
+        return jinaga;
     }
 }
 

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -1,7 +1,7 @@
 import { Authentication } from "./authentication/authentication";
 import { dehydrateReference, Dehydration, HashMap, hashSymbol, hydrate, hydrateFromTree, lookupHash } from './fact/hydrate';
 import { SyncStatus, SyncStatusNotifier } from './http/web-client';
-import { DistributionDiagnostic, toDistributionDiagnostics } from './managers/distributionDiagnostic';
+import { DistributionDeniedError, DistributionDiagnostic, isStructuralDenial, toDistributionDiagnostics } from './managers/distributionDiagnostic';
 import { FactManager } from './managers/factManager';
 import { User } from './model/user';
 import { ObservableCollection, Observer, ResultAddedFunc } from './observer/observer';
@@ -13,7 +13,7 @@ import { FactEnvelope, FactReference, ProjectedResult } from './storage';
 import { toJSON } from './util/obj';
 import { Trace } from './util/trace';
 
-export { DistributionDiagnostic } from './managers/distributionDiagnostic';
+export { DistributionDeniedError, DistributionDiagnostic } from './managers/distributionDiagnostic';
 
 export interface Profile {
     displayName: string;
@@ -37,7 +37,12 @@ export class Jinaga {
     constructor(
         private authentication: Authentication,
         private factManager: FactManager,
-        private syncStatusNotifier: SyncStatusNotifier | null
+        private syncStatusNotifier: SyncStatusNotifier | null,
+        // Development mode (issue #207 W7/W8): when true, `query` throws a
+        // typed `DistributionDeniedError` for structural denials so a
+        // mis-authored spec fails loudly at the call site. Off by default, so
+        // production keeps the silent-empty behavior.
+        private readonly developmentMode: boolean = false
     ) { }
 
     /**
@@ -189,11 +194,22 @@ export class Jinaga {
 
         const references = given.map(g => this.prepareFactReference(g));
         const decisions = await this.factManager.fetch(references, innerSpecification);
-        this.emitDistributionDiagnostics(toDistributionDiagnostics(
+        const diagnostics = toDistributionDiagnostics(
             'query',
             describeSpecification(innerSpecification, 0),
             decisions
-        ));
+        );
+        this.emitDistributionDiagnostics(diagnostics);
+        // In development mode, fail loudly for a structural denial (a missing or
+        // narrowed-past rule) that provably never self-heals — never for a
+        // `reactive` decision, which is the subscription race. Production keeps
+        // the silent-empty behavior below.
+        if (this.developmentMode) {
+            const structural = diagnostics.filter(isStructuralDenial);
+            if (structural.length > 0) {
+                throw new DistributionDeniedError(structural);
+            }
+        }
         const projectedResults = await this.factManager.read(references, innerSpecification);
         const extracted = extractResults(projectedResults, innerSpecification.projection);
         Trace.counter("facts_loaded", extracted.totalCount);

--- a/src/managers/developmentDiagnosticHandler.ts
+++ b/src/managers/developmentDiagnosticHandler.ts
@@ -1,6 +1,16 @@
 import { DistributionDiagnostic } from "./distributionDiagnostic";
 
 /**
+ * Upper bound on the dedupe set (issue #207 W7). A long-lived app in
+ * development mode with dynamic specs/reasons would otherwise accumulate
+ * distinct messages without bound; once the cap is reached the oldest entry is
+ * evicted (FIFO — `Set` preserves insertion order). Eviction only means the
+ * evicted message could be logged once more if it recurs, which is harmless for
+ * a development aid.
+ */
+const MAX_DEDUP_ENTRIES = 1000;
+
+/**
  * Create the default development-mode distribution-diagnostic handler
  * (issue #207 W7). Installed by `JinagaBrowser` when `developmentMode` is on, it
  * turns otherwise-silent distribution denials into deduplicated, actionable
@@ -8,8 +18,8 @@ import { DistributionDiagnostic } from "./distributionDiagnostic";
  *
  *  - `no-matching-rule` / `spec-more-restrictive-than-rule` → `console.error`
  *    (structural authoring errors that never self-heal),
- *  - non-reactive `principal-excluded` → `console.warn`
- *    (the logged-in user is simply not permitted),
+ *  - any other non-reactive denial (`principal-excluded`, `not-authenticated`,
+ *    or an unrecognized code) → `console.warn`,
  *  - any `reactive` decision → `console.info`
  *    (the pending-authorization race; will populate when the fact arrives).
  *
@@ -18,9 +28,10 @@ import { DistributionDiagnostic } from "./distributionDiagnostic";
  * `NoOpTracer` would swallow them), and without flipping the global tracer on
  * and flooding the console with the library's internal traces.
  *
- * Deduplicated by message text so a long-lived subscription that re-reports the
- * same feed does not spam the console. (Clearing a `reactive` line once data
- * flows is the subscription-lifecycle concern handled separately in W9.)
+ * Deduplicated by message text (bounded — see `MAX_DEDUP_ENTRIES`) so a
+ * long-lived subscription that re-reports the same feed does not spam the
+ * console. (Clearing a `reactive` line once data flows is the
+ * subscription-lifecycle concern handled separately in W9.)
  */
 export function createDevelopmentDiagnosticHandler(): (diagnostic: DistributionDiagnostic) => void {
     const seen = new Set<string>();
@@ -30,6 +41,10 @@ export function createDevelopmentDiagnosticHandler(): (diagnostic: DistributionD
             return;
         }
         seen.add(message);
+        // Bound the dedupe set: evict the oldest entry once over the cap.
+        if (seen.size > MAX_DEDUP_ENTRIES) {
+            seen.delete(seen.values().next().value as string);
+        }
 
         if (diagnostic.reactive) {
             console.info(message);

--- a/src/managers/developmentDiagnosticHandler.ts
+++ b/src/managers/developmentDiagnosticHandler.ts
@@ -1,0 +1,66 @@
+import { DistributionDiagnostic } from "./distributionDiagnostic";
+
+/**
+ * Create the default development-mode distribution-diagnostic handler
+ * (issue #207 W7). Installed by `JinagaBrowser` when `developmentMode` is on, it
+ * turns otherwise-silent distribution denials into deduplicated, actionable
+ * console messages tiered by severity:
+ *
+ *  - `no-matching-rule` / `spec-more-restrictive-than-rule` → `console.error`
+ *    (structural authoring errors that never self-heal),
+ *  - non-reactive `principal-excluded` → `console.warn`
+ *    (the logged-in user is simply not permitted),
+ *  - any `reactive` decision → `console.info`
+ *    (the pending-authorization race; will populate when the fact arrives).
+ *
+ * Writes straight to `console.*` rather than through `Trace` so the messages are
+ * visible in development regardless of the configured tracer (the default
+ * `NoOpTracer` would swallow them), and without flipping the global tracer on
+ * and flooding the console with the library's internal traces.
+ *
+ * Deduplicated by message text so a long-lived subscription that re-reports the
+ * same feed does not spam the console. (Clearing a `reactive` line once data
+ * flows is the subscription-lifecycle concern handled separately in W9.)
+ */
+export function createDevelopmentDiagnosticHandler(): (diagnostic: DistributionDiagnostic) => void {
+    const seen = new Set<string>();
+    return (diagnostic: DistributionDiagnostic) => {
+        const message = formatMessage(diagnostic);
+        if (seen.has(message)) {
+            return;
+        }
+        seen.add(message);
+
+        if (diagnostic.reactive) {
+            console.info(message);
+        }
+        else if (diagnostic.code === 'no-matching-rule' || diagnostic.code === 'spec-more-restrictive-than-rule') {
+            console.error(message);
+        }
+        else {
+            console.warn(message);
+        }
+    };
+}
+
+function formatMessage(diagnostic: DistributionDiagnostic): string {
+    const spec = diagnostic.specification.trim();
+    if (diagnostic.reactive) {
+        return `[jinaga] Specification is pending authorization for the current user; ` +
+            `it will populate when the authorizing fact arrives.\n${spec}`;
+    }
+    switch (diagnostic.code) {
+        case 'no-matching-rule':
+            return `[jinaga] Specification has no distribution rule in the replicator. ` +
+                `Add a share(...).with(...) rule for it. Results will remain empty until you do.\n${spec}`;
+        case 'spec-more-restrictive-than-rule':
+            return `[jinaga] Specification is narrower than its share rule (it adds a positive join). ` +
+                `Distribution matches exact or predecessor-subset shapes only. Broaden the query or the rule.\n${spec}\n${diagnostic.reason}`;
+        case 'principal-excluded':
+            return `[jinaga] The logged-in user is not permitted to see this specification.\n${spec}`;
+        case 'not-authenticated':
+            return `[jinaga] No user is logged in, so this specification cannot be distributed.\n${spec}`;
+        default:
+            return `[jinaga] This specification is denied by distribution.\n${spec}\n${diagnostic.reason}`;
+    }
+}

--- a/src/managers/distributionDiagnostic.ts
+++ b/src/managers/distributionDiagnostic.ts
@@ -51,3 +51,39 @@ export function toDistributionDiagnostics(
             reason: d.reason
         }));
 }
+
+/**
+ * The denial codes that are *structural* — a missing rule or a spec narrowed
+ * past its rule. These never self-heal (unlike the subscription race), so they
+ * are the only cases `query` throws for in development mode (issue #207 W8) and
+ * the ones the default dev handler reports at error level (W7). A `reactive`
+ * diagnostic is never structural regardless of its code.
+ */
+export function isStructuralDenial(diagnostic: DistributionDiagnostic): boolean {
+    return !diagnostic.reactive
+        && (diagnostic.code === 'no-matching-rule'
+            || diagnostic.code === 'spec-more-restrictive-than-rule');
+}
+
+/**
+ * Thrown by `query` in development mode (issue #207 W8) when a feed is denied by
+ * a structural cause that provably never self-heals — so a mis-authored spec
+ * fails loudly at the call site instead of silently returning empty. Never
+ * thrown for a `reactive` decision (that would break the subscription race) and
+ * never in production, where `query` stays silent-empty. `diagnostics` carries
+ * the structural diagnostics that caused the throw.
+ */
+export class DistributionDeniedError extends Error {
+    constructor(public readonly diagnostics: DistributionDiagnostic[]) {
+        super(DistributionDeniedError.buildMessage(diagnostics));
+        this.name = 'DistributionDeniedError';
+        // Restore the prototype chain so `instanceof` works after TypeScript's
+        // down-level `extends Error` transpilation.
+        Object.setPrototypeOf(this, DistributionDeniedError.prototype);
+    }
+
+    private static buildMessage(diagnostics: DistributionDiagnostic[]): string {
+        return diagnostics.map(d => d.reason).join('\n\n')
+            || 'The specification is denied by distribution.';
+    }
+}

--- a/test/distribution/developmentModeSpec.ts
+++ b/test/distribution/developmentModeSpec.ts
@@ -1,0 +1,186 @@
+import {
+  AuthenticationNoOp,
+  DistributionDeniedError,
+  FactEnvelope,
+  FactManager,
+  FactReference,
+  FeedResponse,
+  FeedsResponse,
+  Jinaga,
+  MemoryStore,
+  ObservableSource,
+  PassThroughFork,
+  Specification,
+  User,
+} from "@src";
+import { Network } from "../../src/managers/NetworkManager";
+import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
+import { createDevelopmentDiagnosticHandler } from "../../src/managers/developmentDiagnosticHandler";
+import { DistributionDiagnostic } from "../../src/managers/distributionDiagnostic";
+import { Blog, Post, model } from "../blogModel";
+
+class DecisionNetwork implements Network {
+  public response: FeedsResponse = { feeds: [] };
+  feeds(): Promise<FeedsResponse> { return Promise.resolve(this.response); }
+  fetchFeed(_feed: string, bookmark: string): Promise<FeedResponse> { return Promise.resolve({ references: [], bookmark }); }
+  streamFeed(): () => void { return () => {}; }
+  load(): Promise<FactEnvelope[]> { return Promise.resolve([]); }
+  intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+    return Promise.resolve([{ start, specification }]);
+  }
+}
+
+function diagnostic(overrides: Partial<DistributionDiagnostic>): DistributionDiagnostic {
+  return {
+    operation: "query",
+    specification: "(p1: Blog) { u1: Post [ u1->blog: Blog = p1 ] } => u1",
+    decision: "denied",
+    reactive: false,
+    reason: "reason text",
+    ...overrides,
+  };
+}
+
+describe("development-mode distribution diagnostics (issue #207 W7/W8)", () => {
+  const blog = new Blog(new User("creator"), "domain");
+  const blogPosts = model.given(Blog).match((blog, facts) =>
+    facts.ofType(Post).join(post => post.blog, blog)
+  );
+
+  describe("W8 — query strict-throw in development mode", () => {
+    let network: DecisionNetwork;
+
+    function makeJinaga(developmentMode: boolean): Jinaga {
+      network = new DecisionNetwork();
+      const store = new MemoryStore();
+      const factManager = new FactManager(new PassThroughFork(store), new ObservableSource(store), store, network, []);
+      return new Jinaga(new AuthenticationNoOp(), factManager, null, developmentMode);
+    }
+
+    it("throws DistributionDeniedError for a structural denial (no-matching-rule)", async () => {
+      const j = makeJinaga(true);
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
+      };
+
+      await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
+    });
+
+    it("carries the structural diagnostics on the thrown error", async () => {
+      const j = makeJinaga(true);
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "spec-more-restrictive-than-rule", reason: "narrower than rule" }],
+      };
+
+      const error = await j.query(blogPosts, blog).catch(e => e);
+      expect(error).toBeInstanceOf(DistributionDeniedError);
+      expect(error.diagnostics).toHaveLength(1);
+      expect(error.diagnostics[0].code).toBe("spec-more-restrictive-than-rule");
+    });
+
+    it("does NOT throw for a reactive decision (the subscription race)", async () => {
+      const j = makeJinaga(true);
+      network.response = {
+        feeds: ["f"],
+        decisions: [{ feed: "f", decision: "reactive", reason: "pending authorization" }],
+      };
+
+      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+    });
+
+    it("does NOT throw for a non-structural denial (principal-excluded)", async () => {
+      const j = makeJinaga(true);
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "principal-excluded", reason: "excluded" }],
+      };
+
+      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+    });
+
+    it("stays silent-empty in production mode even for a structural denial", async () => {
+      const j = makeJinaga(false);
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
+      };
+
+      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+    });
+
+    it("queryWithDiagnostics never throws in development mode — it returns diagnostics", async () => {
+      const j = makeJinaga(true);
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
+      };
+
+      const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
+      expect(results).toEqual([]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].code).toBe("no-matching-rule");
+    });
+  });
+
+  describe("W7 — default development diagnostic handler", () => {
+    let errorSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+    let infoSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      infoSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+    });
+
+    it("logs no-matching-rule at error level", () => {
+      const handler = createDevelopmentDiagnosticHandler();
+      handler(diagnostic({ code: "no-matching-rule" }));
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain("no distribution rule");
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+
+    it("logs spec-more-restrictive-than-rule at error level", () => {
+      const handler = createDevelopmentDiagnosticHandler();
+      handler(diagnostic({ code: "spec-more-restrictive-than-rule" }));
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain("narrower than its share rule");
+    });
+
+    it("logs a non-reactive principal-excluded at warn level", () => {
+      const handler = createDevelopmentDiagnosticHandler();
+      handler(diagnostic({ code: "principal-excluded" }));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("not permitted");
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("logs a reactive decision at info level regardless of code", () => {
+      const handler = createDevelopmentDiagnosticHandler();
+      handler(diagnostic({ decision: "reactive", reactive: true, code: "not-authenticated" }));
+      expect(infoSpy).toHaveBeenCalledTimes(1);
+      expect(infoSpy.mock.calls[0][0]).toContain("pending authorization");
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("deduplicates identical diagnostics", () => {
+      const handler = createDevelopmentDiagnosticHandler();
+      const d = diagnostic({ code: "no-matching-rule" });
+      handler(d);
+      handler(d);
+      handler(d);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/distribution/developmentModeSpec.ts
+++ b/test/distribution/developmentModeSpec.ts
@@ -182,5 +182,23 @@ describe("development-mode distribution diagnostics (issue #207 W7/W8)", () => {
       handler(d);
       expect(errorSpy).toHaveBeenCalledTimes(1);
     });
+
+    it("bounds the dedupe set, evicting the oldest so it can recur but recent ones stay deduped", () => {
+      const handler = createDevelopmentDiagnosticHandler();
+      // More distinct messages than any reasonable cap, so the first is evicted.
+      const count = 2000;
+      for (let i = 0; i < count; i++) {
+        handler(diagnostic({ code: "no-matching-rule", specification: `spec-${i}` }));
+      }
+      expect(errorSpy).toHaveBeenCalledTimes(count);
+
+      // The most-recent message is still remembered — re-sending is deduped.
+      handler(diagnostic({ code: "no-matching-rule", specification: `spec-${count - 1}` }));
+      expect(errorSpy).toHaveBeenCalledTimes(count);
+
+      // The oldest was evicted, so re-sending it logs once more.
+      handler(diagnostic({ code: "no-matching-rule", specification: "spec-0" }));
+      expect(errorSpy).toHaveBeenCalledTimes(count + 1);
+    });
   });
 });


### PR DESCRIPTION
Third tranche of #207, **PR 2 of 3** for the W5–W10 follow-on. Builds on W5/W6/W10 (#221). W9 (lifecycle dedup/clearing) follows.

## W7 — `developmentMode` config + default console handler
- New `developmentMode?: boolean` on `JinagaBrowserConfig`. A library can't reliably read `NODE_ENV`, so the app passes it explicitly (e.g. `process.env.NODE_ENV !== 'production'`).
- When on, `JinagaBrowser` installs a default `onDistributionDiagnostic` handler that turns otherwise-silent denials into **deduplicated, actionable** console messages, tiered by severity:
  - `no-matching-rule` / `spec-more-restrictive-than-rule` → `console.error` (structural authoring errors)
  - non-reactive `principal-excluded` → `console.warn`
  - any `reactive` decision → `console.info` (the pending-authorization race)
- **Design note:** the handler writes straight to `console.*` rather than through `Trace`. `Trace` is a `NoOpTracer` by default (would swallow the messages), and flipping it on globally would flood the console with the library's internal `[Observer]` traces. Writing to `console.*` matches the tier mapping in the issue and guarantees visibility in dev. Happy to route through `Trace` instead if you'd prefer.

## W8 — `query` strict-throw in dev; silent-empty in prod
- In `developmentMode`, `query` throws a typed **`DistributionDeniedError`** (carrying the offending diagnostics) for a **structural** denial (`no-matching-rule` / `spec-more-restrictive-than-rule`) that provably never self-heals — so a mis-authored spec fails loudly at the call site.
- It **never throws for a `reactive` decision** (that would break the subscription race), and **never in production** (silent-empty as today).
- `queryWithDiagnostics` still never throws — it returns the diagnostics. `watch`/`subscribe` are unaffected.

The `developmentMode` flag threads through the `Jinaga` constructor (optional, defaults `false` — all existing call sites unaffected). The structural-denial predicate and `DistributionDeniedError` live in `managers/distributionDiagnostic.ts` so W7 and W8 share one definition of "structural."

## Load-bearing constraint
Everything keys on `reactive`: structural denials are loud (throw + `console.error`), the reactive race is quiet (`console.info`, no throw). Old replicators report no decisions → inert.

## Tests
Full suite: **553 passing** (+12: 6 W8 query-throw, 5 W7 handler tiers/dedup, plus queryWithDiagnostics-never-throws-in-dev).

Verified **end-to-end against replicator 3.7.0** via `JinagaBrowser({ developmentMode: true })`: `query` on a `no-matching-rule` spec throws `DistributionDeniedError` and logs it at error level, while a `reactive` spec logs an info line and returns empty **without throwing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)