### PR TITLE
Correct the stale development-mode note on isStructuralDenial

### DIFF
--- a/src/managers/distributionDiagnostic.ts
+++ b/src/managers/distributionDiagnostic.ts
@@ -97,9 +97,13 @@ export function toClearingDiagnostic(
 /**
  * The denial codes that are *structural* — a missing rule or a spec narrowed
  * past its rule. These never self-heal (unlike the subscription race), so they
- * are the only cases `query` throws for in development mode (issue #207 W8) and
- * the ones the default dev handler reports at error level (W7). A `reactive`
- * diagnostic is never structural regardless of its code.
+ * are the only cases `query` throws for (issue #207 W8) and the ones the
+ * default dev handler reports at error level (W7). A `reactive` diagnostic is
+ * never structural regardless of its code.
+ *
+ * The throw is unconditional. `developmentMode` gates only the installation of
+ * the console handler in `JinagaBrowser`, never `query`'s contract, so a
+ * structural denial fails loudly in production too.
  */
 export function isStructuralDenial(diagnostic: DistributionDiagnostic): boolean {
     return !diagnostic.reactive

--- a/src/managers/distributionDiagnostic.ts
+++ b/src/managers/distributionDiagnostic.ts
@@ -112,12 +112,16 @@ export function isStructuralDenial(diagnostic: DistributionDiagnostic): boolean 
 }
 
 /**
- * Thrown by `query` in development mode (issue #207 W8) when a feed is denied by
- * a structural cause that provably never self-heals — so a mis-authored spec
- * fails loudly at the call site instead of silently returning empty. Never
- * thrown for a `reactive` decision (that would break the subscription race) and
- * never in production, where `query` stays silent-empty. `diagnostics` carries
- * the structural diagnostics that caused the throw.
+ * Thrown by `query` (issue #207 W8) when a feed is denied by a structural cause
+ * that provably never self-heals — so a mis-authored spec fails loudly at the
+ * call site instead of silently returning empty. Never thrown for a `reactive`
+ * decision (that would break the subscription race), nor for a non-structural
+ * denial (`principal-excluded` / `not-authenticated`), which are auth states
+ * rather than authoring errors. `diagnostics` carries the structural
+ * diagnostics that caused the throw.
+ *
+ * Thrown in every environment. `developmentMode` gates only the installation of
+ * the console handler in `JinagaBrowser`, never this contract.
  */
 export class DistributionDeniedError extends Error {
     constructor(public readonly diagnostics: DistributionDiagnostic[]) {


### PR DESCRIPTION
## Summary

Two doc comments in `src/managers/distributionDiagnostic.ts` described a `developmentMode` gate on `query`'s throwing contract that does not exist.

`Jinaga.query` filters structural diagnostics and throws `DistributionDeniedError` unconditionally (`src/jinaga.ts`). `developmentMode` gates only the installation of the console handler in `JinagaBrowser`.

**`isStructuralDenial`** called structural denials "the only cases `query` throws for **in development mode**".

**`DistributionDeniedError`** was the more serious of the two, and states the opposite of the shipped contract: "Thrown by `query` **in development mode** … and **never in production, where `query` stays silent-empty**." That sits on the exported error type a developer reads when deciding whether to catch it.

The README already documents the correct behavior — its Breaking Changes section notes the flag "no longer affects this — it only installs the console diagnostic handler" — so the code, the README, and these two comments disagreed.

## Changes

Comments only, one file. No code change, no behavior change.

Both replacements drop the environment qualifier and name what `developmentMode` actually gates, so the drift is less likely to recur. The `DistributionDeniedError` comment also picks up the non-structural exclusion it omitted: `principal-excluded` and `not-authenticated` are auth states rather than authoring errors and do not throw, which matches the rationale already documented at the throw site.

I swept the rest of `src` for other environment-conditional claims about `query`'s contract. The remaining `developmentMode` references describe the console handler, which genuinely is gated.

## Verification

`npm run build` and `npm test` clean: 586 passing.

## Provenance

Found while investigating issue #232. That investigation closed without a code change (see #232 and #236), but these comments were independently wrong and worth correcting on their own.