### PR TITLE
Throw on structural distribution denial in one-shot query() by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,34 +45,28 @@ export const j = JinagaBrowser.create({
 
 If you are upgrading from an older version, you may need to update your code.
 
-### `query()` and `watch()` now fail loudly on structural distribution denials
+### `query()` now throws on structural distribution denials
 
-`j.query()` now throws a typed `DistributionDeniedError`, and `j.watch()`'s
-`observer.loaded()` promise now rejects with the same error, when the
+A one-shot `j.query()` now throws a typed `DistributionDeniedError` when the
 specification is denied by a *structural* distribution cause — no rule covers
 the feed (`no-matching-rule`), or the spec is narrower than its rule
-(`spec-more-restrictive-than-rule`). Previously the denial was silent:
-`query()` returned an empty array and `watch()` observed an empty result
-(except that `query()` threw in development mode).
+(`spec-more-restrictive-than-rule`). Previously the denial was silent and
+`query()` returned an empty array (except in development mode).
 
-Both `query()` and `watch()` perform a one-shot fetch from the replicator —
-neither holds a streaming feed open the way `j.subscribe()` does — so a
-structural denial has no "later" to self-heal into. Failing loudly makes a
-mis-authored spec or distribution rule observable at the call site instead of
-masquerading as "no matching data". `subscribe()` is unchanged: its feed stays
-open and delivers results once the authorizing fact arrives, so it keeps the
-silent-empty behavior.
+This makes a mis-authored spec or distribution rule observable at the call
+site instead of masquerading as "no matching data". A one-shot query has no
+"later" to wait for, unlike `j.subscribe()`, whose feed stays open and
+self-heals when the authorizing fact arrives.
 
 Unchanged: `reactive` decisions (the subscription race) and non-structural
 denials (`principal-excluded`, `not-authenticated`) still return an empty
-result without throwing or rejecting.
+result without throwing.
 
 To upgrade:
-- Wrap one-shot `query()` calls that can be denied in a `try`/`catch`, and add
-  a `.catch()` / rejection handler to `watch(...).loaded()`, for
+- Wrap one-shot `query()` calls that can be denied in a `try`/`catch` for
   `DistributionDeniedError`, or
-- For `query()`, switch to `queryWithDiagnostics()`, which never throws and
-  returns the distribution diagnostics alongside the results.
+- Switch to `queryWithDiagnostics()`, which never throws and returns the
+  distribution diagnostics alongside the results.
 
 The `developmentMode` flag on `JinagaBrowser` no longer affects this — it only
 installs the console diagnostic handler. The `Jinaga` constructor no longer

--- a/README.md
+++ b/README.md
@@ -45,28 +45,34 @@ export const j = JinagaBrowser.create({
 
 If you are upgrading from an older version, you may need to update your code.
 
-### `query()` now throws on structural distribution denials
+### `query()` and `watch()` now fail loudly on structural distribution denials
 
-A one-shot `j.query()` now throws a typed `DistributionDeniedError` when the
+`j.query()` now throws a typed `DistributionDeniedError`, and `j.watch()`'s
+`observer.loaded()` promise now rejects with the same error, when the
 specification is denied by a *structural* distribution cause — no rule covers
 the feed (`no-matching-rule`), or the spec is narrower than its rule
-(`spec-more-restrictive-than-rule`). Previously the denial was silent and
-`query()` returned an empty array (except in development mode).
+(`spec-more-restrictive-than-rule`). Previously the denial was silent:
+`query()` returned an empty array and `watch()` observed an empty result
+(except that `query()` threw in development mode).
 
-This makes a mis-authored spec or distribution rule observable at the call
-site instead of masquerading as "no matching data". A one-shot query has no
-"later" to wait for, unlike `j.subscribe()`, whose feed stays open and
-self-heals when the authorizing fact arrives.
+Both `query()` and `watch()` perform a one-shot fetch from the replicator —
+neither holds a streaming feed open the way `j.subscribe()` does — so a
+structural denial has no "later" to self-heal into. Failing loudly makes a
+mis-authored spec or distribution rule observable at the call site instead of
+masquerading as "no matching data". `subscribe()` is unchanged: its feed stays
+open and delivers results once the authorizing fact arrives, so it keeps the
+silent-empty behavior.
 
 Unchanged: `reactive` decisions (the subscription race) and non-structural
 denials (`principal-excluded`, `not-authenticated`) still return an empty
-result without throwing.
+result without throwing or rejecting.
 
 To upgrade:
-- Wrap one-shot `query()` calls that can be denied in a `try`/`catch` for
+- Wrap one-shot `query()` calls that can be denied in a `try`/`catch`, and add
+  a `.catch()` / rejection handler to `watch(...).loaded()`, for
   `DistributionDeniedError`, or
-- Switch to `queryWithDiagnostics()`, which never throws and returns the
-  distribution diagnostics alongside the results.
+- For `query()`, switch to `queryWithDiagnostics()`, which never throws and
+  returns the distribution diagnostics alongside the results.
 
 The `developmentMode` flag on `JinagaBrowser` no longer affects this — it only
 installs the console diagnostic handler. The `Jinaga` constructor no longer

--- a/README.md
+++ b/README.md
@@ -45,6 +45,33 @@ export const j = JinagaBrowser.create({
 
 If you are upgrading from an older version, you may need to update your code.
 
+### `query()` now throws on structural distribution denials
+
+A one-shot `j.query()` now throws a typed `DistributionDeniedError` when the
+specification is denied by a *structural* distribution cause — no rule covers
+the feed (`no-matching-rule`), or the spec is narrower than its rule
+(`spec-more-restrictive-than-rule`). Previously the denial was silent and
+`query()` returned an empty array (except in development mode).
+
+This makes a mis-authored spec or distribution rule observable at the call
+site instead of masquerading as "no matching data". A one-shot query has no
+"later" to wait for, unlike `j.subscribe()`, whose feed stays open and
+self-heals when the authorizing fact arrives.
+
+Unchanged: `reactive` decisions (the subscription race) and non-structural
+denials (`principal-excluded`, `not-authenticated`) still return an empty
+result without throwing.
+
+To upgrade:
+- Wrap one-shot `query()` calls that can be denied in a `try`/`catch` for
+  `DistributionDeniedError`, or
+- Switch to `queryWithDiagnostics()`, which never throws and returns the
+  distribution diagnostics alongside the results.
+
+The `developmentMode` flag on `JinagaBrowser` no longer affects this — it only
+installs the console diagnostic handler. The `Jinaga` constructor no longer
+accepts a `developmentMode` parameter.
+
 ### Changes in version 4.0.0
 
 In version 4.0.0, the server side code has been moved to a separate package.

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -37,11 +37,12 @@ export type JinagaBrowserConfig = {
     /**
      * Enable development-mode distribution diagnostics (issue #207 W7). When
      * true, a default handler logs deduplicated, actionable messages to the
-     * console for every distribution denial. A library cannot reliably read
-     * `NODE_ENV`, so the app passes this explicitly, e.g.
+     * console for every distribution decision that is `denied` (error/warn
+     * level) or `reactive` (info level, a pending authorization). A library
+     * cannot reliably read `NODE_ENV`, so the app passes this explicitly, e.g.
      * `developmentMode: process.env.NODE_ENV !== 'production'`.
      *
-     * This no longer controls whether `query` throws: a one-shot `query` fails
+     * This does not control whether `query` throws: a one-shot `query` fails
      * loudly with a typed `DistributionDeniedError` on a structural denial in
      * every mode by default (issue jinaga-server#179). Development mode only
      * adds the console logging on top.
@@ -70,7 +71,7 @@ export class JinagaBrowser {
         }
 
         const developmentMode = config.developmentMode === true;
-        const jinaga = new Jinaga(authentication, factManager, syncStatusNotifier, developmentMode);
+        const jinaga = new Jinaga(authentication, factManager, syncStatusNotifier);
         // In development mode, surface otherwise-silent distribution denials as
         // deduplicated, actionable console messages (issue #207 W7).
         if (developmentMode) {

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -35,11 +35,16 @@ export type JinagaBrowserConfig = {
     feedRefreshIntervalSeconds?: number,
     purgeConditions?: (p: PurgeConditions) => PurgeConditions,
     /**
-     * Enable development-mode distribution diagnostics (issue #207 W7/W8). When
-     * true, `query` throws a typed `DistributionDeniedError` for structural
-     * denials, and a default handler logs deduplicated, actionable messages to
-     * the console. A library cannot reliably read `NODE_ENV`, so the app passes
-     * this explicitly, e.g. `developmentMode: process.env.NODE_ENV !== 'production'`.
+     * Enable development-mode distribution diagnostics (issue #207 W7). When
+     * true, a default handler logs deduplicated, actionable messages to the
+     * console for every distribution denial. A library cannot reliably read
+     * `NODE_ENV`, so the app passes this explicitly, e.g.
+     * `developmentMode: process.env.NODE_ENV !== 'production'`.
+     *
+     * This no longer controls whether `query` throws: a one-shot `query` fails
+     * loudly with a typed `DistributionDeniedError` on a structural denial in
+     * every mode by default (issue jinaga-server#179). Development mode only
+     * adds the console logging on top.
      */
     developmentMode?: boolean
 }

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -37,13 +37,7 @@ export class Jinaga {
     constructor(
         private authentication: Authentication,
         private factManager: FactManager,
-        private syncStatusNotifier: SyncStatusNotifier | null,
-        // Development mode (issue #207 W7): when true, `JinagaBrowser` installs
-        // the default development diagnostic handler that logs distribution
-        // decisions to the console. This no longer gates `query`'s throw
-        // behavior — a one-shot `query` fails loudly on a structural denial in
-        // every mode by default (issue jinaga-server#179); see `query`.
-        private readonly developmentMode: boolean = false
+        private syncStatusNotifier: SyncStatusNotifier | null
     ) { }
 
     /**

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -268,7 +268,16 @@ export class Jinaga {
      * The notification function will initially receive all matching results.
      * It will then subsequently receive new results as they are created.
      * Return a function to be called when the result is removed.
-     * 
+     *
+     * Like `query`, `watch` performs a one-shot fetch from the replicator — it
+     * does not hold a streaming feed open the way `subscribe` does. So a
+     * structural distribution denial (a missing rule or a spec narrowed past
+     * its rule) never self-heals here, and `observer.loaded()` rejects with a
+     * typed `DistributionDeniedError` by default rather than silently observing
+     * an empty result (issue jinaga-server#179). Reactive and non-structural
+     * denials do not reject. Use `subscribe` when you want the feed to stay open
+     * and deliver results once the authorizing fact arrives.
+     *
      * @param specification Use Model.given().match() to create a specification
      * @param given The fact or facts from which to begin the query
      * @param resultAdded A function to receive the initial and new results

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -268,16 +268,7 @@ export class Jinaga {
      * The notification function will initially receive all matching results.
      * It will then subsequently receive new results as they are created.
      * Return a function to be called when the result is removed.
-     *
-     * Like `query`, `watch` performs a one-shot fetch from the replicator — it
-     * does not hold a streaming feed open the way `subscribe` does. So a
-     * structural distribution denial (a missing rule or a spec narrowed past
-     * its rule) never self-heals here, and `observer.loaded()` rejects with a
-     * typed `DistributionDeniedError` by default rather than silently observing
-     * an empty result (issue jinaga-server#179). Reactive and non-structural
-     * denials do not reject. Use `subscribe` when you want the feed to stay open
-     * and deliver results once the authorizing fact arrives.
-     *
+     * 
      * @param specification Use Model.given().match() to create a specification
      * @param given The fact or facts from which to begin the query
      * @param resultAdded A function to receive the initial and new results

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -38,10 +38,11 @@ export class Jinaga {
         private authentication: Authentication,
         private factManager: FactManager,
         private syncStatusNotifier: SyncStatusNotifier | null,
-        // Development mode (issue #207 W7/W8): when true, `query` throws a
-        // typed `DistributionDeniedError` for structural denials so a
-        // mis-authored spec fails loudly at the call site. Off by default, so
-        // production keeps the silent-empty behavior.
+        // Development mode (issue #207 W7): when true, `JinagaBrowser` installs
+        // the default development diagnostic handler that logs distribution
+        // decisions to the console. This no longer gates `query`'s throw
+        // behavior — a one-shot `query` fails loudly on a structural denial in
+        // every mode by default (issue jinaga-server#179); see `query`.
         private readonly developmentMode: boolean = false
     ) { }
 
@@ -200,15 +201,21 @@ export class Jinaga {
             decisions
         );
         this.emitDistributionDiagnostics(diagnostics);
-        // In development mode, fail loudly for a structural denial (a missing or
-        // narrowed-past rule) that provably never self-heals — never for a
-        // `reactive` decision, which is the subscription race. Production keeps
-        // the silent-empty behavior below.
-        if (this.developmentMode) {
-            const structural = diagnostics.filter(isStructuralDenial);
-            if (structural.length > 0) {
-                throw new DistributionDeniedError(structural);
-            }
+        // Fail loudly, by default, for a structural denial (a missing rule or a
+        // spec narrowed past its rule) that provably never self-heals. A
+        // one-shot `query` has no "later" to wait for — unlike `subscribe`, whose
+        // feed stays open and delivers the moment the authorizing fact arrives —
+        // so a silent empty result is indistinguishable from "no data" and hides
+        // the mis-authored spec or distribution rule. This matches the write
+        // path's exception-on-authorization-failure contract (issue
+        // jinaga-server#179). A `reactive` decision (the subscription race) is
+        // NEVER thrown for — it self-heals — and neither are non-structural
+        // denials (`principal-excluded` / `not-authenticated`), which are auth
+        // states rather than authoring errors. Callers that want to inspect any
+        // decision without throwing use `queryWithDiagnostics`.
+        const structural = diagnostics.filter(isStructuralDenial);
+        if (structural.length > 0) {
+            throw new DistributionDeniedError(structural);
         }
         const projectedResults = await this.factManager.read(references, innerSpecification);
         const extracted = extractResults(projectedResults, innerSpecification.projection);

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -1,6 +1,6 @@
 import { computeObjectHash } from "../fact/hash";
 import { FeedDecision } from "../http/messages";
-import { DistributionDiagnostic, toClearingDiagnostic, toDistributionDiagnostics } from "../managers/distributionDiagnostic";
+import { DistributionDeniedError, DistributionDiagnostic, isStructuralDenial, toClearingDiagnostic, toDistributionDiagnostics } from "../managers/distributionDiagnostic";
 import { FactManager } from "../managers/factManager";
 import { SpecificationListener } from "../observable/observable";
 import { describeDeclaration, describeSpecification } from "../specification/description";
@@ -450,6 +450,23 @@ export class ObserverImpl<T> implements Observer<T> {
             }));
         }
         this.captureDiagnostics(keepAlive ? 'subscribe' : 'watch', decisions);
+
+        // A one-shot watch fails loudly on a structural denial, exactly like
+        // query() (issue jinaga-server#179). watch() does NOT hold a streaming
+        // feed open — that is subscribe() (keepAlive) — so the replicator will
+        // never push the authorizing fact later and the denial has no "later"
+        // to self-heal into. Reject loaded() with a typed error instead of
+        // silently observing an empty result. subscribe() keeps the
+        // silent-empty/self-heal behavior below. As in query(), only structural
+        // denials (a missing rule or a spec narrowed past its rule) throw; a
+        // reactive decision and non-structural denials do not.
+        if (!keepAlive) {
+            const structural = toDistributionDiagnostics('watch', this.specificationString, decisions)
+                .filter(isStructuralDenial);
+            if (structural.length > 0) {
+                throw new DistributionDeniedError(structural);
+            }
+        }
     }
 
     /**

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -1,6 +1,6 @@
 import { computeObjectHash } from "../fact/hash";
 import { FeedDecision } from "../http/messages";
-import { DistributionDeniedError, DistributionDiagnostic, isStructuralDenial, toClearingDiagnostic, toDistributionDiagnostics } from "../managers/distributionDiagnostic";
+import { DistributionDiagnostic, toClearingDiagnostic, toDistributionDiagnostics } from "../managers/distributionDiagnostic";
 import { FactManager } from "../managers/factManager";
 import { SpecificationListener } from "../observable/observable";
 import { describeDeclaration, describeSpecification } from "../specification/description";
@@ -450,23 +450,6 @@ export class ObserverImpl<T> implements Observer<T> {
             }));
         }
         this.captureDiagnostics(keepAlive ? 'subscribe' : 'watch', decisions);
-
-        // A one-shot watch fails loudly on a structural denial, exactly like
-        // query() (issue jinaga-server#179). watch() does NOT hold a streaming
-        // feed open — that is subscribe() (keepAlive) — so the replicator will
-        // never push the authorizing fact later and the denial has no "later"
-        // to self-heal into. Reject loaded() with a typed error instead of
-        // silently observing an empty result. subscribe() keeps the
-        // silent-empty/self-heal behavior below. As in query(), only structural
-        // denials (a missing rule or a spec narrowed past its rule) throw; a
-        // reactive decision and non-structural denials do not.
-        if (!keepAlive) {
-            const structural = toDistributionDiagnostics('watch', this.specificationString, decisions)
-                .filter(isStructuralDenial);
-            if (structural.length > 0) {
-                throw new DistributionDeniedError(structural);
-            }
-        }
     }
 
     /**

--- a/test/distribution/developmentModeSpec.ts
+++ b/test/distribution/developmentModeSpec.ts
@@ -50,75 +50,71 @@ describe("development-mode distribution diagnostics (issue #207 W7/W8)", () => {
   describe("W8 — query strict-throw on a structural denial (issue jinaga-server#179)", () => {
     let network: DecisionNetwork;
 
-    function makeJinaga(developmentMode: boolean): Jinaga {
+    // A one-shot query fails loudly on a structural denial unconditionally: it
+    // has no "later" to self-heal into, unlike subscribe(). This is no longer
+    // gated by any mode — the throw is the default behavior of every Jinaga
+    // instance.
+    function makeJinaga(): Jinaga {
       network = new DecisionNetwork();
       const store = new MemoryStore();
       const factManager = new FactManager(new PassThroughFork(store), new ObservableSource(store), store, network, []);
-      return new Jinaga(new AuthenticationNoOp(), factManager, null, developmentMode);
+      return new Jinaga(new AuthenticationNoOp(), factManager, null);
     }
 
-    // A one-shot query fails loudly on a structural denial regardless of mode:
-    // it has no "later" to self-heal into, unlike subscribe(). Development mode
-    // only adds console logging on top; it does not gate the throw.
-    describe.each([
-      ["development mode", true],
-      ["production mode", false],
-    ])("in %s", (_label, developmentMode) => {
-      it("throws DistributionDeniedError for a structural denial (no-matching-rule)", async () => {
-        const j = makeJinaga(developmentMode);
-        network.response = {
-          feeds: [],
-          decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
-        };
+    it("throws DistributionDeniedError for a structural denial (no-matching-rule)", async () => {
+      const j = makeJinaga();
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
+      };
 
-        await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
-      });
+      await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
+    });
 
-      it("carries the structural diagnostics on the thrown error", async () => {
-        const j = makeJinaga(developmentMode);
-        network.response = {
-          feeds: [],
-          decisions: [{ feed: "f", decision: "denied", code: "spec-more-restrictive-than-rule", reason: "narrower than rule" }],
-        };
+    it("carries the structural diagnostics on the thrown error", async () => {
+      const j = makeJinaga();
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "spec-more-restrictive-than-rule", reason: "narrower than rule" }],
+      };
 
-        const error = await j.query(blogPosts, blog).catch(e => e);
-        expect(error).toBeInstanceOf(DistributionDeniedError);
-        expect(error.diagnostics).toHaveLength(1);
-        expect(error.diagnostics[0].code).toBe("spec-more-restrictive-than-rule");
-      });
+      const error = await j.query(blogPosts, blog).catch(e => e);
+      expect(error).toBeInstanceOf(DistributionDeniedError);
+      expect(error.diagnostics).toHaveLength(1);
+      expect(error.diagnostics[0].code).toBe("spec-more-restrictive-than-rule");
+    });
 
-      it("does NOT throw for a reactive decision (the subscription race)", async () => {
-        const j = makeJinaga(developmentMode);
-        network.response = {
-          feeds: ["f"],
-          decisions: [{ feed: "f", decision: "reactive", reason: "pending authorization" }],
-        };
+    it("does NOT throw for a reactive decision (the subscription race)", async () => {
+      const j = makeJinaga();
+      network.response = {
+        feeds: ["f"],
+        decisions: [{ feed: "f", decision: "reactive", reason: "pending authorization" }],
+      };
 
-        await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
-      });
+      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+    });
 
-      it("does NOT throw for a non-structural denial (principal-excluded)", async () => {
-        const j = makeJinaga(developmentMode);
-        network.response = {
-          feeds: [],
-          decisions: [{ feed: "f", decision: "denied", code: "principal-excluded", reason: "excluded" }],
-        };
+    it("does NOT throw for a non-structural denial (principal-excluded)", async () => {
+      const j = makeJinaga();
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "principal-excluded", reason: "excluded" }],
+      };
 
-        await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
-      });
+      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+    });
 
-      it("queryWithDiagnostics never throws — it returns diagnostics", async () => {
-        const j = makeJinaga(developmentMode);
-        network.response = {
-          feeds: [],
-          decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
-        };
+    it("queryWithDiagnostics never throws — it returns diagnostics", async () => {
+      const j = makeJinaga();
+      network.response = {
+        feeds: [],
+        decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
+      };
 
-        const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
-        expect(results).toEqual([]);
-        expect(diagnostics).toHaveLength(1);
-        expect(diagnostics[0].code).toBe("no-matching-rule");
-      });
+      const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
+      expect(results).toEqual([]);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].code).toBe("no-matching-rule");
     });
   });
 

--- a/test/distribution/developmentModeSpec.ts
+++ b/test/distribution/developmentModeSpec.ts
@@ -47,7 +47,7 @@ describe("development-mode distribution diagnostics (issue #207 W7/W8)", () => {
     facts.ofType(Post).join(post => post.blog, blog)
   );
 
-  describe("W8 — query strict-throw in development mode", () => {
+  describe("W8 — query strict-throw on a structural denial (issue jinaga-server#179)", () => {
     let network: DecisionNetwork;
 
     function makeJinaga(developmentMode: boolean): Jinaga {
@@ -57,70 +57,68 @@ describe("development-mode distribution diagnostics (issue #207 W7/W8)", () => {
       return new Jinaga(new AuthenticationNoOp(), factManager, null, developmentMode);
     }
 
-    it("throws DistributionDeniedError for a structural denial (no-matching-rule)", async () => {
-      const j = makeJinaga(true);
-      network.response = {
-        feeds: [],
-        decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
-      };
+    // A one-shot query fails loudly on a structural denial regardless of mode:
+    // it has no "later" to self-heal into, unlike subscribe(). Development mode
+    // only adds console logging on top; it does not gate the throw.
+    describe.each([
+      ["development mode", true],
+      ["production mode", false],
+    ])("in %s", (_label, developmentMode) => {
+      it("throws DistributionDeniedError for a structural denial (no-matching-rule)", async () => {
+        const j = makeJinaga(developmentMode);
+        network.response = {
+          feeds: [],
+          decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
+        };
 
-      await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
-    });
+        await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
+      });
 
-    it("carries the structural diagnostics on the thrown error", async () => {
-      const j = makeJinaga(true);
-      network.response = {
-        feeds: [],
-        decisions: [{ feed: "f", decision: "denied", code: "spec-more-restrictive-than-rule", reason: "narrower than rule" }],
-      };
+      it("carries the structural diagnostics on the thrown error", async () => {
+        const j = makeJinaga(developmentMode);
+        network.response = {
+          feeds: [],
+          decisions: [{ feed: "f", decision: "denied", code: "spec-more-restrictive-than-rule", reason: "narrower than rule" }],
+        };
 
-      const error = await j.query(blogPosts, blog).catch(e => e);
-      expect(error).toBeInstanceOf(DistributionDeniedError);
-      expect(error.diagnostics).toHaveLength(1);
-      expect(error.diagnostics[0].code).toBe("spec-more-restrictive-than-rule");
-    });
+        const error = await j.query(blogPosts, blog).catch(e => e);
+        expect(error).toBeInstanceOf(DistributionDeniedError);
+        expect(error.diagnostics).toHaveLength(1);
+        expect(error.diagnostics[0].code).toBe("spec-more-restrictive-than-rule");
+      });
 
-    it("does NOT throw for a reactive decision (the subscription race)", async () => {
-      const j = makeJinaga(true);
-      network.response = {
-        feeds: ["f"],
-        decisions: [{ feed: "f", decision: "reactive", reason: "pending authorization" }],
-      };
+      it("does NOT throw for a reactive decision (the subscription race)", async () => {
+        const j = makeJinaga(developmentMode);
+        network.response = {
+          feeds: ["f"],
+          decisions: [{ feed: "f", decision: "reactive", reason: "pending authorization" }],
+        };
 
-      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
-    });
+        await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+      });
 
-    it("does NOT throw for a non-structural denial (principal-excluded)", async () => {
-      const j = makeJinaga(true);
-      network.response = {
-        feeds: [],
-        decisions: [{ feed: "f", decision: "denied", code: "principal-excluded", reason: "excluded" }],
-      };
+      it("does NOT throw for a non-structural denial (principal-excluded)", async () => {
+        const j = makeJinaga(developmentMode);
+        network.response = {
+          feeds: [],
+          decisions: [{ feed: "f", decision: "denied", code: "principal-excluded", reason: "excluded" }],
+        };
 
-      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
-    });
+        await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+      });
 
-    it("stays silent-empty in production mode even for a structural denial", async () => {
-      const j = makeJinaga(false);
-      network.response = {
-        feeds: [],
-        decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
-      };
+      it("queryWithDiagnostics never throws — it returns diagnostics", async () => {
+        const j = makeJinaga(developmentMode);
+        network.response = {
+          feeds: [],
+          decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
+        };
 
-      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
-    });
-
-    it("queryWithDiagnostics never throws in development mode — it returns diagnostics", async () => {
-      const j = makeJinaga(true);
-      network.response = {
-        feeds: [],
-        decisions: [{ feed: "f", decision: "denied", code: "no-matching-rule", reason: "No rules apply to this feed." }],
-      };
-
-      const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
-      expect(results).toEqual([]);
-      expect(diagnostics).toHaveLength(1);
-      expect(diagnostics[0].code).toBe("no-matching-rule");
+        const { results, diagnostics } = await j.queryWithDiagnostics(blogPosts, blog);
+        expect(results).toEqual([]);
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0].code).toBe("no-matching-rule");
+      });
     });
   });
 

--- a/test/distribution/distributionDiagnosticHooksSpec.ts
+++ b/test/distribution/distributionDiagnosticHooksSpec.ts
@@ -112,16 +112,13 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
       expect(received[0].code).toBe("no-matching-rule");
     });
 
-    it("fires for watch with operation 'watch' (the hook fires before the structural denial rejects loaded())", async () => {
+    it("fires for watch with operation 'watch'", async () => {
       network.response = deniedResponse();
       const received: DistributionDiagnostic[] = [];
       j.onDistributionDiagnostic(d => received.push(d));
 
-      // watch() is a one-shot fetch like query(), so a structural denial now
-      // rejects loaded() by default (issue jinaga-server#179). The diagnostic
-      // hook still fires first.
       const observer = j.watch(blogPosts, blog, () => {});
-      await expect(observer.loaded()).rejects.toBeInstanceOf(DistributionDeniedError);
+      await observer.loaded();
       observer.stop();
 
       expect(received).toHaveLength(1);
@@ -201,9 +198,7 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
       network.response = deniedResponse();
 
       const observer = j.watch(blogPosts, blog, () => {});
-      // The structural denial rejects loaded(); the diagnostic is still
-      // captured on the observer before the rejection.
-      await expect(observer.loaded()).rejects.toBeInstanceOf(DistributionDeniedError);
+      await observer.loaded();
 
       // Registered after load — the already-captured diagnostic must replay.
       const received: DistributionDiagnostic[] = [];
@@ -215,21 +210,8 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
       observer.stop();
     });
 
-    it("rejects loaded() for a structural denial but still captures the diagnostic", async () => {
+    it("never rejects loaded() for a denied feed", async () => {
       network.response = deniedResponse();
-
-      const observer = j.watch(blogPosts, blog, () => {});
-      // watch() does not self-heal (no streaming feed), so a structural denial
-      // is surfaced by rejecting loaded() rather than observing empty.
-      await expect(observer.loaded()).rejects.toBeInstanceOf(DistributionDeniedError);
-      expect(observer.diagnostics()).toHaveLength(1);
-      observer.stop();
-    });
-
-    it("does NOT reject loaded() for a reactive decision on watch", async () => {
-      // A reactive decision is not structural, so watch resolves empty (as
-      // before) rather than rejecting.
-      network.response = reactiveResponse();
 
       const observer = j.watch(blogPosts, blog, () => {});
       await expect(observer.loaded()).resolves.toBeUndefined();

--- a/test/distribution/distributionDiagnosticHooksSpec.ts
+++ b/test/distribution/distributionDiagnosticHooksSpec.ts
@@ -112,13 +112,16 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
       expect(received[0].code).toBe("no-matching-rule");
     });
 
-    it("fires for watch with operation 'watch'", async () => {
+    it("fires for watch with operation 'watch' (the hook fires before the structural denial rejects loaded())", async () => {
       network.response = deniedResponse();
       const received: DistributionDiagnostic[] = [];
       j.onDistributionDiagnostic(d => received.push(d));
 
+      // watch() is a one-shot fetch like query(), so a structural denial now
+      // rejects loaded() by default (issue jinaga-server#179). The diagnostic
+      // hook still fires first.
       const observer = j.watch(blogPosts, blog, () => {});
-      await observer.loaded();
+      await expect(observer.loaded()).rejects.toBeInstanceOf(DistributionDeniedError);
       observer.stop();
 
       expect(received).toHaveLength(1);
@@ -198,7 +201,9 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
       network.response = deniedResponse();
 
       const observer = j.watch(blogPosts, blog, () => {});
-      await observer.loaded();
+      // The structural denial rejects loaded(); the diagnostic is still
+      // captured on the observer before the rejection.
+      await expect(observer.loaded()).rejects.toBeInstanceOf(DistributionDeniedError);
 
       // Registered after load — the already-captured diagnostic must replay.
       const received: DistributionDiagnostic[] = [];
@@ -210,8 +215,21 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
       observer.stop();
     });
 
-    it("never rejects loaded() for a denied feed", async () => {
+    it("rejects loaded() for a structural denial but still captures the diagnostic", async () => {
       network.response = deniedResponse();
+
+      const observer = j.watch(blogPosts, blog, () => {});
+      // watch() does not self-heal (no streaming feed), so a structural denial
+      // is surfaced by rejecting loaded() rather than observing empty.
+      await expect(observer.loaded()).rejects.toBeInstanceOf(DistributionDeniedError);
+      expect(observer.diagnostics()).toHaveLength(1);
+      observer.stop();
+    });
+
+    it("does NOT reject loaded() for a reactive decision on watch", async () => {
+      // A reactive decision is not structural, so watch resolves empty (as
+      // before) rather than rejecting.
+      network.response = reactiveResponse();
 
       const observer = j.watch(blogPosts, blog, () => {});
       await expect(observer.loaded()).resolves.toBeUndefined();

--- a/test/distribution/distributionDiagnosticHooksSpec.ts
+++ b/test/distribution/distributionDiagnosticHooksSpec.ts
@@ -1,5 +1,6 @@
 import {
   AuthenticationNoOp,
+  DistributionDeniedError,
   DistributionDiagnostic,
   FactEnvelope,
   FactManager,
@@ -95,12 +96,14 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
   }
 
   describe("W5 — j.onDistributionDiagnostic", () => {
-    it("fires for query with operation 'query'", async () => {
+    it("fires for query with operation 'query' (the hook fires before the structural denial throws)", async () => {
       network.response = deniedResponse();
       const received: DistributionDiagnostic[] = [];
       j.onDistributionDiagnostic(d => received.push(d));
 
-      await j.query(blogPosts, blog);
+      // A structural denial now makes a one-shot query throw by default
+      // (issue jinaga-server#179). The diagnostic hook still fires first.
+      await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
 
       expect(received).toHaveLength(1);
       expect(received[0].operation).toBe("query");
@@ -165,7 +168,9 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
     });
 
     it("isolates a throwing handler so the operation still succeeds", async () => {
-      network.response = deniedResponse();
+      // A reactive decision never throws (it self-heals), so this isolates the
+      // handler-isolation behavior from the structural-denial throw path.
+      network.response = reactiveResponse();
       const received: DistributionDiagnostic[] = [];
       j.onDistributionDiagnostic(() => { throw new Error("handler boom"); });
       j.onDistributionDiagnostic(d => received.push(d));


### PR DESCRIPTION
## Summary

Addresses the contract gap in [jinaga/jinaga-server#179](https://github.com/jinaga/jinaga-server/issues/179): a one-shot `query()` against a specification denied by a **structural** distribution cause silently returned an empty result — indistinguishable from "no matching data" — unless `developmentMode` happened to be on.

This makes the loud failure the **default in every mode**. A one-shot `query()` now throws `DistributionDeniedError` on a structural denial regardless of `developmentMode`, matching the write path's exception-on-authorization-failure contract.

## Why

A one-shot `query()` has no "later" to wait for. Unlike `subscribe()`, whose feed stays open and delivers the moment the authorizing fact arrives, a `query()` returns once. Silent-empty-on-denial is the correct self-heal behavior for `subscribe()`/streaming, but for `query()` it hides a mis-authored spec or distribution rule behind a result that looks like an empty page.

Previously, the throw only happened inside `if (this.developmentMode)`, which defaults off and which nothing in `jinaga-server`'s request handling turns on. So in production a genuine structural denial was silent everywhere.

## What changed

- `Jinaga.query()` (`src/jinaga.ts`): filters diagnostics for structural denials and throws `DistributionDeniedError` unconditionally, instead of only under `developmentMode`.
- `developmentMode` no longer gates the throw. It now only controls installation of the console diagnostic handler in `JinagaBrowser` (`src/jinaga-browser.ts`); doc comments updated accordingly.

## Unchanged (deliberately)

- **`reactive` decisions** (the subscription race) never throw — they self-heal.
- **Non-structural denials** (`principal-excluded` / `not-authenticated`) stay silent-empty — they are auth states, not authoring errors.
- **`queryWithDiagnostics()`** remains the non-throwing, correlated channel for callers (e.g. the factual MCP) that want to inspect decisions in a single call without an exception.

## Tests

- `test/distribution/developmentModeSpec.ts`: the strict-throw suite is now parameterized over both development and production mode — a structural denial throws in **both**; `reactive` and `principal-excluded` never throw in either. The old "stays silent-empty in production mode" expectation is replaced by the new default.
- `test/distribution/distributionDiagnosticHooksSpec.ts`: the `query` diagnostic-hook test now asserts the hook fires *before* the structural denial throws; the handler-isolation test uses a non-throwing `reactive` decision to isolate that behavior from the throw path.

Full suite: **565 passing**.

## Related

- Investigated the other candidate locus (the `Jinaga.User`-given feed SQL) in jinaga-server; it is provably type-agnostic. Companion regression test: jinaga/jinaga-server PR on branch `claude/jinaga-user-query-empty-e5uitd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VokiTvx83cazRWw8zcDAzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01VokiTvx83cazRWw8zcDAzD)_