### PR TITLE
Surface server diagnostics through the HTTP layer

### DIFF
--- a/src/authorization/authorization-engine.ts
+++ b/src/authorization/authorization-engine.ts
@@ -4,6 +4,7 @@ import { FactEnvelope, FactRecord, FactReference, Storage, factEnvelopeEquals, f
 import { distinct, mapAsync } from '../util/fn';
 import { Trace } from '../util/trace';
 import { AuthorizationRules } from './authorizationRules';
+import { AuthorizationRuleError, PredecessorNotResolvedError } from './errors';
 
 function predecessorReferences(fact: FactRecord): FactReference[] {
     const references: FactReference[] = [];
@@ -66,6 +67,7 @@ export class AuthorizationEngine {
         const existing = await this.store.whichExist([...facts, ...externalReferences]);
 
         const sorter = new TopologicalSorter<Promise<AuthorizationResult>>();
+        const missingPredecessors: FactReference[] = [];
         externalReferences.forEach(reference => {
             if (existing.some(factReferenceEquals(reference))) {
                 sorter.markAsVisited(reference, Promise.resolve(<AuthorizationResult>{
@@ -74,6 +76,7 @@ export class AuthorizationEngine {
                 }));
             }
             else {
+                missingPredecessors.push(reference);
                 Trace.warn(`The fact ${reference.type}:${reference.hash} is referenced as a predecessor but does not exist in storage and was not included in the batch. Facts that depend on it will not be authorized.`);
             }
         });
@@ -95,7 +98,18 @@ export class AuthorizationEngine {
                 .filter(distinct)
                 .join(", ");
             const count = unresolved.length === 1 ? "1 fact" : `${unresolved.length} facts`;
-            throw new Error(`Cannot authorize ${count} of type ${distinctTypes}: one or more predecessors could not be resolved. This can happen when a predecessor does not exist in storage and was not included in the batch.`);
+            // Name the predecessors that could not be found. They were already
+            // identified above; previously only the failed successors reached the
+            // message, which left the caller with nothing to act on (issue #234).
+            const detail = missingPredecessors.length === 1
+                ? `predecessor ${missingPredecessors[0].type}:${missingPredecessors[0].hash} does not exist in storage and was not included in the batch. Add it to the batch, or commit it first.`
+                : missingPredecessors.length > 1
+                    ? `the following predecessors do not exist in storage and were not included in the batch. Add them to the batch, or commit them first:\n${missingPredecessors.map(r => `${r.type}:${r.hash}`).join("\n")}`
+                    : "one or more predecessors could not be resolved. This can happen when a predecessor does not exist in storage and was not included in the batch.";
+            throw new PredecessorNotResolvedError(
+                `Cannot authorize ${count} of type ${distinctTypes}: ${detail}`,
+                missingPredecessors,
+                unresolved.map(f => ({ type: f.type, hash: f.hash })));
         }
 
         const rejected = results.filter(r => r.verdict === "Reject");
@@ -155,7 +169,7 @@ export class AuthorizationEngine {
         }
         else {
             const _exhaustiveCheck: never = population;
-            throw new Error(`Unknown quantifier ${(_exhaustiveCheck as any).quantifier}.`);
+            throw new AuthorizationRuleError(`Unknown quantifier ${(_exhaustiveCheck as any).quantifier}.`);
         }
     }
 }

--- a/src/authorization/authorizationRules.ts
+++ b/src/authorization/authorizationRules.ts
@@ -1,3 +1,4 @@
+import { AuthorizationRuleError } from './errors';
 import { getPredecessors } from '../memory/memory-store';
 import { Device, User } from '../model/user';
 import { describeSpecification } from '../specification/description';
@@ -20,7 +21,7 @@ class FactGraph {
     async getField(reference: FactReference, name: string) {
         const record = await this.findFact(reference);
         if (record === null) {
-            throw new Error(`The fact ${reference.type}:${reference.hash} is not defined.`);
+            throw new AuthorizationRuleError(`The fact ${reference.type}:${reference.hash} is not defined.`);
         }
         return record.fields[name];
     }
@@ -47,7 +48,7 @@ class FactGraph {
     private async executeMatch(references: ReferencesByName, match: Match): Promise<ReferencesByName[]> {
         let results: ReferencesByName[] = [];
         if (match.conditions.length === 0) {
-            throw new Error("A match must have at least one condition.");
+            throw new AuthorizationRuleError("A match must have at least one condition.");
         }
         const firstCondition = match.conditions[0];
         if (firstCondition.type === "path") {
@@ -61,7 +62,7 @@ class FactGraph {
             }));
         }
         else {
-            throw new Error("The first condition must be a path condition.");
+            throw new AuthorizationRuleError("The first condition must be a path condition.");
         }
 
         const remainingConditions = match.conditions.slice(1);
@@ -73,14 +74,14 @@ class FactGraph {
 
     private async executePathCondition(references: ReferencesByName, unknown: Label, pathCondition: PathCondition): Promise<FactReference[]> {
         if (!references.hasOwnProperty(pathCondition.labelRight)) {
-            throw new Error(`The label ${pathCondition.labelRight} is not defined.`);
+            throw new AuthorizationRuleError(`The label ${pathCondition.labelRight} is not defined.`);
         }
         let predecessors = [references[pathCondition.labelRight]];
         for (const role of pathCondition.rolesRight) {
             predecessors = await this.executePredecessorStep(predecessors, role.name, role.predecessorType);
         }
         if (pathCondition.rolesLeft.length > 0) {
-            throw new Error('Cannot execute successor steps on evidence.');
+            throw new AuthorizationRuleError('Cannot execute successor steps on evidence.');
         }
         return predecessors;
     }
@@ -92,7 +93,7 @@ class FactGraph {
         return flatten(set, reference => {
             const record = this.findFactSync(reference);
             if (record === null) {
-                throw new Error(`The fact ${reference.type}:${reference.hash} is not defined.`);
+                throw new AuthorizationRuleError(`The fact ${reference.type}:${reference.hash} is not defined.`);
             }
             const predecessors = getPredecessors(record, name);
             return predecessors.filter(predecessor => predecessor.type === predecessorType);
@@ -115,7 +116,7 @@ class FactGraph {
         }
         else {
             const _exhaustiveCheck: never = condition;
-            throw new Error(`Unknown condition type: ${(_exhaustiveCheck as any).type}`);
+            throw new AuthorizationRuleError(`Unknown condition type: ${(_exhaustiveCheck as any).type}`);
         }
     }
 
@@ -238,12 +239,12 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
 
         // The specification must be given a single fact.
         if (this.specification.given.length !== 1) {
-            throw new Error('The specification must be given a single fact.');
+            throw new AuthorizationRuleError('The specification must be given a single fact.');
         }
 
         // The projection must be a singular label.
         if (this.specification.projection.type !== 'fact') {
-            throw new Error('The projection must be a singular label.');
+            throw new AuthorizationRuleError('The projection must be a singular label.');
         }
         const label = this.specification.projection.label;
 
@@ -254,12 +255,12 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
 
         // If there is no head, then the specification is unsatisfiable.
         if (head === undefined) {
-            throw new Error('The specification must start with a predecessor join. Otherwise, it is unsatisfiable.');
+            throw new AuthorizationRuleError('The specification must start with a predecessor join. Otherwise, it is unsatisfiable.');
         }
 
         // Execute the head on the graph.
         if (head.projection.type !== 'fact') {
-            throw new Error('The head of the specification must project a fact.');
+            throw new AuthorizationRuleError('The head of the specification must project a fact.');
         }
         let results = await graph.executeSpecification(
             head.given[0].label.name,
@@ -270,7 +271,7 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
         // If there is a tail, execute it on the store.
         if (tail !== undefined) {
             if (tail.given.length !== 1) {
-                throw new Error('The tail of the specification must be given a single fact.');
+                throw new AuthorizationRuleError('The tail of the specification must be given a single fact.');
             }
             const tailResults: FactReference[] = [];
             for (const result of results) {
@@ -295,12 +296,12 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
 
         // The specification must be given a single fact.
         if (this.specification.given.length !== 1) {
-            throw new Error('The specification must be given a single fact.');
+            throw new AuthorizationRuleError('The specification must be given a single fact.');
         }
 
         // The projection must be a singular label.
         if (this.specification.projection.type !== 'fact') {
-            throw new Error('The projection must be a singular label.');
+            throw new AuthorizationRuleError('The projection must be a singular label.');
         }
 
         // Split the specification.
@@ -310,12 +311,12 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
 
         // If there is no head, then the specification is unsatisfiable.
         if (head === undefined) {
-            throw new Error('The specification must start with a predecessor join. Otherwise, it is unsatisfiable.');
+            throw new AuthorizationRuleError('The specification must start with a predecessor join. Otherwise, it is unsatisfiable.');
         }
 
         // Execute the head on the graph.
         if (head.projection.type !== 'fact') {
-            throw new Error('The head of the specification must project a fact.');
+            throw new AuthorizationRuleError('The head of the specification must project a fact.');
         }
         const results = await graph.executeSpecification(
             head.given[0].label.name,
@@ -327,7 +328,7 @@ export class AuthorizationRuleSpecification implements AuthorizationRule {
         // If there is a tail, execute it on the store.
         if (tail !== undefined) {
             if (tail.given.length !== 1) {
-                throw new Error('The tail of the specification must be given a single fact.');
+                throw new AuthorizationRuleError('The tail of the specification must be given a single fact.');
             }
             for (const result of results) {
                 const users = await store.read([result], tail);
@@ -424,7 +425,7 @@ export class AuthorizationRules {
     private typeFromDefinition<T>(factConstructor: FactConstructor<T>, definition: UserSpecificationDefinition<T>): AuthorizationRules {
         const type = factConstructor.Type;
         if (this.model === undefined) {
-            throw new Error('The model must be given to define a rule using a specification.');
+            throw new AuthorizationRuleError('The model must be given to define a rule using a specification.');
         }
         const specification = this.model.given(factConstructor).match<unknown>(definition);
         return this.withRule(type, new AuthorizationRuleSpecification(specification.specification));
@@ -433,7 +434,7 @@ export class AuthorizationRules {
     private typeFromPredecessorSelector<T>(factConstructor: FactConstructor<T>, predecessorSelector: UserPredecessorSelector<T>): AuthorizationRules {
         const type = factConstructor.Type;
         if (this.model === undefined) {
-            throw new Error('The model must be given to define a rule using a specification.');
+            throw new AuthorizationRuleError('The model must be given to define a rule using a specification.');
         }
         const specification = this.model.given(factConstructor).match<unknown>((fact, facts) => {
             const label = predecessorSelector(fact);
@@ -442,20 +443,20 @@ export class AuthorizationRules {
                 const traversal = payload as Traversal<LabelOf<User> | LabelOf<Device>>;
                 const projection = traversal.projection;
                 if (projection.type !== 'fact') {
-                    throw new Error('Authorization rules must select facts.');
+                    throw new AuthorizationRuleError('Authorization rules must select facts.');
                 }
                 const label = projection.label;
                 const match = traversal.matches.find(m => m.unknown.name === label);
                 if (match === undefined) {
-                    throw new Error(`The traversal must match the label ${label}.`);
+                    throw new AuthorizationRuleError(`The traversal must match the label ${label}.`);
                 }
                 if (match.unknown.type !== User.Type && match.unknown.type !== Device.Type) {
-                    throw new Error(`The traversal must match a user or device.`);
+                    throw new AuthorizationRuleError(`The traversal must match a user or device.`);
                 }
                 return traversal;
             }
             if (payload.type !== 'fact') {
-                throw new Error('Authorization rules must select facts.');
+                throw new AuthorizationRuleError('Authorization rules must select facts.');
             }
             if (payload.factType === User.Type) {
                 const userTraversal = facts.ofType(User)
@@ -468,7 +469,7 @@ export class AuthorizationRules {
                 return deviceTraversal;
             }
             else {
-                throw new Error(`Authorization rules must select users or devices.`);
+                throw new AuthorizationRuleError(`Authorization rules must select users or devices.`);
             }
         });
         return this.withRule(type, new AuthorizationRuleSpecification(specification.specification));

--- a/src/authorization/errors.ts
+++ b/src/authorization/errors.ts
@@ -1,0 +1,35 @@
+import { FactReference } from '../storage';
+import { ValidationError } from '../util/errors';
+
+/**
+ * Thrown when an authorization rule is defined incorrectly — an unsatisfiable
+ * specification, a projection that isn't a fact, a label that isn't in scope.
+ * These are authoring mistakes, not runtime denials: `Forbidden` covers the
+ * latter.
+ */
+export class AuthorizationRuleError extends ValidationError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'AuthorizationRuleError';
+        Object.setPrototypeOf(this, AuthorizationRuleError.prototype);
+    }
+}
+
+/**
+ * Thrown by `AuthorizationEngine.authorizeFacts` when a fact in the batch names
+ * a predecessor that is neither in the batch nor in storage, so the fact can
+ * never be sorted and authorized. `missingPredecessors` names the references
+ * that could not be found; `unresolvedFacts` names the facts that depend on
+ * them.
+ */
+export class PredecessorNotResolvedError extends ValidationError {
+    constructor(
+        message: string,
+        public readonly missingPredecessors: FactReference[],
+        public readonly unresolvedFacts: FactReference[]
+    ) {
+        super(message);
+        this.name = 'PredecessorNotResolvedError';
+        Object.setPrototypeOf(this, PredecessorNotResolvedError.prototype);
+    }
+}

--- a/src/http/deserializer.ts
+++ b/src/http/deserializer.ts
@@ -1,5 +1,6 @@
 import { computeHash } from "../fact/hash";
 import { FactEnvelope, FactReference, FactRecord, PredecessorCollection, FactSignature } from "../storage";
+import { ValidationError } from "../util/errors";
 
 export interface GraphSource {
     read(
@@ -42,12 +43,12 @@ export class GraphDeserializer implements GraphSource {
 
     private async readPublicKey(index: number) {
         if (index !== this.publicKeys.length) {
-            throw new Error(`Public key index ${index} is out of order`);
+            throw new ValidationError(`Public key index ${index} is out of order`);
         }
         const publicKey = await this.parseNextJSONLine();
         const emptyLine = await this.readLine();
         if (emptyLine !== "") {
-            throw new Error(`Expected empty line after public key, but got "${emptyLine}"`);
+            throw new ValidationError(`Expected empty line after public key, but got "${emptyLine}"`);
         }
         this.publicKeys.push(publicKey);
     }
@@ -81,13 +82,13 @@ export class GraphDeserializer implements GraphSource {
             if (Array.isArray(index)) {
                 predecessors[role] = index.map(i => {
                     if (i >= this.factReferences.length) {
-                        throw new Error(`Predecessor reference ${i} is out of range`);
+                        throw new ValidationError(`Predecessor reference ${i} is out of range`);
                     }
                     return this.factReferences[i];
                 });
             } else {
                 if (index >= this.factReferences.length) {
-                    throw new Error(`Predecessor reference ${index} is out of range`);
+                    throw new ValidationError(`Predecessor reference ${index} is out of range`);
                 }
                 predecessors[role] = this.factReferences[index];
             }
@@ -100,11 +101,11 @@ export class GraphDeserializer implements GraphSource {
         let line: string | null;
         while ((line = await this.readLine()) !== null && line !== "") {
             if (!line.startsWith("PK")) {
-                throw new Error(`Expected public key reference, but got "${line}"`);
+                throw new ValidationError(`Expected public key reference, but got "${line}"`);
             }
             const publicKeyIndex = parseInt(line.substring(2));
             if (publicKeyIndex >= this.publicKeys.length) {
-                throw new Error(`Public key reference ${publicKeyIndex} is out of range`);
+                throw new ValidationError(`Public key reference ${publicKeyIndex} is out of range`);
             }
             const publicKey = this.publicKeys[publicKeyIndex];
             const signature = await this.parseNextJSONLine();
@@ -117,7 +118,7 @@ export class GraphDeserializer implements GraphSource {
     private async parseNextJSONLine() {
         const line = await this.readLine();
         if (!line) {
-            throw new Error("Expected JSON line, but got end of file");
+            throw new ValidationError("Expected JSON line, but got end of file");
         }
         return JSON.parse(line);
     }

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,33 +1,49 @@
 /**
- * Thrown on an HTTP 403 from the replicator (issue #207 W10). The replicator
- * sends the actual reason a `/read`/`/load`/`/feeds` request was forbidden in
- * the *response body*, but the previous `new Error(statusMessage)` threw away
- * everything but the status line (`"Forbidden"`). `reason` is the extracted
- * human-readable message and `body` is the raw response body, so callers can
- * surface or inspect the replicator's explanation.
+ * Thrown when the replicator responds with an error status (issue #234). The
+ * server sends its actual diagnostic text in the *response body*, but the
+ * previous `new Error(statusMessage)` threw all of that away and kept only the
+ * generic HTTP reason phrase (`"Internal Server Error"`, `"Bad Request"`), so
+ * no server-side error message ever reached a caller. `reason` is the extracted
+ * human-readable message, `statusCode` is the HTTP status, and `body` is the
+ * raw response body, so callers can surface or inspect the explanation.
  */
-export class ForbiddenError extends Error {
+export class HttpError extends Error {
     constructor(
         public readonly reason: string,
+        public readonly statusCode: number,
         public readonly body: unknown
     ) {
         super(reason);
-        this.name = 'ForbiddenError';
-        // Restore the prototype chain so `instanceof ForbiddenError` works after
+        this.name = 'HttpError';
+        // Restore the prototype chain so `instanceof HttpError` works after
         // TypeScript's down-level `extends Error` transpilation.
+        Object.setPrototypeOf(this, HttpError.prototype);
+    }
+}
+
+/**
+ * Thrown on an HTTP 403 from the replicator (issue #207 W10). The replicator
+ * sends the actual reason a `/read`/`/load`/`/feeds` request was forbidden in
+ * the response body; this preserves it rather than discarding it for the bare
+ * status line.
+ */
+export class ForbiddenError extends HttpError {
+    constructor(reason: string, body: unknown) {
+        super(reason, 403, body);
+        this.name = 'ForbiddenError';
         Object.setPrototypeOf(this, ForbiddenError.prototype);
     }
 }
 
 /**
- * Derive a human-readable reason from a 403 response body, preferring a
- * `reason`/`message` field or a plain-string body, and falling back to the HTTP
+ * Derive a human-readable reason from an error response body, preferring a
+ * plain-string body or a `reason`/`message` field, and falling back to the HTTP
  * status line otherwise. An object body without a `reason`/`message` field is
  * not stringified into the reason — that would yield noisy or oversized text
- * like `"{}"`; the raw body is preserved on `ForbiddenError.body` for callers
- * that want to inspect it.
+ * like `"{}"`; the raw body is preserved on `HttpError.body` for callers that
+ * want to inspect it.
  */
-export function forbiddenReason(body: unknown, fallback: string | undefined): string {
+export function responseReason(body: unknown, statusMessage: string | undefined, fallback: string): string {
     if (typeof body === 'string' && body.trim().length > 0) {
         return body;
     }
@@ -40,5 +56,13 @@ export function forbiddenReason(body: unknown, fallback: string | undefined): st
             return record.message;
         }
     }
-    return fallback || 'Forbidden';
+    return statusMessage || fallback;
+}
+
+/**
+ * The 403 flavor of {@link responseReason}, falling back to `'Forbidden'` when
+ * the response carries neither a usable body nor a status line.
+ */
+export function forbiddenReason(body: unknown, fallback: string | undefined): string {
+    return responseReason(body, fallback, 'Forbidden');
 }

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -1,7 +1,7 @@
 import { Trace } from "../util/trace";
 import { HttpHeaders } from "./authenticationProvider";
 import { PostAccept, PostContentType, ContentTypeJson } from "./ContentType";
-import { ForbiddenError, forbiddenReason } from "./errors";
+import { ForbiddenError, forbiddenReason, HttpError, responseReason } from "./errors";
 import { HttpConnection, HttpResponse } from "./web-client";
 
 interface FetchHttpResponse {
@@ -9,6 +9,17 @@ interface FetchHttpResponse {
     statusMessage: string | undefined;
     responseType: string;
     response: any;
+}
+
+/**
+ * Decide whether a POST that failed with this status is worth retrying
+ * (issue #234). 5xx is transient by definition. Of the 4xx, only 408 — which
+ * this connection also synthesizes for its own timeout — and 429 ask to be
+ * retried. Every other 4xx is deterministic: the same request will fail the
+ * same way, so retrying only delays the failure the caller needs to act on.
+ */
+function isRetryableStatus(statusCode: number): boolean {
+    return statusCode >= 500 || statusCode === 408 || statusCode === 429;
 }
 
 export class FetchConnection implements HttpConnection {
@@ -35,7 +46,12 @@ export class FetchConnection implements HttpConnection {
                 throw new ForbiddenError(forbiddenReason(response.response, response.statusMessage), response.response);
             }
             else if (response.statusCode >= 400) {
-                throw new Error(response.statusMessage);
+                // Surface the server's diagnostic body instead of the bare
+                // status line (issue #234).
+                throw new HttpError(
+                    responseReason(response.response, response.statusMessage, "Unknown error"),
+                    response.statusCode,
+                    response.response);
             }
             else if (response.statusCode === 200) {
                 if (typeof response.response === 'string') {
@@ -213,9 +229,14 @@ export class FetchConnection implements HttpConnection {
                 throw new ForbiddenError(forbiddenReason(response.response, response.statusMessage), response.response);
             }
             else if (response.statusCode >= 400) {
+                // Surface the server's diagnostic body instead of the bare
+                // status line, and only ask for a retry when the status can
+                // actually succeed on a second attempt (issue #234).
                 return {
-                    result: "retry",
-                    error: response.statusMessage || "Unknown error"
+                    result: isRetryableStatus(response.statusCode) ? "retry" : "failure",
+                    error: responseReason(response.response, response.statusMessage, "Unknown error"),
+                    statusCode: response.statusCode,
+                    body: response.response
                 }
             }
             else if (response.statusCode === 201) {

--- a/src/http/messageParsers.ts
+++ b/src/http/messageParsers.ts
@@ -3,8 +3,16 @@ import { FactRecord, FactReference, PredecessorCollection } from "../storage";
 import { ValidationError } from "../util/errors";
 import { FeedDecision, FeedsResponse, LoadMessage, SaveMessage } from "./messages";
 
+// `typeof null === 'object'`, and so is an array. Neither is a valid message
+// object here: letting them through produced a bare TypeError on the next
+// property access rather than the intended ValidationError, which is exactly
+// the classification hole this parser is meant to close.
+function isObject(value: any): boolean {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function parseFactReference(factReference: any): FactReference {
-  if (typeof factReference !== 'object') throw new ValidationError("Expected FactReference to be an object.");
+  if (!isObject(factReference)) throw new ValidationError("Expected FactReference to be an object.");
   if (typeof factReference.type !== 'string') throw new ValidationError("Expected a string 'type' property.");
   if (typeof factReference.hash !== 'string') throw new ValidationError("Expected a string 'hash' property.");
   return {
@@ -23,7 +31,7 @@ function parsePredecessor(predecessor: any): FactReference | FactReference[] {
 }
 
 function parsePredecessorCollection(predecessors: any): PredecessorCollection {
-  if (typeof predecessors !== 'object') throw new ValidationError("Expected PredecessorCollection to be an object.");
+  if (!isObject(predecessors)) throw new ValidationError("Expected PredecessorCollection to be an object.");
   return Object.keys(predecessors).reduce((result, key) => ({
     ...result,
     [key]: parsePredecessor(predecessors[key])
@@ -31,10 +39,10 @@ function parsePredecessorCollection(predecessors: any): PredecessorCollection {
 }
 
 function parseFactRecord(factRecord: any): FactRecord {
-  if (typeof factRecord !== 'object') throw new ValidationError("Expected FactRecord to be an object.");
+  if (!isObject(factRecord)) throw new ValidationError("Expected FactRecord to be an object.");
   if (typeof factRecord.type !== 'string') throw new ValidationError("Expected a string 'type' property.");
   if (typeof factRecord.hash !== 'string') throw new ValidationError("Expected a string 'hash' property.");
-  if (typeof factRecord.fields !== 'object') throw new ValidationError("Expected an object 'fields' property.");
+  if (!isObject(factRecord.fields)) throw new ValidationError("Expected an object 'fields' property.");
   return {
     type: factRecord.type,
     hash: factRecord.hash,
@@ -44,7 +52,7 @@ function parseFactRecord(factRecord: any): FactRecord {
 }
 
 export function parseSaveMessage(message: any): SaveMessage {
-  if (typeof message !== 'object') throw new ValidationError("Expected an object. Check the content type of the request.");
+  if (!isObject(message)) throw new ValidationError("Expected an object. Check the content type of the request.");
   if (!Array.isArray(message.facts)) throw new ValidationError("Expected an array 'facts' property.");
   return {
     facts: message.facts.map(parseFactRecord)
@@ -52,7 +60,7 @@ export function parseSaveMessage(message: any): SaveMessage {
 }
 
 export function parseLoadMessage(message: any): LoadMessage {
-  if (typeof message !== 'object') throw new ValidationError("Expected an object. Check the content type of the request.");
+  if (!isObject(message)) throw new ValidationError("Expected an object. Check the content type of the request.");
   if (!Array.isArray(message.references)) throw new ValidationError("Expected an array 'references' property.");
   return {
     references: message.references.map(parseFactReference)
@@ -62,7 +70,7 @@ export function parseLoadMessage(message: any): LoadMessage {
 const feedDecisionKinds = ['authorized', 'reactive', 'denied'];
 
 function parseFeedDecision(decision: any): FeedDecision {
-  if (typeof decision !== 'object' || decision === null) throw new ValidationError("Expected FeedDecision to be an object.");
+  if (!isObject(decision)) throw new ValidationError("Expected FeedDecision to be an object.");
   if (typeof decision.feed !== 'string') throw new ValidationError("Expected a string 'feed' property.");
   if (!feedDecisionKinds.includes(decision.decision)) {
     throw new ValidationError("Expected 'decision' to be 'authorized', 'reactive', or 'denied'.");
@@ -84,7 +92,7 @@ function parseFeedDecision(decision: any): FeedDecision {
 }
 
 export function parseFeedsResponse(message: any): FeedsResponse {
-  if (typeof message !== 'object' || message === null) throw new ValidationError("Expected an object. Check the content type of the response.");
+  if (!isObject(message)) throw new ValidationError("Expected an object. Check the content type of the response.");
   if (!Array.isArray(message.feeds)) throw new ValidationError("Expected an array 'feeds' property.");
   const feeds: string[] = message.feeds.map((feed: any) => {
     if (typeof feed !== 'string') throw new ValidationError("Expected 'feeds' to be an array of strings.");

--- a/src/http/messageParsers.ts
+++ b/src/http/messageParsers.ts
@@ -1,11 +1,12 @@
 import { DistributionDenialCode, distributionDenialCodes } from "../distribution/distribution-engine";
 import { FactRecord, FactReference, PredecessorCollection } from "../storage";
+import { ValidationError } from "../util/errors";
 import { FeedDecision, FeedsResponse, LoadMessage, SaveMessage } from "./messages";
 
 function parseFactReference(factReference: any): FactReference {
-  if (typeof factReference !== 'object') throw new Error("Expected FactReference to be an object.");
-  if (typeof factReference.type !== 'string') throw new Error("Expected a string 'type' property.");
-  if (typeof factReference.hash !== 'string') throw new Error("Expected a string 'hash' property.");
+  if (typeof factReference !== 'object') throw new ValidationError("Expected FactReference to be an object.");
+  if (typeof factReference.type !== 'string') throw new ValidationError("Expected a string 'type' property.");
+  if (typeof factReference.hash !== 'string') throw new ValidationError("Expected a string 'hash' property.");
   return {
     type: factReference.type,
     hash: factReference.hash
@@ -22,7 +23,7 @@ function parsePredecessor(predecessor: any): FactReference | FactReference[] {
 }
 
 function parsePredecessorCollection(predecessors: any): PredecessorCollection {
-  if (typeof predecessors !== 'object') throw new Error("Expected PredecessorCollection to be an object.");
+  if (typeof predecessors !== 'object') throw new ValidationError("Expected PredecessorCollection to be an object.");
   return Object.keys(predecessors).reduce((result, key) => ({
     ...result,
     [key]: parsePredecessor(predecessors[key])
@@ -30,10 +31,10 @@ function parsePredecessorCollection(predecessors: any): PredecessorCollection {
 }
 
 function parseFactRecord(factRecord: any): FactRecord {
-  if (typeof factRecord !== 'object') throw new Error("Expected FactRecord to be an object.");
-  if (typeof factRecord.type !== 'string') throw new Error("Expected a string 'type' property.");
-  if (typeof factRecord.hash !== 'string') throw new Error("Expected a string 'hash' property.");
-  if (typeof factRecord.fields !== 'object') throw new Error("Expected an object 'fields' property.");
+  if (typeof factRecord !== 'object') throw new ValidationError("Expected FactRecord to be an object.");
+  if (typeof factRecord.type !== 'string') throw new ValidationError("Expected a string 'type' property.");
+  if (typeof factRecord.hash !== 'string') throw new ValidationError("Expected a string 'hash' property.");
+  if (typeof factRecord.fields !== 'object') throw new ValidationError("Expected an object 'fields' property.");
   return {
     type: factRecord.type,
     hash: factRecord.hash,
@@ -43,16 +44,16 @@ function parseFactRecord(factRecord: any): FactRecord {
 }
 
 export function parseSaveMessage(message: any): SaveMessage {
-  if (typeof message !== 'object') throw new Error("Expected an object. Check the content type of the request.");
-  if (!Array.isArray(message.facts)) throw new Error("Expected an array 'facts' property.");
+  if (typeof message !== 'object') throw new ValidationError("Expected an object. Check the content type of the request.");
+  if (!Array.isArray(message.facts)) throw new ValidationError("Expected an array 'facts' property.");
   return {
     facts: message.facts.map(parseFactRecord)
   };
 }
 
 export function parseLoadMessage(message: any): LoadMessage {
-  if (typeof message !== 'object') throw new Error("Expected an object. Check the content type of the request.");
-  if (!Array.isArray(message.references)) throw new Error("Expected an array 'references' property.");
+  if (typeof message !== 'object') throw new ValidationError("Expected an object. Check the content type of the request.");
+  if (!Array.isArray(message.references)) throw new ValidationError("Expected an array 'references' property.");
   return {
     references: message.references.map(parseFactReference)
   };
@@ -61,21 +62,21 @@ export function parseLoadMessage(message: any): LoadMessage {
 const feedDecisionKinds = ['authorized', 'reactive', 'denied'];
 
 function parseFeedDecision(decision: any): FeedDecision {
-  if (typeof decision !== 'object' || decision === null) throw new Error("Expected FeedDecision to be an object.");
-  if (typeof decision.feed !== 'string') throw new Error("Expected a string 'feed' property.");
+  if (typeof decision !== 'object' || decision === null) throw new ValidationError("Expected FeedDecision to be an object.");
+  if (typeof decision.feed !== 'string') throw new ValidationError("Expected a string 'feed' property.");
   if (!feedDecisionKinds.includes(decision.decision)) {
-    throw new Error("Expected 'decision' to be 'authorized', 'reactive', or 'denied'.");
+    throw new ValidationError("Expected 'decision' to be 'authorized', 'reactive', or 'denied'.");
   }
-  if (typeof decision.reason !== 'string') throw new Error("Expected a string 'reason' property.");
+  if (typeof decision.reason !== 'string') throw new ValidationError("Expected a string 'reason' property.");
   const result: FeedDecision = {
     feed: decision.feed,
     decision: decision.decision,
     reason: decision.reason
   };
   if (decision.code !== undefined) {
-    if (typeof decision.code !== 'string') throw new Error("Expected a string 'code' property.");
+    if (typeof decision.code !== 'string') throw new ValidationError("Expected a string 'code' property.");
     if (!(distributionDenialCodes as readonly string[]).includes(decision.code)) {
-      throw new Error(`Unknown denial 'code': ${decision.code}.`);
+      throw new ValidationError(`Unknown denial 'code': ${decision.code}.`);
     }
     result.code = decision.code as DistributionDenialCode;
   }
@@ -83,17 +84,17 @@ function parseFeedDecision(decision: any): FeedDecision {
 }
 
 export function parseFeedsResponse(message: any): FeedsResponse {
-  if (typeof message !== 'object' || message === null) throw new Error("Expected an object. Check the content type of the response.");
-  if (!Array.isArray(message.feeds)) throw new Error("Expected an array 'feeds' property.");
+  if (typeof message !== 'object' || message === null) throw new ValidationError("Expected an object. Check the content type of the response.");
+  if (!Array.isArray(message.feeds)) throw new ValidationError("Expected an array 'feeds' property.");
   const feeds: string[] = message.feeds.map((feed: any) => {
-    if (typeof feed !== 'string') throw new Error("Expected 'feeds' to be an array of strings.");
+    if (typeof feed !== 'string') throw new ValidationError("Expected 'feeds' to be an array of strings.");
     return feed;
   });
   const response: FeedsResponse = { feeds };
   // Old replicators omit `decisions`; when absent the client simply has
   // nothing to report (graceful degradation).
   if (message.decisions !== undefined) {
-    if (!Array.isArray(message.decisions)) throw new Error("Expected an array 'decisions' property.");
+    if (!Array.isArray(message.decisions)) throw new ValidationError("Expected an array 'decisions' property.");
     response.decisions = message.decisions.map(parseFeedDecision);
   }
   return response;

--- a/src/http/web-client.ts
+++ b/src/http/web-client.ts
@@ -2,6 +2,7 @@ import { serializeSave } from "../fork/serialize";
 import { FactEnvelope } from "../storage";
 import { Trace } from "../util/trace";
 import { ContentTypeGraph, ContentTypeJson, ContentTypeText, PostAccept, PostContentType } from "./ContentType";
+import { HttpError } from "./errors";
 import { parseFeedsResponse } from "./messageParsers";
 import { FeedResponse, FeedsResponse, LoadMessage, LoadResponse, LoginResponse } from "./messages";
 import { serializeGraph } from "./serializer";
@@ -35,11 +36,19 @@ export interface HttpSuccess {
 export interface HttpFailure {
     result: "failure";
     error: string;
+    /** HTTP status, when the connection knows it. See {@link httpError}. */
+    statusCode?: number;
+    /** Raw response body, preserved for callers that want to inspect it. */
+    body?: unknown;
 }
 
 export interface HttpRetry {
     result: "retry";
     error: string
+    /** HTTP status, when the connection knows it. See {@link httpError}. */
+    statusCode?: number;
+    /** Raw response body, preserved for callers that want to inspect it. */
+    body?: unknown;
 }
 
 export type HttpResponse = HttpSuccess | HttpFailure | HttpRetry;
@@ -49,6 +58,18 @@ export interface HttpConnection {
     getStream(path: string, onResponse: (response: {}) => Promise<void>, onError: (err: Error) => void, feedRefreshIntervalSeconds: number): () => void;
     post(path: string, contentType: PostContentType, accept: PostAccept, body: string, timeoutSeconds: number): Promise<HttpResponse>;
     getAcceptedContentTypes(path: string): Promise<string[]>;
+}
+
+/**
+ * Build the error to throw for a failed response. A connection that reports the
+ * status gets the richer `HttpError`, so callers can read `statusCode` and the
+ * raw `body` (issue #234); the status is optional on `HttpFailure`/`HttpRetry`,
+ * so a third-party `HttpConnection` that omits it still gets a plain `Error`.
+ */
+function httpError(response: HttpFailure | HttpRetry): Error {
+    return response.statusCode === undefined
+        ? new Error(response.error)
+        : new HttpError(response.error, response.statusCode, response.body);
 }
 
 function delay(timeSeconds: number): Promise<void> {
@@ -125,7 +146,7 @@ export class WebClient {
             return response.response;
         }
         else {
-            throw new Error(response.error);
+            throw httpError(response);
         }
     }
 
@@ -139,7 +160,7 @@ export class WebClient {
                 return response.response;
             }
             else if (response.result === 'failure') {
-                throw new Error(response.error);
+                throw httpError(response);
             }
             else {
                 if (retrySeconds <= 4) {
@@ -149,7 +170,7 @@ export class WebClient {
                     retrySeconds = retrySeconds * 2;
                 }
                 else {
-                    throw new Error(response.error);
+                    throw httpError(response);
                 }
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { Authorization } from './authorization/authorization';
 export { AuthorizationEngine, Forbidden } from './authorization/authorization-engine';
 export { AuthorizationNoOp } from "./authorization/authorization-noop";
 export { AuthorizationRules, describeAuthorizationRules } from "./authorization/authorizationRules";
+export { AuthorizationRuleError, PredecessorNotResolvedError } from "./authorization/errors";
 export { generateKeyPair, KeyPair, signFacts } from "./cryptography/key-pair";
 export { verifyEnvelopes } from "./cryptography/verify";
 export { DistributionEngine, DistributionDenialCode, distributionDenialCodes, DistributionFailure, DistributionPerFeedFailure, DistributionResult, DistributionSuccess } from './distribution/distribution-engine';
@@ -18,7 +19,7 @@ export { PersistentFork } from "./fork/persistent-fork";
 export { TransientFork } from './fork/transient-fork';
 export { AuthenticationProvider, HttpHeaders } from "./http/authenticationProvider";
 export { GraphDeserializer, GraphSource } from "./http/deserializer";
-export { ForbiddenError } from "./http/errors";
+export { ForbiddenError, HttpError } from "./http/errors";
 export { FetchConnection } from "./http/fetch";
 export { HttpNetwork } from "./http/httpNetwork";
 export { parseFeedsResponse, parseLoadMessage, parseSaveMessage } from './http/messageParsers';
@@ -63,6 +64,7 @@ export { Invalid, SpecificationParser } from './specification/specification-pars
 export { detectDisconnectedSpecification, DisconnectedSpecificationError } from "./specification/UnionFind";
 export { computeTupleSubsetHash, FactEnvelope, factEnvelopeEquals, FactFeed, FactRecord, FactReference, factReferenceEquals, FactSignature, FactTuple, PredecessorCollection, ProjectedResult, Queue, ReferencesByName, Storage, uniqueFactReferences, validateGiven } from './storage';
 export { UserIdentity } from './user-identity';
+export { ValidationError } from './util/errors';
 export { delay } from './util/promise';
 export { ConsoleTracer, NoOpTracer, Trace, Tracer } from './util/trace';
 

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -1,0 +1,17 @@
+/**
+ * Thrown when input is malformed or violates a rule that no retry can fix
+ * (issue #234). Every throw site in this package used to be a bare `new Error`,
+ * which left downstream code — notably `jinaga-server`'s error-to-HTTP-status
+ * mapping — with no way to classify a failure except by regex-matching the
+ * English message text. That breaks silently whenever the wording changes here.
+ * Subclasses carry structured detail so callers can `instanceof`-check instead.
+ */
+export class ValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ValidationError';
+        // Restore the prototype chain so `instanceof ValidationError` works after
+        // TypeScript's down-level `extends Error` transpilation.
+        Object.setPrototypeOf(this, ValidationError.prototype);
+    }
+}

--- a/test/authorization/authorizationEngineSpec.ts
+++ b/test/authorization/authorizationEngineSpec.ts
@@ -1,4 +1,4 @@
-import { AuthorizationEngine, AuthorizationRules, FactEnvelope, MemoryStore, dehydrateFact } from "@src";
+import { AuthorizationEngine, AuthorizationRules, FactEnvelope, MemoryStore, PredecessorNotResolvedError, dehydrateFact } from "@src";
 
 describe("AuthorizationEngine.authorizeFacts", () => {
     it("authorizes a fact whose predecessor already exists in the store but is not in the current batch", async () => {
@@ -35,7 +35,7 @@ describe("AuthorizationEngine.authorizeFacts", () => {
         expect(authorizedTypes).toEqual(["Test.Channel", "Test.ChannelOwner"]);
     });
 
-    it("throws instead of silently dropping a fact whose predecessor does not exist anywhere", async () => {
+    it("names the missing predecessor instead of only the facts that depend on it", async () => {
         const store = new MemoryStore();
 
         // The user does not exist in the store, and is not resubmitted as
@@ -51,6 +51,7 @@ describe("AuthorizationEngine.authorizeFacts", () => {
                 publicKey: "nonexistent-owner"
             }
         });
+        const missingUser = facts.find(f => f.type === "Jinaga.User")!;
         const batchFacts = facts.filter(f => f.type !== "Jinaga.User");
 
         const authorizationRules = new AuthorizationRules(undefined)
@@ -60,6 +61,16 @@ describe("AuthorizationEngine.authorizeFacts", () => {
 
         const envelopes: FactEnvelope[] = batchFacts.map(fact => ({ fact, signatures: [] }));
 
-        await expect(engine.authorizeFacts(envelopes, null)).rejects.toThrow();
+        const error = await engine.authorizeFacts(envelopes, null).catch(e => e);
+
+        expect(error).toBeInstanceOf(PredecessorNotResolvedError);
+        expect(error.message).toContain(`predecessor Jinaga.User:${missingUser.hash}`);
+        expect(error.message).toContain("Add it to the batch, or commit it first.");
+        expect(error.missingPredecessors).toEqual([
+            { type: "Jinaga.User", hash: missingUser.hash }
+        ]);
+        expect(error.unresolvedFacts).toEqual([
+            { type: "Test.ChannelOwner", hash: batchFacts.find(f => f.type === "Test.ChannelOwner")!.hash }
+        ]);
     });
 });

--- a/test/http/feedsResponseParserSpec.ts
+++ b/test/http/feedsResponseParserSpec.ts
@@ -1,4 +1,4 @@
-import { parseFeedsResponse } from "@src";
+import { parseFeedsResponse, parseLoadMessage, parseSaveMessage, ValidationError } from "@src";
 
 describe("parseFeedsResponse (issue #207 W3)", () => {
   it("parses a response with only feeds (old replicator)", () => {
@@ -46,5 +46,11 @@ describe("parseFeedsResponse (issue #207 W3)", () => {
 
   it("rejects non-string feed entries", () => {
     expect(() => parseFeedsResponse({ feeds: [1, 2] })).toThrow(/'feeds'/);
+  });
+
+  it("throws a ValidationError so callers can classify without matching prose (issue #234)", () => {
+    expect(() => parseFeedsResponse({ feeds: "abc" })).toThrow(ValidationError);
+    expect(() => parseSaveMessage({ facts: "abc" })).toThrow(ValidationError);
+    expect(() => parseLoadMessage("not an object")).toThrow(ValidationError);
   });
 });

--- a/test/http/feedsResponseParserSpec.ts
+++ b/test/http/feedsResponseParserSpec.ts
@@ -53,4 +53,33 @@ describe("parseFeedsResponse (issue #207 W3)", () => {
     expect(() => parseSaveMessage({ facts: "abc" })).toThrow(ValidationError);
     expect(() => parseLoadMessage("not an object")).toThrow(ValidationError);
   });
+
+  // `typeof null === 'object'`, and so is an array, so these once slipped past
+  // the guard and failed later as a bare TypeError — unclassifiable downstream.
+  it.each([null, [], ["abc"]])("rejects %p as a message with a ValidationError", (message) => {
+    expect(() => parseFeedsResponse(message)).toThrow(ValidationError);
+    expect(() => parseSaveMessage(message)).toThrow(ValidationError);
+    expect(() => parseLoadMessage(message)).toThrow(ValidationError);
+  });
+
+  it("rejects a null or array fact reference with a ValidationError", () => {
+    expect(() => parseLoadMessage({ references: [null] }))
+      .toThrow("Expected FactReference to be an object.");
+    expect(() => parseLoadMessage({ references: [["Test.Type", "hash"]] }))
+      .toThrow("Expected FactReference to be an object.");
+  });
+
+  it("rejects a null fact record, fields map, or predecessor collection with a ValidationError", () => {
+    expect(() => parseSaveMessage({ facts: [null] }))
+      .toThrow("Expected FactRecord to be an object.");
+    expect(() => parseSaveMessage({ facts: [{ type: "Test.Type", hash: "abc", fields: null }] }))
+      .toThrow("Expected an object 'fields' property.");
+    expect(() => parseSaveMessage({ facts: [{ type: "Test.Type", hash: "abc", fields: {}, predecessors: null }] }))
+      .toThrow("Expected PredecessorCollection to be an object.");
+  });
+
+  it("rejects a null feed decision with a ValidationError", () => {
+    expect(() => parseFeedsResponse({ feeds: [], decisions: [null] }))
+      .toThrow("Expected FeedDecision to be an object.");
+  });
 });

--- a/test/http/httpErrorSpec.ts
+++ b/test/http/httpErrorSpec.ts
@@ -1,0 +1,194 @@
+import { FetchConnection, HttpError, SyncStatusNotifier, WebClient } from "@src";
+import { ContentTypeJson, PostAccept, PostContentType } from "../../src/http/ContentType";
+import { HttpConnection, HttpResponse } from "../../src/http/web-client";
+
+// Build a minimal fetch Response stand-in with the shape FetchConnection reads.
+function fakeResponse(status: number, statusText: string, contentType: string, body: unknown) {
+  return {
+    status,
+    statusText,
+    headers: { get: (h: string) => (h.toLowerCase() === "content-type" ? contentType : null) },
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  };
+}
+
+// A stub HttpConnection that hands back canned responses and counts attempts,
+// so the retry policy can be observed without waiting on real backoff.
+class StubConnection implements HttpConnection {
+  public postCount = 0;
+
+  constructor(private responses: HttpResponse[]) {}
+
+  get(path: string): Promise<{}> {
+    throw new Error("not used");
+  }
+
+  getStream(): () => void {
+    throw new Error("not used");
+  }
+
+  async post(path: string, contentType: PostContentType, accept: PostAccept, body: string, timeoutSeconds: number): Promise<HttpResponse> {
+    const response = this.responses[Math.min(this.postCount, this.responses.length - 1)];
+    this.postCount++;
+    return response;
+  }
+
+  async getAcceptedContentTypes(path: string): Promise<string[]> {
+    return [ContentTypeJson];
+  }
+}
+
+describe("HTTP error diagnostics (issue #234)", () => {
+  describe("FetchConnection surfaces the response body", () => {
+    const realFetch = global.fetch;
+    afterEach(() => { global.fetch = realFetch; });
+
+    function connection() {
+      return new FetchConnection(
+        "http://localhost",
+        () => Promise.resolve({}),
+        () => Promise.resolve(false)
+      );
+    }
+
+    it("throws HttpError carrying the plain-text body, status, and raw body (GET)", async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(500, "Internal Server Error", "text/plain", "Fact Test.Order:AXn3 has no signature.")
+      ) as any;
+
+      const error = await connection().get("/feeds/abc").catch(e => e);
+      expect(error).toBeInstanceOf(HttpError);
+      expect(error.message).toBe("Fact Test.Order:AXn3 has no signature.");
+      expect(error.statusCode).toBe(500);
+      expect(error.body).toBe("Fact Test.Order:AXn3 has no signature.");
+    });
+
+    it("prefers the 'message' field of a JSON body over the status line (GET)", async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(400, "Bad Request", "application/json", { message: "Expected an array 'facts' property." })
+      ) as any;
+
+      const error = await connection().get("/load").catch(e => e);
+      expect(error.message).toBe("Expected an array 'facts' property.");
+      expect(error.statusCode).toBe(400);
+    });
+
+    it("falls back to the status line when the body is empty (GET)", async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(500, "Internal Server Error", "text/plain", "")
+      ) as any;
+
+      const error = await connection().get("/feeds/abc").catch(e => e);
+      expect(error.message).toBe("Internal Server Error");
+    });
+
+    it("returns the body as the error text (POST)", async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(400, "Bad Request", "text/plain", "Cannot authorize 1 fact of type Test.Order.")
+      ) as any;
+
+      const response = await connection().post("/save", ContentTypeJson, ContentTypeJson, "{}", 30);
+      expect(response).toMatchObject({
+        error: "Cannot authorize 1 fact of type Test.Order.",
+        statusCode: 400,
+        body: "Cannot authorize 1 fact of type Test.Order."
+      });
+    });
+
+    it("falls back to the status line when the body is empty (POST)", async () => {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(503, "Service Unavailable", "text/plain", "")
+      ) as any;
+
+      const response = await connection().post("/save", ContentTypeJson, ContentTypeJson, "{}", 30);
+      expect(response).toMatchObject({ error: "Service Unavailable" });
+    });
+  });
+
+  describe("FetchConnection classifies retryable statuses", () => {
+    const realFetch = global.fetch;
+    afterEach(() => { global.fetch = realFetch; });
+
+    function connection() {
+      return new FetchConnection(
+        "http://localhost",
+        () => Promise.resolve({}),
+        () => Promise.resolve(false)
+      );
+    }
+
+    async function resultFor(status: number) {
+      global.fetch = jest.fn().mockResolvedValue(
+        fakeResponse(status, "Error", "text/plain", "")
+      ) as any;
+      const response = await connection().post("/save", ContentTypeJson, ContentTypeJson, "{}", 30);
+      return response.result;
+    }
+
+    it.each([500, 502, 503, 408, 429])("retries a transient %i", async (status) => {
+      expect(await resultFor(status)).toBe("retry");
+    });
+
+    it.each([400, 401, 404, 409, 422])("fails immediately on a deterministic %i", async (status) => {
+      expect(await resultFor(status)).toBe("failure");
+    });
+  });
+
+  describe("WebClient propagates the diagnostics", () => {
+    function webClient(connection: HttpConnection) {
+      return new WebClient(connection, new SyncStatusNotifier(), { timeoutSeconds: 30 });
+    }
+
+    it("throws HttpError carrying the status and body", async () => {
+      const connection = new StubConnection([{
+        result: "failure",
+        error: "Cannot authorize 1 fact of type Test.Order.",
+        statusCode: 400,
+        body: "Cannot authorize 1 fact of type Test.Order."
+      }]);
+
+      const error = await webClient(connection).load({ references: [] }).catch(e => e);
+      expect(error).toBeInstanceOf(HttpError);
+      expect(error.message).toBe("Cannot authorize 1 fact of type Test.Order.");
+      expect(error.statusCode).toBe(400);
+    });
+
+    it("throws a plain Error when the connection reports no status", async () => {
+      const connection = new StubConnection([{ result: "failure", error: "network down" }]);
+
+      const error = await webClient(connection).load({ references: [] }).catch(e => e);
+      expect(error).not.toBeInstanceOf(HttpError);
+      expect(error.message).toBe("network down");
+    });
+
+    it("does not retry a deterministic failure", async () => {
+      const connection = new StubConnection([{
+        result: "failure",
+        error: "Expected an array 'facts' property.",
+        statusCode: 400,
+        body: "Expected an array 'facts' property."
+      }]);
+
+      const error = await webClient(connection).loadWithRetry({ references: [] }).catch(e => e);
+      expect(error.message).toBe("Expected an array 'facts' property.");
+      // One attempt, no backoff: the request cannot succeed on a second try.
+      expect(connection.postCount).toBe(1);
+    });
+
+    it("still retries a transient failure and reports the last body on give-up", async () => {
+      const connection = new StubConnection([{
+        result: "retry",
+        error: "The replicator is restarting.",
+        statusCode: 503,
+        body: "The replicator is restarting."
+      }]);
+
+      const error = await webClient(connection).loadWithRetry({ references: [] }).catch(e => e);
+      expect(error).toBeInstanceOf(HttpError);
+      expect(error.statusCode).toBe(503);
+      expect(connection.postCount).toBeGreaterThan(1);
+      // 1s + 2s + 4s of backoff, plus up to a second of jitter each.
+    }, 30000);
+  });
+});


### PR DESCRIPTION
Closes #234

`FetchConnection` reads the full response body for every request and then throws it away for every error status except 403. Callers only ever see the generic HTTP reason phrase — `"Internal Server Error"`, `"Bad Request"` — never the diagnostic text the server actually sent. That makes every server-side error-message improvement inert: `jinaga-server`'s fix for its issue #175 builds a specific, useful message and sends it in the body, and no `WebClient`-based caller can see it.

This generalizes the `ForbiddenError` pattern already used for 403 (issue #207 W10) to every error status, and resolves the three related findings raised in the issue.

## Surface the response body

- **`HttpError`** (`src/http/errors.ts`) carries `reason`, `statusCode`, and the raw `body`. `ForbiddenError` now extends it; its two-argument constructor, `.reason`, `.body`, `.name`, and `instanceof` are all unchanged.
- **`forbiddenReason` is generalized into `responseReason`**, so its body-extraction rules — a plain-string body wins, else a `reason`/`message` field, never stringify an object into noisy text like `"{}"` — apply to every status rather than being duplicated. `forbiddenReason` keeps its signature and its `'Forbidden'` fallback.
- **`FetchConnection.get()` and `.post()`** return the body as the error text, falling back to the status line only when the body is empty.
- **`HttpFailure`/`HttpRetry`** gain optional `statusCode` and `body`. The body previously died at the `HttpConnection` boundary — those variants carried only `error: string`. The fields are optional so a third-party `HttpConnection` still compiles and still gets a plain `Error`.

## Fail fast on deterministic errors

`FetchConnection.post` never returned `result: "failure"` at all — every status ≥ 400 except 403 was `"retry"`, so `postWithLimitedRetry` burned 1s + 2s + 4s of backoff on a 400 that cannot possibly succeed on a second attempt.

A new `isRetryableStatus` keeps 5xx retryable, along with two 4xx: **429**, and **408** — which this connection *synthesizes* for its own timeout, so treating it as deterministic would have been a real regression on flaky networks. Everything else in the 4xx range now fails immediately. That includes 401/407/419, which already get one reauthenticate-and-retry pass inside `post`; if that pass fails, re-posting the same credentials cannot help.

## Name the missing predecessor

`authorizeFacts` named only the failed *successor* fact types. The specific missing predecessor's `type:hash` was already computed and already reached `Trace.warn` — it just never reached the thrown error. It now does:

> Cannot authorize 1 fact of type Test.ChannelOwner: predecessor Jinaga.User:AXn3…== does not exist in storage and was not included in the batch. Add it to the batch, or commit it first.

Several missing predecessors are listed one per line. When none can be identified the previous generic sentence is kept, so the failure is never *less* informative than before.

## Typed error hierarchy

Every other throw site in this package was a bare `new Error`, leaving downstream code — notably `jinaga-server`'s `toSaveAuthorizationError` — with no way to classify a failure except by regex-matching English prose, which breaks silently on any wording change here.

| File | Now throws |
|---|---|
| `src/http/messageParsers.ts`, `src/http/deserializer.ts` | `ValidationError` |
| `src/authorization/authorizationRules.ts`, `authorization-engine.ts` (quantifier) | `AuthorizationRuleError` |
| `authorization-engine.ts` (unresolved predecessors) | `PredecessorNotResolvedError`, carrying `missingPredecessors` and `unresolvedFacts` |

**All existing message text is preserved verbatim.** Current prose-matching consumers keep working and can migrate to `instanceof` at their own pace. `Forbidden` is left alone — it is already typed and exported.

`HttpError`, `ValidationError`, `AuthorizationRuleError`, and `PredecessorNotResolvedError` are exported from the package index.

## Tests

`npm test` — **580 passing** (was 560). New `test/http/httpErrorSpec.ts` follows the `global.fetch` stub pattern from `forbiddenErrorSpec.ts` and covers: body surfaced with status and raw body on GET and POST; JSON `message` field preferred; fallback to the status line on an empty body; the retryable/deterministic classification across ten statuses; `WebClient` throwing `HttpError` with the detail attached; and — the point of the retry change — a 400 throwing on the **first** attempt with no backoff, asserted by call count.

`test/authorization/authorizationEngineSpec.ts` is tightened from a bare `.rejects.toThrow()` to assert the error type, the named predecessor, and the structured references. `test/http/feedsResponseParserSpec.ts` gains a `ValidationError` case alongside its existing message-regex assertions, which still pass unchanged — as do `forbiddenErrorSpec.ts` and the rest of the suite.

## Observed, not changed

`postWithLimitedRetry` computes an escalating `timeoutSeconds` local but passes `this.config.timeoutSeconds` to `post` (`web-client.ts:158`), so the timeout escalation is dead code. Out of scope here; worth its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9fsCg9xTxpU1HeXPjKiaJ)_