### PR TITLE
Distribution diagnostics: clear the reactive race on transition (#207 W9)

### DIFF
--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -368,10 +368,15 @@ export class NetworkManager {
             if (!subscriber) {
                 // Wrap notifyFactsAdded so this feed's "began delivering data"
                 // signal fires after facts are saved (issue #207 W9), letting a
-                // reactive diagnostic clear when the race resolves.
+                // reactive diagnostic clear when the race resolves. Only signal
+                // when facts actually arrived: the subscriber calls
+                // notifyFactsAdded even for an empty graph (references present
+                // but load() returned nothing), which must not count as delivery.
                 const notify = async (envelopes: FactEnvelope[]) => {
                     await this.notifyFactsAdded(envelopes);
-                    this.handleFeedData(feed);
+                    if (envelopes.length > 0) {
+                        this.handleFeedData(feed);
+                    }
                 };
                 subscriber = new Subscriber(feed, this.network, this.store, notify, this.feedRefreshIntervalSeconds);
                 this.subscribers.set(feed, subscriber);

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -261,14 +261,63 @@ export class NetworkManager {
     private currentBatch: LoadBatch | null = null;
     private subscribers: Map<string, Subscriber> = new Map();
     private readonly feedRefreshIntervalSeconds: number;
+    // Per-feed "began delivering data" signal (issue #207 W9). `feedsDelivered`
+    // remembers feeds that have delivered at least one fact so a late listener
+    // fires immediately; `feedDataListeners` holds observers waiting to clear a
+    // reactive diagnostic when the feed's race resolves.
+    private readonly feedsDelivered = new Set<string>();
+    private readonly feedDataListeners = new Map<string, Set<() => void>>();
 
     constructor(
         private readonly network: Network,
         private readonly store: Storage,
         private readonly notifyFactsAdded: (factsAdded: FactEnvelope[]) => Promise<void>,
         feedRefreshIntervalSeconds?: number
-    ) { 
+    ) {
         this.feedRefreshIntervalSeconds = feedRefreshIntervalSeconds || 90; // Default to 90 seconds
+    }
+
+    /**
+     * Register a listener fired the first time `feed` delivers data (issue #207
+     * W9). If the feed has already delivered, the listener fires immediately.
+     * Returns an unregister function. The observer uses this to clear a
+     * `reactive` diagnostic once the subscription race resolves.
+     */
+    onFeedData(feed: string, listener: () => void): () => void {
+        if (this.feedsDelivered.has(feed)) {
+            // Already delivered — fire immediately (isolated) and don't retain.
+            try { listener(); } catch (e) { Trace.error(e); }
+            return () => { };
+        }
+        let listeners = this.feedDataListeners.get(feed);
+        if (!listeners) {
+            listeners = new Set();
+            this.feedDataListeners.set(feed, listeners);
+        }
+        listeners.add(listener);
+        return () => {
+            const set = this.feedDataListeners.get(feed);
+            if (set) {
+                set.delete(listener);
+                if (set.size === 0) this.feedDataListeners.delete(feed);
+            }
+        };
+    }
+
+    // Called when a feed's subscriber saves new facts. Fires waiting listeners
+    // once, on the first delivery for that feed.
+    private handleFeedData(feed: string) {
+        if (this.feedsDelivered.has(feed)) {
+            return;
+        }
+        this.feedsDelivered.add(feed);
+        const listeners = this.feedDataListeners.get(feed);
+        if (listeners) {
+            this.feedDataListeners.delete(feed);
+            for (const listener of listeners) {
+                try { listener(); } catch (e) { Trace.error(e); }
+            }
+        }
     }
 
     /**
@@ -317,7 +366,14 @@ export class NetworkManager {
         const subscribers = feeds.map(feed => {
             let subscriber = this.subscribers.get(feed);
             if (!subscriber) {
-                subscriber = new Subscriber(feed, this.network, this.store, this.notifyFactsAdded, this.feedRefreshIntervalSeconds);
+                // Wrap notifyFactsAdded so this feed's "began delivering data"
+                // signal fires after facts are saved (issue #207 W9), letting a
+                // reactive diagnostic clear when the race resolves.
+                const notify = async (envelopes: FactEnvelope[]) => {
+                    await this.notifyFactsAdded(envelopes);
+                    this.handleFeedData(feed);
+                };
+                subscriber = new Subscriber(feed, this.network, this.store, notify, this.feedRefreshIntervalSeconds);
                 this.subscribers.set(feed, subscriber);
             }
             return subscriber;

--- a/src/managers/developmentDiagnosticHandler.ts
+++ b/src/managers/developmentDiagnosticHandler.ts
@@ -46,7 +46,12 @@ export function createDevelopmentDiagnosticHandler(): (diagnostic: DistributionD
             seen.delete(seen.values().next().value as string);
         }
 
-        if (diagnostic.reactive) {
+        // A clearing diagnostic (W9) resolves an earlier reactive line; always
+        // an informational, positive signal.
+        if (diagnostic.cleared) {
+            console.info(message);
+        }
+        else if (diagnostic.reactive) {
             console.info(message);
         }
         else if (diagnostic.code === 'no-matching-rule' || diagnostic.code === 'spec-more-restrictive-than-rule') {
@@ -60,6 +65,10 @@ export function createDevelopmentDiagnosticHandler(): (diagnostic: DistributionD
 
 function formatMessage(diagnostic: DistributionDiagnostic): string {
     const spec = diagnostic.specification.trim();
+    if (diagnostic.cleared) {
+        return `[jinaga] Specification is now authorized for the current user; ` +
+            `data is flowing. The earlier pending-authorization notice is resolved.\n${spec}`;
+    }
     if (diagnostic.reactive) {
         return `[jinaga] Specification is pending authorization for the current user; ` +
             `it will populate when the authorizing fact arrives.\n${spec}`;

--- a/src/managers/distributionDiagnostic.ts
+++ b/src/managers/distributionDiagnostic.ts
@@ -27,6 +27,18 @@ export interface DistributionDiagnostic {
     code?: DistributionDenialCode;
     reactive: boolean;                // true => will self-heal; NEVER treat as fatal
     reason: string;
+    /**
+     * The feed hash this diagnostic pertains to (issue #207 W9). Lets a
+     * consumer correlate a raised diagnostic with its later clearing and
+     * deduplicate per `(feed, code)`.
+     */
+    feed?: string;
+    /**
+     * True when this diagnostic reports that a previously `reactive` feed has
+     * begun delivering data — the subscription race resolving (issue #207 W9).
+     * The matching raised diagnostic (same `feed`) can be considered resolved.
+     */
+    cleared?: boolean;
 }
 
 /**
@@ -48,8 +60,33 @@ export function toDistributionDiagnostics(
             decision: d.decision as 'reactive' | 'denied',
             code: d.code,
             reactive: d.decision === 'reactive',
-            reason: d.reason
+            reason: d.reason,
+            feed: d.feed
         }));
+}
+
+/**
+ * Build the clearing diagnostic (issue #207 W9) emitted when a previously
+ * `reactive` feed begins delivering data — the subscription race resolving. It
+ * carries the same feed/code/operation as the raised diagnostic, with
+ * `cleared: true`, so a consumer can retire the earlier "pending authorization"
+ * signal.
+ */
+export function toClearingDiagnostic(
+    operation: DistributionDiagnostic['operation'],
+    specification: string,
+    decision: FeedDecision
+): DistributionDiagnostic {
+    return {
+        operation,
+        specification,
+        decision: decision.decision === 'denied' ? 'denied' : 'reactive',
+        code: decision.code,
+        reactive: decision.decision === 'reactive',
+        reason: decision.reason,
+        feed: decision.feed,
+        cleared: true
+    };
 }
 
 /**

--- a/src/managers/distributionDiagnostic.ts
+++ b/src/managers/distributionDiagnostic.ts
@@ -82,8 +82,13 @@ export function toClearingDiagnostic(
         specification,
         decision: decision.decision === 'denied' ? 'denied' : 'reactive',
         code: decision.code,
-        reactive: decision.decision === 'reactive',
-        reason: decision.reason,
+        // The race has resolved, so this is no longer a pending state: a
+        // consumer that only inspects `reactive`/`reason` (ignoring `cleared`)
+        // must not read it as another pending-authorization event. Hence
+        // `reactive: false` and a resolution-specific reason rather than reusing
+        // the original "pending authorization" text.
+        reactive: false,
+        reason: 'Distribution is now authorized for the current user; the feed is delivering data.',
         feed: decision.feed,
         cleared: true
     };

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -135,6 +135,15 @@ export class FactManager {
         this.networkManager.unsubscribe(feeds);
     }
 
+    /**
+     * Register a listener fired when `feed` first delivers data (issue #207 W9),
+     * so the observer can clear a `reactive` diagnostic once the race resolves.
+     * Returns an unregister function.
+     */
+    onFeedData(feed: string, listener: () => void): () => void {
+        return this.networkManager.onFeedData(feed, listener);
+    }
+
     async load(references: FactReference[]): Promise<FactEnvelope[]> {
         const loaded = await this.fork.load(references);
         Trace.counter("facts_loaded", loaded.length);

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -1,6 +1,6 @@
 import { computeObjectHash } from "../fact/hash";
 import { FeedDecision } from "../http/messages";
-import { DistributionDiagnostic, toDistributionDiagnostics } from "../managers/distributionDiagnostic";
+import { DistributionDiagnostic, toClearingDiagnostic, toDistributionDiagnostics } from "../managers/distributionDiagnostic";
 import { FactManager } from "../managers/factManager";
 import { SpecificationListener } from "../observable/observable";
 import { describeDeclaration, describeSpecification } from "../specification/description";
@@ -166,6 +166,12 @@ export class ObserverImpl<T> implements Observer<T> {
     private readonly _diagnostics: DistributionDiagnostic[] = [];
     private readonly diagnosticHandlers: ((diagnostic: DistributionDiagnostic) => void)[] = [];
     private readonly specificationString: string;
+    /**
+     * Unregister callbacks for the per-feed "began delivering data" listeners
+     * (issue #207 W9) that clear a reactive diagnostic when the subscription
+     * race resolves. Torn down in `stop()`.
+     */
+    private readonly clearingUnsubscribes: (() => void)[] = [];
 
     constructor(
         private factManager: FactManager,
@@ -337,6 +343,12 @@ export class ObserverImpl<T> implements Observer<T> {
 
     public stop() {
         this.stopped = true;
+        // Drop any diagnostic-clearing listeners (issue #207 W9) so a feed that
+        // delivers after stop() does not emit through a torn-down observer.
+        for (const unsubscribe of this.clearingUnsubscribes) {
+            unsubscribe();
+        }
+        this.clearingUnsubscribes.length = 0;
         for (const branch of this.branches) {
             for (const listener of branch.listeners) {
                 this.factManager.removeSpecificationListener(listener);
@@ -428,6 +440,7 @@ export class ObserverImpl<T> implements Observer<T> {
                 }
                 branch.feeds = feeds;
                 decisions.push(...branchDecisions);
+                this.registerClearingListeners(feeds, branchDecisions);
             }));
         }
         else {
@@ -474,6 +487,55 @@ export class ObserverImpl<T> implements Observer<T> {
     private safelyInvokeDiagnostic(handler: (diagnostic: DistributionDiagnostic) => void, diagnostic: DistributionDiagnostic) {
         try {
             handler(diagnostic);
+        }
+        catch (e) {
+            Trace.error(e);
+        }
+    }
+
+    /**
+     * For each kept-alive `reactive` feed, register a one-shot listener that
+     * emits a clearing diagnostic once the feed begins delivering data (issue
+     * #207 W9). A structural denial never delivers, so it never clears; only
+     * reactive feeds — the subscription race — resolve this way. Fires once per
+     * feed (NetworkManager dedupes the transition).
+     */
+    private registerClearingListeners(feeds: string[], decisions: FeedDecision[]) {
+        if (this.stopped) {
+            return;
+        }
+        const keptAlive = new Set(feeds);
+        for (const decision of decisions) {
+            if (decision.decision === 'reactive' && decision.feed && keptAlive.has(decision.feed)) {
+                const unsubscribe = this.factManager.onFeedData(decision.feed, () => this.emitFeedCleared(decision));
+                this.clearingUnsubscribes.push(unsubscribe);
+            }
+        }
+    }
+
+    /**
+     * Emit the clearing diagnostic for a resolved reactive feed to the observer
+     * handlers (W6) and the instance sink (W5). Guarded like `captureDiagnostics`
+     * so it never disturbs the observer.
+     */
+    private emitFeedCleared(decision: FeedDecision) {
+        if (this.stopped) {
+            return;
+        }
+        try {
+            const cleared = toClearingDiagnostic('subscribe', this.specificationString, decision);
+            this._diagnostics.push(cleared);
+            for (const handler of this.diagnosticHandlers) {
+                this.safelyInvokeDiagnostic(handler, cleared);
+            }
+            if (this.onDiagnostics) {
+                try {
+                    this.onDiagnostics([cleared]);
+                }
+                catch (e) {
+                    Trace.error(e);
+                }
+            }
         }
         catch (e) {
             Trace.error(e);

--- a/test/distribution/distributionClearingSpec.ts
+++ b/test/distribution/distributionClearingSpec.ts
@@ -1,5 +1,6 @@
 import {
   AuthenticationNoOp,
+  dehydrateFact,
   DistributionDiagnostic,
   FactEnvelope,
   FactManager,
@@ -18,10 +19,12 @@ import { DistributionIntersectionBranch } from "../../src/distribution/distribut
 import { Blog, Post, model } from "../blogModel";
 
 // A Network double whose feed stream can be driven on demand, so a test can
-// simulate a `reactive` feed's race resolving — the feed later delivering data
-// (issue #207 W9).
+// simulate a `reactive` feed's race resolving — the feed later delivering real
+// facts (issue #207 W9). `loadResult` is what `load()` returns for the
+// delivered references, so a test controls whether facts actually arrive.
 class ControllableNetwork implements Network {
   public response: FeedsResponse = { feeds: [] };
+  public loadResult: FactEnvelope[] = [];
   private streamCallbacks = new Map<string, (refs: FactReference[], bookmark: string) => Promise<void>>();
 
   feeds(): Promise<FeedsResponse> { return Promise.resolve(this.response); }
@@ -40,17 +43,17 @@ class ControllableNetwork implements Network {
     return () => {};
   }
 
-  load(_factReferences: FactReference[]): Promise<FactEnvelope[]> { return Promise.resolve([]); }
+  load(_factReferences: FactReference[]): Promise<FactEnvelope[]> { return Promise.resolve(this.loadResult); }
   intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
     return Promise.resolve([{ start, specification }]);
   }
 
-  // Test helper: deliver a novel fact reference on a feed, which the subscriber
-  // treats as new data — triggering the feed's "began delivering" signal.
-  async deliver(feed: string): Promise<void> {
+  // Test helper: push feed references, which the subscriber loads (via
+  // loadResult) and saves — the real "began delivering" path.
+  async deliver(feed: string, references: FactReference[]): Promise<void> {
     const cb = this.streamCallbacks.get(feed);
     if (!cb) throw new Error(`No stream open for feed ${feed}`);
-    await cb([{ type: Post.Type, hash: "novel-post-hash" }], "bookmark-2");
+    await cb(references, "bookmark-2");
   }
 }
 
@@ -62,6 +65,12 @@ describe("distribution diagnostic clearing on transition (issue #207 W9)", () =>
     facts.ofType(Post).join(post => post.blog, blog)
   );
 
+  // A real Post under the blog, so delivering it loads + saves actual facts.
+  const post = new Post(blog, new User("author"), "2020-01-01T00:00:00Z");
+  const postRecords = dehydrateFact(post);
+  const postEnvelopes: FactEnvelope[] = postRecords.map(f => ({ fact: f, signatures: [] }));
+  const postRef: FactReference = { type: postRecords[postRecords.length - 1].type, hash: postRecords[postRecords.length - 1].hash };
+
   let network: ControllableNetwork;
   let store: MemoryStore;
   let j: Jinaga;
@@ -72,6 +81,7 @@ describe("distribution diagnostic clearing on transition (issue #207 W9)", () =>
       feeds: [FEED],
       decisions: [{ feed: FEED, decision: "reactive", reason: "pending authorization" }],
     };
+    network.loadResult = postEnvelopes;
     store = new MemoryStore();
     const factManager = new FactManager(new PassThroughFork(store), new ObservableSource(store), store, network, []);
     j = new Jinaga(new AuthenticationNoOp(), factManager, null);
@@ -90,13 +100,29 @@ describe("distribution diagnostic clearing on transition (issue #207 W9)", () =>
     expect(received[0].cleared).toBeFalsy();
     expect(received[0].feed).toBe(FEED);
 
-    // The race resolves: the feed delivers data.
-    await network.deliver(FEED);
+    // The race resolves: the feed delivers real facts.
+    await network.deliver(FEED, [postRef]);
 
     expect(received).toHaveLength(2);
     expect(received[1].cleared).toBe(true);
+    expect(received[1].reactive).toBe(false);
     expect(received[1].feed).toBe(FEED);
     expect(received[1].operation).toBe("subscribe");
+    expect(received[1].reason).not.toContain("pending");
+
+    observer.stop();
+  });
+
+  it("does NOT clear when the feed delivers references but no facts load", async () => {
+    network.loadResult = []; // references arrive, but load returns an empty graph
+    const received: DistributionDiagnostic[] = [];
+    j.onDistributionDiagnostic(d => received.push(d));
+
+    const observer = j.subscribe(blogPosts, blog, () => {});
+    await observer.loaded();
+    await network.deliver(FEED, [postRef]);
+
+    expect(received.filter(d => d.cleared)).toHaveLength(0);
 
     observer.stop();
   });
@@ -104,7 +130,7 @@ describe("distribution diagnostic clearing on transition (issue #207 W9)", () =>
   it("exposes both the raised and clearing diagnostics via observer.diagnostics()", async () => {
     const observer = j.subscribe(blogPosts, blog, () => {});
     await observer.loaded();
-    await network.deliver(FEED);
+    await network.deliver(FEED, [postRef]);
 
     const diagnostics = observer.diagnostics();
     expect(diagnostics).toHaveLength(2);
@@ -121,8 +147,8 @@ describe("distribution diagnostic clearing on transition (issue #207 W9)", () =>
     const observer = j.subscribe(blogPosts, blog, () => {});
     await observer.loaded();
 
-    await network.deliver(FEED);
-    await network.deliver(FEED);
+    await network.deliver(FEED, [postRef]);
+    await network.deliver(FEED, [postRef]);
 
     const cleared = received.filter(d => d.cleared);
     expect(cleared).toHaveLength(1);
@@ -138,16 +164,16 @@ describe("distribution diagnostic clearing on transition (issue #207 W9)", () =>
     await observer.loaded();
     observer.stop();
 
-    await network.deliver(FEED);
+    await network.deliver(FEED, [postRef]);
 
     expect(received.filter(d => d.cleared)).toHaveLength(0);
   });
 
   describe("NetworkManager.onFeedData", () => {
-    it("fires a late-registered listener immediately once the feed has delivered", async () => {
+    it("fires a late-registered listener immediately once the feed has delivered facts", async () => {
       const manager = new NetworkManager(network, store, async () => {});
       const { feeds } = await manager.subscribe([], blogPosts.specification);
-      await network.deliver(FEED);
+      await network.deliver(FEED, [postRef]);
 
       let fired = false;
       const unregister = manager.onFeedData(FEED, () => { fired = true; });

--- a/test/distribution/distributionClearingSpec.ts
+++ b/test/distribution/distributionClearingSpec.ts
@@ -1,0 +1,160 @@
+import {
+  AuthenticationNoOp,
+  DistributionDiagnostic,
+  FactEnvelope,
+  FactManager,
+  FactReference,
+  FeedResponse,
+  FeedsResponse,
+  Jinaga,
+  MemoryStore,
+  ObservableSource,
+  PassThroughFork,
+  Specification,
+  User,
+} from "@src";
+import { Network, NetworkManager } from "../../src/managers/NetworkManager";
+import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
+import { Blog, Post, model } from "../blogModel";
+
+// A Network double whose feed stream can be driven on demand, so a test can
+// simulate a `reactive` feed's race resolving — the feed later delivering data
+// (issue #207 W9).
+class ControllableNetwork implements Network {
+  public response: FeedsResponse = { feeds: [] };
+  private streamCallbacks = new Map<string, (refs: FactReference[], bookmark: string) => Promise<void>>();
+
+  feeds(): Promise<FeedsResponse> { return Promise.resolve(this.response); }
+  fetchFeed(_feed: string, bookmark: string): Promise<FeedResponse> { return Promise.resolve({ references: [], bookmark }); }
+
+  streamFeed(
+    feed: string,
+    bookmark: string,
+    onResponse: (factReferences: FactReference[], nextBookmark: string) => Promise<void>,
+    _onError: (err: Error) => void,
+    _feedRefreshIntervalSeconds: number
+  ): () => void {
+    this.streamCallbacks.set(feed, onResponse);
+    // Resolve the subscriber's start() with an initial empty response.
+    Promise.resolve().then(() => onResponse([], bookmark));
+    return () => {};
+  }
+
+  load(_factReferences: FactReference[]): Promise<FactEnvelope[]> { return Promise.resolve([]); }
+  intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+    return Promise.resolve([{ start, specification }]);
+  }
+
+  // Test helper: deliver a novel fact reference on a feed, which the subscriber
+  // treats as new data — triggering the feed's "began delivering" signal.
+  async deliver(feed: string): Promise<void> {
+    const cb = this.streamCallbacks.get(feed);
+    if (!cb) throw new Error(`No stream open for feed ${feed}`);
+    await cb([{ type: Post.Type, hash: "novel-post-hash" }], "bookmark-2");
+  }
+}
+
+const FEED = "reactive-feed";
+
+describe("distribution diagnostic clearing on transition (issue #207 W9)", () => {
+  const blog = new Blog(new User("creator"), "domain");
+  const blogPosts = model.given(Blog).match((blog, facts) =>
+    facts.ofType(Post).join(post => post.blog, blog)
+  );
+
+  let network: ControllableNetwork;
+  let store: MemoryStore;
+  let j: Jinaga;
+
+  beforeEach(() => {
+    network = new ControllableNetwork();
+    network.response = {
+      feeds: [FEED],
+      decisions: [{ feed: FEED, decision: "reactive", reason: "pending authorization" }],
+    };
+    store = new MemoryStore();
+    const factManager = new FactManager(new PassThroughFork(store), new ObservableSource(store), store, network, []);
+    j = new Jinaga(new AuthenticationNoOp(), factManager, null);
+  });
+
+  it("emits a clearing diagnostic when a reactive feed begins delivering data", async () => {
+    const received: DistributionDiagnostic[] = [];
+    j.onDistributionDiagnostic(d => received.push(d));
+
+    const observer = j.subscribe(blogPosts, blog, () => {});
+    await observer.loaded();
+
+    // Raised only, so far.
+    expect(received).toHaveLength(1);
+    expect(received[0].reactive).toBe(true);
+    expect(received[0].cleared).toBeFalsy();
+    expect(received[0].feed).toBe(FEED);
+
+    // The race resolves: the feed delivers data.
+    await network.deliver(FEED);
+
+    expect(received).toHaveLength(2);
+    expect(received[1].cleared).toBe(true);
+    expect(received[1].feed).toBe(FEED);
+    expect(received[1].operation).toBe("subscribe");
+
+    observer.stop();
+  });
+
+  it("exposes both the raised and clearing diagnostics via observer.diagnostics()", async () => {
+    const observer = j.subscribe(blogPosts, blog, () => {});
+    await observer.loaded();
+    await network.deliver(FEED);
+
+    const diagnostics = observer.diagnostics();
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics[0].cleared).toBeFalsy();
+    expect(diagnostics[1].cleared).toBe(true);
+
+    observer.stop();
+  });
+
+  it("fires the clearing only once even if the feed delivers again", async () => {
+    const received: DistributionDiagnostic[] = [];
+    j.onDistributionDiagnostic(d => received.push(d));
+
+    const observer = j.subscribe(blogPosts, blog, () => {});
+    await observer.loaded();
+
+    await network.deliver(FEED);
+    await network.deliver(FEED);
+
+    const cleared = received.filter(d => d.cleared);
+    expect(cleared).toHaveLength(1);
+
+    observer.stop();
+  });
+
+  it("does not emit a clearing after the observer is stopped", async () => {
+    const received: DistributionDiagnostic[] = [];
+    j.onDistributionDiagnostic(d => received.push(d));
+
+    const observer = j.subscribe(blogPosts, blog, () => {});
+    await observer.loaded();
+    observer.stop();
+
+    await network.deliver(FEED);
+
+    expect(received.filter(d => d.cleared)).toHaveLength(0);
+  });
+
+  describe("NetworkManager.onFeedData", () => {
+    it("fires a late-registered listener immediately once the feed has delivered", async () => {
+      const manager = new NetworkManager(network, store, async () => {});
+      const { feeds } = await manager.subscribe([], blogPosts.specification);
+      await network.deliver(FEED);
+
+      let fired = false;
+      const unregister = manager.onFeedData(FEED, () => { fired = true; });
+      expect(fired).toBe(true);
+      unregister();
+      // Release the subscriber so its refresh timer doesn't leak.
+      manager.unsubscribe(feeds);
+    });
+  });
+});


### PR DESCRIPTION
Final tranche of #207, **PR 3 of 3**. Completes W5–W10 (after #221 and #222). Directly resolves the reactive-staleness point raised in the #220 review.

## The problem
When a `reactive` feed heals — the authorizing fact arrives and the feed begins delivering data — the earlier "pending authorization" diagnostic went stale: a long-lived subscription could show populated results alongside a lingering `reactive` diagnostic. W9 fires a **clearing** diagnostic on that transition.

## What's here
- **Per-feed "began delivering data" signal.** `NetworkManager` wraps each `Subscriber`'s `notifyFactsAdded` so the first save on a feed fires `onFeedData` listeners once (a late registration fires immediately). `FactManager.onFeedData` delegates to it.
- **Observer clears the race.** For each kept-alive `reactive` feed, the observer registers a one-shot listener that, when the feed first delivers data, emits a clearing diagnostic (`cleared: true`, same `feed`/`code`) through the same observer-level (W6) and instance (W5) channels. Listeners are torn down on `stop()`.
- **Structural denials never clear.** A `no-matching-rule`/`spec-more-restrictive-than-rule` feed isn't kept alive and never delivers data, so it never clears — only the `reactive` race resolves this way. Correct by construction.
- **Diagnostic gains `feed` + `cleared`.** `feed` (the hash) lets a consumer correlate a raised diagnostic with its clearing and dedupe per `(feed, code)`; `cleared` marks the resolution. The W7 dev handler logs a clearing at `info` level as a resolved/now-flowing message.
- **Once per transition.** Raised once per subscribe; clearing once when the feed first delivers (NetworkManager dedupes the transition).

## Load-bearing constraint
Still keyed on `reactive`. Only the reactive race clears; structural denials stay reported. Nothing here rejects `loaded()` or changes feed registration/keep-alive — the clearing is purely additive signal.

## Tests
Full suite: **559 passing** (+5 W9). The tests drive the **real** `Observer`/`FactManager`/`NetworkManager`/`Subscriber` transition path (streamFeed → whichExist → load → save → notifyFactsAdded → onFeedData), with only the HTTP transport doubled.

**On live verification:** a real-replicator heal needs a full JWT auth-fact-arrival flow that isn't scripted here, so W9's clearing is covered by the integration tests above rather than a live heal. The reactive *emission* it builds on was verified end-to-end against replicator 3.7.0 in #221, and I re-ran that live check on this branch to confirm the raised path is unchanged.

With this, #207's client tranche (W4–W10 + W8b) is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)