### PR TITLE
Fix multi-hop authorization rules across GraphDeserializer flush batches

### DIFF
--- a/src/authorization/authorizationRules.ts
+++ b/src/authorization/authorizationRules.ts
@@ -5,51 +5,52 @@ import { FactConstructor, FactRepository, LabelOf, Model, Traversal, getPayload 
 import { Condition, Label, Match, PathCondition, Specification, splitBeforeFirstSuccessor } from '../specification/specification';
 import { SpecificationParser } from '../specification/specification-parser';
 import { FactEnvelope, FactRecord, FactReference, ReferencesByName, Storage, factReferenceEquals } from '../storage';
-import { distinct, flatten } from '../util/fn';
+import { distinct, filterAsync, flattenAsync } from '../util/fn';
 import { Trace } from '../util/trace';
 
 class FactGraph {
+    private loadedRecords: FactRecord[] = [];
+
     constructor(
-        private factRecords: FactRecord[]
+        private factRecords: FactRecord[],
+        private store: Storage
     ) { }
 
-    getField(reference: FactReference, name: string) {
-        const record = this.findFact(reference);
+    async getField(reference: FactReference, name: string) {
+        const record = await this.findFact(reference);
         if (record === null) {
             throw new Error(`The fact ${reference.type}:${reference.hash} is not defined.`);
         }
         return record.fields[name];
     }
 
-    executeSpecification(givenName: string, matches: Match[], label: string, fact: FactRecord): FactReference[] {
+    async executeSpecification(givenName: string, matches: Match[], label: string, fact: FactRecord): Promise<FactReference[]> {
         const references: ReferencesByName = {
             [givenName]: {
                 type: fact.type,
                 hash: fact.hash
             }
         };
-        const results = this.executeMatches(references, matches);
+        const results = await this.executeMatches(references, matches);
         return results.map(result => result[label]);
     }
 
-    private executeMatches(references: ReferencesByName, matches: Match[]): ReferencesByName[] {
-        const results = matches.reduce(
-            (tuples, match) => tuples.flatMap(
-                tuple => this.executeMatch(tuple, match)
-            ),
-            [references]
-        );
-        return results;
+    private async executeMatches(references: ReferencesByName, matches: Match[]): Promise<ReferencesByName[]> {
+        let tuples = [references];
+        for (const match of matches) {
+            tuples = await flattenAsync(tuples, tuple => this.executeMatch(tuple, match));
+        }
+        return tuples;
     }
 
-    private executeMatch(references: ReferencesByName, match: Match): ReferencesByName[] {
+    private async executeMatch(references: ReferencesByName, match: Match): Promise<ReferencesByName[]> {
         let results: ReferencesByName[] = [];
         if (match.conditions.length === 0) {
             throw new Error("A match must have at least one condition.");
         }
         const firstCondition = match.conditions[0];
         if (firstCondition.type === "path") {
-            const result: FactReference[] = this.executePathCondition(references, match.unknown, firstCondition);
+            const result: FactReference[] = await this.executePathCondition(references, match.unknown, firstCondition);
             results = result.map(reference => ({
                 ...references,
                 [match.unknown.name]: {
@@ -64,29 +65,28 @@ class FactGraph {
 
         const remainingConditions = match.conditions.slice(1);
         for (const condition of remainingConditions) {
-            results = this.filterByCondition(references, match.unknown, results, condition);
+            results = await this.filterByCondition(references, match.unknown, results, condition);
         }
         return results;
     }
 
-    private executePathCondition(references: ReferencesByName, unknown: Label, pathCondition: PathCondition): FactReference[] {
+    private async executePathCondition(references: ReferencesByName, unknown: Label, pathCondition: PathCondition): Promise<FactReference[]> {
         if (!references.hasOwnProperty(pathCondition.labelRight)) {
             throw new Error(`The label ${pathCondition.labelRight} is not defined.`);
         }
-        const start = references[pathCondition.labelRight];
-        const predecessors = pathCondition.rolesRight.reduce(
-            (set, role) => this.executePredecessorStep(set, role.name, role.predecessorType),
-            [start]
-        );
+        let predecessors = [references[pathCondition.labelRight]];
+        for (const role of pathCondition.rolesRight) {
+            predecessors = await this.executePredecessorStep(predecessors, role.name, role.predecessorType);
+        }
         if (pathCondition.rolesLeft.length > 0) {
             throw new Error('Cannot execute successor steps on evidence.');
         }
         return predecessors;
     }
 
-    private executePredecessorStep(set: FactReference[], name: string, predecessorType: string): FactReference[] {
-        return flatten(set, reference => {
-            const record = this.findFact(reference);
+    private async executePredecessorStep(set: FactReference[], name: string, predecessorType: string): Promise<FactReference[]> {
+        return await flattenAsync(set, async reference => {
+            const record = await this.findFact(reference);
             if (record === null) {
                 throw new Error(`The fact ${reference.type}:${reference.hash} is not defined.`);
             }
@@ -95,14 +95,14 @@ class FactGraph {
         });
     }
 
-    private filterByCondition(references: ReferencesByName, unknown: Label, results: ReferencesByName[], condition: Condition): ReferencesByName[] {
+    private async filterByCondition(references: ReferencesByName, unknown: Label, results: ReferencesByName[], condition: Condition): Promise<ReferencesByName[]> {
         if (condition.type === "path") {
-            const otherResults = this.executePathCondition(references, unknown, condition);
+            const otherResults = await this.executePathCondition(references, unknown, condition);
             return results.filter(result => otherResults.some(factReferenceEquals(result[unknown.name])));
         }
         else if (condition.type === "existential") {
-            const matchingReferences = results.filter(result => {
-                const matches = this.executeMatches(result, condition.matches);
+            const matchingReferences = await filterAsync(results, async result => {
+                const matches = await this.executeMatches(result, condition.matches);
                 return condition.exists ?
                     matches.length > 0 :
                     matches.length === 0;
@@ -115,8 +115,27 @@ class FactGraph {
         }
     }
 
-    private findFact(reference: FactReference): FactRecord | null {
-        return this.factRecords.find(factReferenceEquals(reference)) ?? null;
+    // A fact referenced by a multi-hop rule may live in an earlier flush batch
+    // than the one currently being authorized (see GraphDeserializer's
+    // flushThreshold). Such a fact is not in `factRecords`, but if it has
+    // already been saved to the store, we can load it from there instead of
+    // failing the whole authorization.
+    private async findFact(reference: FactReference): Promise<FactRecord | null> {
+        const local = this.factRecords.find(factReferenceEquals(reference));
+        if (local) {
+            return local;
+        }
+        const loaded = this.loadedRecords.find(factReferenceEquals(reference));
+        if (loaded) {
+            return loaded;
+        }
+        const envelopes = await this.store.load([reference]);
+        const record = envelopes.map(e => e.fact).find(factReferenceEquals(reference));
+        if (record) {
+            this.loadedRecords.push(record);
+            return record;
+        }
+        return null;
     }
 }
 
@@ -200,7 +219,7 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
         if (head.projection.type !== 'fact') {
             throw new Error('The head of the specification must project a fact.');
         }
-        let results = graph.executeSpecification(
+        let results = await graph.executeSpecification(
             head.given[0].label.name,
             head.matches,
             head.projection.label,
@@ -256,7 +275,7 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
         if (head.projection.type !== 'fact') {
             throw new Error('The head of the specification must project a fact.');
         }
-        const results = graph.executeSpecification(
+        const results = await graph.executeSpecification(
             head.given[0].label.name,
             head.matches,
             head.projection.label,
@@ -274,7 +293,9 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
             }
         }
         else {
-            publicKeys.push(...results.map(result => graph.getField(result, 'publicKey')));
+            for (const result of results) {
+                publicKeys.push(await graph.getField(result, 'publicKey'));
+            }
         }
 
         // Find the intersection between the available keys and the public keys.
@@ -464,7 +485,7 @@ export class AuthorizationRules {
             };
         }
 
-        const graph = new FactGraph(factEnvelopes.map(e => e.fact));
+        const graph = new FactGraph(factEnvelopes.map(e => e.fact), store);
         let authorizedKeys: string[] = [];
         for (const rule of rules) {
             const population = await rule.getAuthorizedPopulation(candidateKeys, envelope, graph, store);

--- a/src/authorization/authorizationRules.ts
+++ b/src/authorization/authorizationRules.ts
@@ -5,11 +5,12 @@ import { FactConstructor, FactRepository, LabelOf, Model, Traversal, getPayload 
 import { Condition, Label, Match, PathCondition, Specification, splitBeforeFirstSuccessor } from '../specification/specification';
 import { SpecificationParser } from '../specification/specification-parser';
 import { FactEnvelope, FactRecord, FactReference, ReferencesByName, Storage, factReferenceEquals } from '../storage';
-import { distinct, filterAsync, flattenAsync } from '../util/fn';
+import { distinct, filterAsync, flatten, flattenAsync } from '../util/fn';
 import { Trace } from '../util/trace';
 
 class FactGraph {
     private loadedRecords: FactRecord[] = [];
+    private pendingLoads = new Map<string, Promise<void>>();
 
     constructor(
         private factRecords: FactRecord[],
@@ -85,8 +86,11 @@ class FactGraph {
     }
 
     private async executePredecessorStep(set: FactReference[], name: string, predecessorType: string): Promise<FactReference[]> {
-        return await flattenAsync(set, async reference => {
-            const record = await this.findFact(reference);
+        // Resolve every reference needed for this step with a single batched
+        // store read, rather than one store.load() call per fact.
+        await this.ensureLoaded(set);
+        return flatten(set, reference => {
+            const record = this.findFactSync(reference);
             if (record === null) {
                 throw new Error(`The fact ${reference.type}:${reference.hash} is not defined.`);
             }
@@ -121,21 +125,59 @@ class FactGraph {
     // already been saved to the store, we can load it from there instead of
     // failing the whole authorization.
     private async findFact(reference: FactReference): Promise<FactRecord | null> {
-        const local = this.factRecords.find(factReferenceEquals(reference));
-        if (local) {
-            return local;
+        await this.ensureLoaded([reference]);
+        return this.findFactSync(reference);
+    }
+
+    private findFactSync(reference: FactReference): FactRecord | null {
+        return this.factRecords.find(factReferenceEquals(reference))
+            ?? this.loadedRecords.find(factReferenceEquals(reference))
+            ?? null;
+    }
+
+    // Resolves every reference not already known locally with as few
+    // store.load() calls as possible: references still missing after
+    // checking `factRecords` and the cache are fetched in a single batched
+    // call, and concurrent requests for the same reference share one
+    // in-flight load instead of issuing duplicate store reads.
+    private async ensureLoaded(references: FactReference[]): Promise<void> {
+        const missing = references.filter(r => !this.findFactSync(r));
+        if (missing.length === 0) {
+            return;
         }
-        const loaded = this.loadedRecords.find(factReferenceEquals(reference));
-        if (loaded) {
-            return loaded;
+
+        const pending = missing
+            .map(r => this.pendingLoads.get(this.factKeyOf(r)))
+            .filter((p): p is Promise<void> => p !== undefined);
+        if (pending.length > 0) {
+            await Promise.all(pending);
         }
-        const envelopes = await this.store.load([reference]);
-        const record = envelopes.map(e => e.fact).find(factReferenceEquals(reference));
-        if (record) {
-            this.loadedRecords.push(record);
-            return record;
+
+        const toLoad = missing.filter(r => !this.findFactSync(r) && !this.pendingLoads.has(this.factKeyOf(r)));
+        if (toLoad.length === 0) {
+            return;
         }
-        return null;
+
+        const loadPromise = (async () => {
+            const envelopes = await this.store.load(toLoad);
+            for (const envelope of envelopes) {
+                if (!this.findFactSync(envelope.fact)) {
+                    this.loadedRecords.push(envelope.fact);
+                }
+            }
+        })();
+
+        toLoad.forEach(r => this.pendingLoads.set(this.factKeyOf(r), loadPromise));
+        try {
+            await loadPromise;
+        }
+        finally {
+            toLoad.forEach(r => this.pendingLoads.delete(this.factKeyOf(r)));
+        }
+    }
+
+    private factKeyOf(reference: FactReference): string {
+        return `${reference.type}:${reference.hash}`;
     }
 }
 

--- a/test/authorization/graphFlushAuthorizationSpec.ts
+++ b/test/authorization/graphFlushAuthorizationSpec.ts
@@ -1,0 +1,125 @@
+import {
+    AuthorizationEngine,
+    AuthorizationRules,
+    FactEnvelope,
+    FactRecord,
+    GraphDeserializer,
+    GraphSerializer,
+    MemoryStore,
+    User,
+    buildModel,
+    dehydrateFact
+} from "@src";
+
+class Filler {
+    static Type = "Test.Filler" as const;
+    type = Filler.Type;
+    constructor(public value: number) {}
+}
+
+class Workspace {
+    static Type = "Test.Workspace" as const;
+    type = Workspace.Type;
+    constructor(public owner: User, public identifier: string) {}
+}
+
+class Application {
+    static Type = "Test.Application" as const;
+    type = Application.Type;
+    constructor(public workspace: Workspace, public name: string) {}
+}
+
+// Regression test for #224: GraphDeserializer flushes envelopes to its
+// callback every 20 facts. When a consumer authorizes each flush batch
+// independently (as jinaga-server's /save handler does), a fact whose
+// authorization rule needs multiple predecessor hops through facts that
+// landed in an earlier flush batch must still be resolvable, even though
+// the deserializer no longer hands those records to the callback.
+describe("Authorization across a GraphDeserializer flush boundary", () => {
+    it("authorizes a fact whose multi-hop predecessors were saved in a prior flush batch", async () => {
+        const ownerPublicKey = "owner-public-key";
+
+        // Pad the graph with enough leading facts that the real predecessor
+        // chain (user -> workspace -> application) crosses the deserializer's
+        // default 20-fact flush threshold, landing Application alone in the
+        // second flush.
+        const fillerRecords: FactRecord[] = [];
+        for (let i = 0; i < 18; i++) {
+            fillerRecords.push(...dehydrateFact(new Filler(i)));
+        }
+
+        const chainRecords = dehydrateFact({
+            type: Application.Type,
+            workspace: {
+                type: Workspace.Type,
+                owner: {
+                    type: User.Type,
+                    publicKey: ownerPublicKey
+                },
+                identifier: "workspace-1"
+            },
+            name: "application-1"
+        });
+
+        const allRecords = [...fillerRecords, ...chainRecords];
+        expect(allRecords.length).toBe(21);
+        expect(allRecords[allRecords.length - 1].type).toBe(Application.Type);
+
+        const envelopes: FactEnvelope[] = allRecords.map(fact => ({ fact, signatures: [] }));
+        const userFact = chainRecords.find(f => f.type === User.Type)!;
+
+        // Round-trip through the wire protocol so the test exercises the
+        // real GraphDeserializer flush boundary, not a hand-picked batch.
+        const lines: string[] = [];
+        new GraphSerializer(chunk => lines.push(chunk)).serialize(envelopes);
+        const wireText = lines.join("");
+        const readLine = createReadLine(wireText);
+        const deserializer = new GraphDeserializer(readLine);
+
+        const model = buildModel(b => b
+            .type(User)
+            .type(Workspace, w => w
+                .predecessor("owner", User)
+            )
+            .type(Application, a => a
+                .predecessor("workspace", Workspace)
+            )
+        );
+        const authorizationRules = new AuthorizationRules(model)
+            .any(Filler.Type)
+            .any(User.Type)
+            .any(Workspace.Type)
+            .type(Application, app => app.workspace.owner);
+
+        const store = new MemoryStore();
+        const engine = new AuthorizationEngine(authorizationRules, store);
+
+        const batches: FactEnvelope[][] = [];
+        await deserializer.read(async batch => {
+            batches.push(batch);
+            // Mirror jinaga-server's /save handler: authorize each flush
+            // batch independently, then persist it, before the next batch
+            // is even read off the wire.
+            const results = await engine.authorizeFacts(batch, userFact);
+            await store.save(results.map(r => ({ fact: r.fact, signatures: [] })));
+        });
+
+        // Confirm the graph really did split across flush batches, or this
+        // test would not exercise the bug.
+        expect(batches.length).toBeGreaterThan(1);
+
+        const saved = await store.whichExist([{ type: Application.Type, hash: chainRecords.find(f => f.type === Application.Type)!.hash }]);
+        expect(saved.length).toBe(1);
+    });
+});
+
+function createReadLine(input: string) {
+    const lines = input.split("\n");
+    if (lines[lines.length - 1] === "") {
+        lines.pop();
+    }
+    return async () => {
+        const line = lines.shift();
+        return line !== undefined ? line : null;
+    };
+}

--- a/test/authorization/graphFlushAuthorizationSpec.ts
+++ b/test/authorization/graphFlushAuthorizationSpec.ts
@@ -104,9 +104,13 @@ describe("Authorization across a GraphDeserializer flush boundary", () => {
             await store.save(results.map(r => ({ fact: r.fact, signatures: [] })));
         });
 
-        // Confirm the graph really did split across flush batches, or this
-        // test would not exercise the bug.
+        // Confirm the graph really did split across flush batches, with the
+        // Application landing in a later batch than its Workspace/User
+        // predecessors. Otherwise this test would pass without ever
+        // exercising the flush boundary the bug depends on.
         expect(batches.length).toBeGreaterThan(1);
+        expect(batches[0].some(e => e.fact.type === Application.Type)).toBe(false);
+        expect(batches.slice(1).some(batch => batch.some(e => e.fact.type === Application.Type))).toBe(true);
 
         const saved = await store.whichExist([{ type: Application.Type, hash: chainRecords.find(f => f.type === Application.Type)!.hash }]);
         expect(saved.length).toBe(1);


### PR DESCRIPTION
## Summary

Fixes #224.

`GraphDeserializer` flushes envelopes to its `read` callback every 20 facts (`flushThreshold`). When a consumer authorizes each flush batch independently (as jinaga-server's `/save` handler does), `AuthorizationRules.getAuthorizedPopulationForEnvelope` built its `FactGraph` only from the facts in that batch. A multi-hop rule (e.g. `fact → application → workspace → owner`) whose predecessor chain crossed a flush boundary would throw `The fact ... is not defined` as soon as it tried to walk a predecessor that had already been saved in an earlier flush but wasn't resubmitted in the current one.

- `FactGraph.findFact` now falls back to `store.load()` when a referenced fact isn't present in the current batch, reusing the same existence guarantee `AuthorizationEngine` already relies on via `whichExist`.
- This required threading `Storage` through `FactGraph` and making its traversal methods (`executeSpecification`, `executeMatches`, `executeMatch`, `executePathCondition`, `executePredecessorStep`, `filterByCondition`, `getField`) async, since a store read is asynchronous.
- Loaded records are cached per `FactGraph` instance to avoid redundant store reads within a single authorization.

## Test plan

- Added `test/authorization/graphFlushAuthorizationSpec.ts`, which round-trips a 21-fact graph through the real `GraphSerializer`/`GraphDeserializer` wire protocol so that a fact's multi-hop predecessor chain (`user → workspace → application`) crosses the default 20-fact flush threshold, authorizing and saving each flush batch independently just like jinaga-server's `/save` handler. Verified this test fails with the exact reported error (`The fact Test.Workspace:... is not defined.`) on the pre-fix code and passes after the fix.
- `npx jest` — all 561 existing tests pass.
- `npx tsc --noEmit --project tsconfig.test.json` — no new type errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVtFVedGhtpA6Kr6RKcYgS)_