### PR TITLE
Bound listener notification so one stuck callback cannot wedge the client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export { Network, NetworkManager, NetworkNoOp } from "./managers/NetworkManager"
 export { QueueProcessor, Saver } from './managers/QueueProcessor';
 export { MemoryStore } from './memory/memory-store';
 export { Device, User, UserName } from "./model/user";
-export { ObservableSource, ObservableSource as ObservableSourceImpl, SpecificationListener } from './observable/observable';
+export { DEFAULT_LISTENER_TIMEOUT_MS, ObservableSource, ObservableSource as ObservableSourceImpl, SpecificationListener } from './observable/observable';
 export { ObservableCollection } from './observer/observer';
 export { Subscriber } from './observer/subscriber';
 export { PurgeConditions } from './purge/purgeConditions';

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -59,22 +59,14 @@ export type JinagaBrowserConfig = {
      * settle. That is the deliberate trade: a bounded, logged delivery gap in
      * place of an unbounded wedge.
      */
-    listenerTimeoutMs?: number,
-    /**
-     * How the listeners registered for one specification are dispatched.
-     * `"parallel"` (the default) notifies them at once, so a slow callback does
-     * not delay its peers. `"serial"` restores one-at-a-time dispatch for an
-     * app that depends on ordering between listeners.
-     */
-    listenerDispatch?: "parallel" | "serial"
+    listenerTimeoutMs?: number
 }
 
 export class JinagaBrowser {
     static create(config: JinagaBrowserConfig) {
         const store = createStore(config);
         const observableSource = new ObservableSource(store, {
-            listenerTimeoutMs: config.listenerTimeoutMs,
-            listenerDispatch: config.listenerDispatch
+            listenerTimeoutMs: config.listenerTimeoutMs
         });
         const syncStatusNotifier = new SyncStatusNotifier();
         const webClient = createWebClient(config, syncStatusNotifier);

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -52,7 +52,8 @@ export type JinagaBrowserConfig = {
      * Maximum milliseconds to wait for a single watch or subscribe callback to
      * settle before continuing without it (issue #246). A callback that never
      * settles would otherwise block `fact()`, and every query behind it,
-     * forever. Set to 0 to wait indefinitely. Defaults to 30000.
+     * forever. Set to 0 to wait indefinitely. Defaults to
+     * `DEFAULT_LISTENER_TIMEOUT_MS`.
      *
      * Once a listener exceeds this bound, `fact()` may resolve before that
      * callback has run, and `processed()` on the affected observer may never

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -59,14 +59,22 @@ export type JinagaBrowserConfig = {
      * settle. That is the deliberate trade: a bounded, logged delivery gap in
      * place of an unbounded wedge.
      */
-    listenerTimeoutMs?: number
+    listenerTimeoutMs?: number,
+    /**
+     * How the listeners registered for one specification are dispatched.
+     * `"parallel"` (the default) notifies them at once, so a slow callback does
+     * not delay its peers. `"serial"` restores one-at-a-time dispatch for an
+     * app that depends on ordering between listeners.
+     */
+    listenerDispatch?: "parallel" | "serial"
 }
 
 export class JinagaBrowser {
     static create(config: JinagaBrowserConfig) {
         const store = createStore(config);
         const observableSource = new ObservableSource(store, {
-            listenerTimeoutMs: config.listenerTimeoutMs
+            listenerTimeoutMs: config.listenerTimeoutMs,
+            listenerDispatch: config.listenerDispatch
         });
         const syncStatusNotifier = new SyncStatusNotifier();
         const webClient = createWebClient(config, syncStatusNotifier);

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -47,13 +47,27 @@ export type JinagaBrowserConfig = {
      * every mode by default (issue jinaga-server#179). Development mode only
      * adds the console logging on top.
      */
-    developmentMode?: boolean
+    developmentMode?: boolean,
+    /**
+     * Maximum milliseconds to wait for a single watch or subscribe callback to
+     * settle before continuing without it (issue #246). A callback that never
+     * settles would otherwise block `fact()`, and every query behind it,
+     * forever. Set to 0 to wait indefinitely. Defaults to 30000.
+     *
+     * Once a listener exceeds this bound, `fact()` may resolve before that
+     * callback has run, and `processed()` on the affected observer may never
+     * settle. That is the deliberate trade: a bounded, logged delivery gap in
+     * place of an unbounded wedge.
+     */
+    listenerTimeoutMs?: number
 }
 
 export class JinagaBrowser {
     static create(config: JinagaBrowserConfig) {
         const store = createStore(config);
-        const observableSource = new ObservableSource(store);
+        const observableSource = new ObservableSource(store, {
+            listenerTimeoutMs: config.listenerTimeoutMs
+        });
         const syncStatusNotifier = new SyncStatusNotifier();
         const webClient = createWebClient(config, syncStatusNotifier);
         const fork = createFork(config, store, webClient);

--- a/src/jinaga-test.ts
+++ b/src/jinaga-test.ts
@@ -30,7 +30,13 @@ export type JinagaTestConfig = {
    * settle before continuing without it (issue #246). Set to 0 to wait
    * indefinitely. Defaults to `DEFAULT_LISTENER_TIMEOUT_MS`.
    */
-  listenerTimeoutMs?: number
+  listenerTimeoutMs?: number,
+  /**
+   * How the listeners registered for one specification are dispatched.
+   * `"parallel"` (the default) notifies them at once; `"serial"` restores
+   * one-at-a-time dispatch.
+   */
+  listenerDispatch?: "parallel" | "serial"
 }
 
 export class JinagaTest {
@@ -38,7 +44,8 @@ export class JinagaTest {
     const store = new MemoryStore();
     this.saveInitialState(config, store);
     const observableSource = new ObservableSource(store, {
-      listenerTimeoutMs: config.listenerTimeoutMs
+      listenerTimeoutMs: config.listenerTimeoutMs,
+      listenerDispatch: config.listenerDispatch
     });
     const syncStatusNotifier = new SyncStatusNotifier();
     const fork = new PassThroughFork(store);

--- a/src/jinaga-test.ts
+++ b/src/jinaga-test.ts
@@ -30,13 +30,7 @@ export type JinagaTestConfig = {
    * settle before continuing without it (issue #246). Set to 0 to wait
    * indefinitely. Defaults to `DEFAULT_LISTENER_TIMEOUT_MS`.
    */
-  listenerTimeoutMs?: number,
-  /**
-   * How the listeners registered for one specification are dispatched.
-   * `"parallel"` (the default) notifies them at once; `"serial"` restores
-   * one-at-a-time dispatch.
-   */
-  listenerDispatch?: "parallel" | "serial"
+  listenerTimeoutMs?: number
 }
 
 export class JinagaTest {
@@ -44,8 +38,7 @@ export class JinagaTest {
     const store = new MemoryStore();
     this.saveInitialState(config, store);
     const observableSource = new ObservableSource(store, {
-      listenerTimeoutMs: config.listenerTimeoutMs,
-      listenerDispatch: config.listenerDispatch
+      listenerTimeoutMs: config.listenerTimeoutMs
     });
     const syncStatusNotifier = new SyncStatusNotifier();
     const fork = new PassThroughFork(store);

--- a/src/jinaga-test.ts
+++ b/src/jinaga-test.ts
@@ -24,14 +24,22 @@ export type JinagaTestConfig = {
   device?: {},
   initialState?: {}[],
   purgeConditions?: (p: PurgeConditions) => PurgeConditions,
-  feedRefreshIntervalSeconds?: number
+  feedRefreshIntervalSeconds?: number,
+  /**
+   * Maximum milliseconds to wait for a single watch or subscribe callback to
+   * settle before continuing without it (issue #246). Set to 0 to wait
+   * indefinitely. Defaults to `DEFAULT_LISTENER_TIMEOUT_MS`.
+   */
+  listenerTimeoutMs?: number
 }
 
 export class JinagaTest {
   static create(config: JinagaTestConfig) {
     const store = new MemoryStore();
     this.saveInitialState(config, store);
-    const observableSource = new ObservableSource(store);
+    const observableSource = new ObservableSource(store, {
+      listenerTimeoutMs: config.listenerTimeoutMs
+    });
     const syncStatusNotifier = new SyncStatusNotifier();
     const fork = new PassThroughFork(store);
     const authentication = this.createAuthentication(config, store);

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -175,6 +175,13 @@ class LoadBatch {
     private readonly factReferences: FactReference[] = [];
     private started = false;
     public readonly completed: Promise<void>;
+    /**
+     * True once the graph is saved and this batch is awaiting the notification
+     * fan-out. A feed parked on `completed` at this point cannot make progress
+     * until every listener returns, which is what lets `fetch` recognize a
+     * re-entrant join it must not wait on (issue #246).
+     */
+    public notifying = false;
     private resolve: (() => void) | undefined;
     private reject: ((reason: any) => void) | undefined;
     private timeout: NodeJS.Timeout;
@@ -224,7 +231,15 @@ class LoadBatch {
         const factsAdded = await this.store.save(graph);
         if (factsAdded.length > 0) {
             Trace.counter("facts_saved", factsAdded.length);
-            await this.notifyFactsAdded(factsAdded);
+            // The graph is durable in the store before this point, so a reader
+            // that declines to wait for the notification still sees these facts.
+            this.notifying = true;
+            try {
+                await this.notifyFactsAdded(factsAdded);
+            }
+            finally {
+                this.notifying = false;
+            }
         }
     }
 }
@@ -259,6 +274,12 @@ export class NetworkManager {
     private readonly activeFeeds = new Map<string, Promise<void>>();
     private fetchCount = 0;
     private currentBatch: LoadBatch | null = null;
+    /**
+     * The batch each in-flight feed is currently parked on, if any. Together
+     * with `LoadBatch.notifying` this identifies a feed whose progress depends
+     * on a notification completing (issue #246).
+     */
+    private readonly feedsAwaitingBatch = new Map<string, LoadBatch>();
     private subscribers: Map<string, Subscriber> = new Map();
     private readonly feedRefreshIntervalSeconds: number;
     // Per-feed "began delivering data" signal (issue #207 W9). `feedsDelivered`
@@ -272,7 +293,12 @@ export class NetworkManager {
         private readonly network: Network,
         private readonly store: Storage,
         private readonly notifyFactsAdded: (factsAdded: FactEnvelope[]) => Promise<void>,
-        feedRefreshIntervalSeconds?: number
+        feedRefreshIntervalSeconds?: number,
+        /**
+         * Reports whether a notification is currently in flight. Optional so
+         * that callers without an observable source keep the old behavior.
+         */
+        private readonly isNotifying?: () => boolean
     ) {
         this.feedRefreshIntervalSeconds = feedRefreshIntervalSeconds || 90; // Default to 90 seconds
     }
@@ -333,6 +359,17 @@ export class NetworkManager {
         // Fork to fetch from each feed.
         const promises = feeds.map(feed => {
             if (this.activeFeeds.has(feed)) {
+                if (this.blockedOnOurOwnNotification(feed)) {
+                    // That feed's processFeed is parked awaiting a batch that is
+                    // itself awaiting the notification we are running inside.
+                    // Waiting on it would deadlock: it cannot finish until this
+                    // call returns (issue #246). Its facts are already saved, so
+                    // read them and move on. Only later pages of the same feed
+                    // are forgone, which this caller would not have had yet.
+                    Trace.counter("network_feed_join_skipped_reentrant", 1);
+                    Trace.warn(`[NetworkManager] Skipping join of in-flight feed ${feed}: its load is awaiting the notification this call is running inside. Continuing with the facts already saved.`);
+                    return Promise.resolve();
+                }
                 return this.activeFeeds.get(feed);
             }
             else {
@@ -473,7 +510,13 @@ export class NetworkManager {
                             // This is the last fetch, so trigger the batch.
                             batch.trigger();
                         }
-                        await batch.completed;
+                        this.feedsAwaitingBatch.set(feed, batch);
+                        try {
+                            await batch.completed;
+                        }
+                        finally {
+                            this.feedsAwaitingBatch.delete(feed);
+                        }
                     }
 
                     bookmark = nextBookmark;
@@ -491,8 +534,20 @@ export class NetworkManager {
             }
         }
         finally {
+            this.feedsAwaitingBatch.delete(feed);
             this.activeFeeds.delete(feed);
         }
+    }
+
+    /**
+     * True when `feed` is parked on a batch that is awaiting notification and
+     * we are ourselves inside a notification turn. That is the exact shape of
+     * the re-entrant cycle: a listener callback queried for a feed whose loader
+     * is waiting on that very callback.
+     */
+    private blockedOnOurOwnNotification(feed: string): boolean {
+        return this.isNotifying?.() === true
+            && this.feedsAwaitingBatch.get(feed)?.notifying === true;
     }
 }
 

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -295,10 +295,10 @@ export class NetworkManager {
         private readonly notifyFactsAdded: (factsAdded: FactEnvelope[]) => Promise<void>,
         feedRefreshIntervalSeconds?: number,
         /**
-         * Reports whether a notification is currently in flight. Optional so
-         * that callers without an observable source keep the old behavior.
+         * Reports whether a listener callback is currently executing. Optional
+         * so that callers without an observable source keep the old behavior.
          */
-        private readonly isNotifying?: () => boolean
+        private readonly isDispatchingListener?: () => boolean
     ) {
         this.feedRefreshIntervalSeconds = feedRefreshIntervalSeconds || 90; // Default to 90 seconds
     }
@@ -359,15 +359,14 @@ export class NetworkManager {
         // Fork to fetch from each feed.
         const promises = feeds.map(feed => {
             if (this.activeFeeds.has(feed)) {
-                if (this.blockedOnOurOwnNotification(feed)) {
+                if (this.joinWouldAwaitARunningListener(feed)) {
                     // That feed's processFeed is parked awaiting a batch that is
-                    // itself awaiting the notification we are running inside.
-                    // Waiting on it would deadlock: it cannot finish until this
-                    // call returns (issue #246). Its facts are already saved, so
-                    // read them and move on. Only later pages of the same feed
-                    // are forgone, which this caller would not have had yet.
+                    // itself awaiting a listener callback — quite possibly this
+                    // caller. Waiting on it would then deadlock, since it cannot
+                    // finish until this call returns (issue #246). Its facts are
+                    // already saved, so read them and move on.
                     Trace.counter("network_feed_join_skipped_reentrant", 1);
-                    Trace.warn(`[NetworkManager] Skipping join of in-flight feed ${feed}: its load is awaiting the notification this call is running inside. Continuing with the facts already saved.`);
+                    Trace.warn(`[NetworkManager] Skipping join of in-flight feed ${feed}: its load is awaiting a listener callback that may be this caller. Continuing with the facts already saved.`);
                     return Promise.resolve();
                 }
                 return this.activeFeeds.get(feed);
@@ -540,13 +539,22 @@ export class NetworkManager {
     }
 
     /**
-     * True when `feed` is parked on a batch that is awaiting notification and
-     * we are ourselves inside a notification turn. That is the exact shape of
-     * the re-entrant cycle: a listener callback queried for a feed whose loader
-     * is waiting on that very callback.
+     * True when `feed` is parked on a batch that is awaiting notification while
+     * some listener callback is executing. That is the shape of the re-entrant
+     * cycle: a listener queried for a feed whose loader is waiting on that very
+     * callback.
+     *
+     * It is not caller-scoped, and cannot be without async context propagation
+     * that the browser target rules out, so an unrelated `fetch` issued while
+     * some other listener runs can also match. What that costs is bounded: the
+     * condition requires this same feed to be mid-notification, so its batch's
+     * facts are already durable in the store and the caller still reads them.
+     * Only pages the feed has not fetched yet are forgone, and the feed goes on
+     * loading them for the next reader. Waiting instead risks a permanent hang,
+     * which is the failure this exists to prevent.
      */
-    private blockedOnOurOwnNotification(feed: string): boolean {
-        return this.isNotifying?.() === true
+    private joinWouldAwaitARunningListener(feed: string): boolean {
+        return this.isDispatchingListener?.() === true
             && this.feedsAwaitingBatch.get(feed)?.notifying === true;
     }
 }

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -29,7 +29,7 @@ export class FactManager {
     ) {
         this.networkManager = new NetworkManager(network, store,
             factsAdded => this.factsAdded(factsAdded), feedRefreshIntervalSeconds,
-            () => this.observableSource.isNotifying());
+            () => this.observableSource.isDispatchingListener());
 
         this.purgeManager = new PurgeManager(store, purgeConditions);
     }

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -28,7 +28,8 @@ export class FactManager {
         feedRefreshIntervalSeconds?: number
     ) {
         this.networkManager = new NetworkManager(network, store,
-            factsAdded => this.factsAdded(factsAdded), feedRefreshIntervalSeconds);
+            factsAdded => this.factsAdded(factsAdded), feedRefreshIntervalSeconds,
+            () => this.observableSource.isNotifying());
 
         this.purgeManager = new PurgeManager(store, purgeConditions);
     }

--- a/src/observable/observable.ts
+++ b/src/observable/observable.ts
@@ -25,13 +25,6 @@ export interface ObservableSourceOptions {
      * `DEFAULT_LISTENER_TIMEOUT_MS`.
      */
     listenerTimeoutMs?: number;
-    /**
-     * `"parallel"` (the default) dispatches every listener registered for a
-     * specification at once, so one slow listener does not delay its peers.
-     * `"serial"` restores one-at-a-time dispatch for a consumer that depends
-     * on ordering between listeners.
-     */
-    listenerDispatch?: "parallel" | "serial";
 }
 
 export class ObservableSource {
@@ -40,13 +33,11 @@ export class ObservableSource {
         listeners: SpecificationListener[]
     }>> = new Map();
     private readonly listenerTimeoutMs: number;
-    private readonly listenerDispatch: "parallel" | "serial";
     private notificationDepth = 0;
     private listenerDispatchDepth = 0;
 
     constructor(private store: Storage, options: ObservableSourceOptions = {}) {
         this.listenerTimeoutMs = options.listenerTimeoutMs ?? DEFAULT_LISTENER_TIMEOUT_MS;
-        this.listenerDispatch = options.listenerDispatch ?? "parallel";
     }
 
     async notify(saved: FactEnvelope[]): Promise<void> {
@@ -63,6 +54,16 @@ export class ObservableSource {
         }
         this.notificationDepth++;
         try {
+            // KNOWN GAP: `saved` arrives in topological order — Dehydration
+            // pushes a fact's predecessors before the fact itself, and both
+            // stores preserve input order — and this line discards it. That is
+            // the one causal edge the model states explicitly and this dispatch
+            // does not honor. `ObserverImpl.pendingAddsByKey` is the standing
+            // compensation: a child row whose parent has not been delivered
+            // buffers and replays when the parent's onAdded registers.
+            // Tracked separately; do not treat this fan-out as evidence that
+            // predecessor order is unimportant.
+            //
             // Wait for all notifications to complete before resolving
             await Promise.all(saved.map(envelope => this.notifyFactSaved(envelope.fact)));
         }
@@ -237,21 +238,28 @@ export class ObservableSource {
                     // Create a snapshot of listeners to avoid modification during iteration
                     const listenerSnapshot = [...listeners.listeners];
 
-                    // notifyListener never rejects, so no dispatch strategy can
-                    // leave a sibling rejection unhandled or short-circuit the
-                    // listeners behind it.
-                    if (this.listenerDispatch === "parallel") {
-                        const outcomes = await Promise.all(listenerSnapshot.map((specificationListener, i) =>
-                            this.notifyListener(specificationListener, results, i, listenerSnapshot.length, specificationKey, fact.type, hasNestedSpecs)));
-                        totalNotifications += outcomes.filter(completed => completed).length;
-                    }
-                    else {
-                        for (let i = 0; i < listenerSnapshot.length; i++) {
-                            if (await this.notifyListener(listenerSnapshot[i], results, i, listenerSnapshot.length, specificationKey, fact.type, hasNestedSpecs)) {
-                                totalNotifications++;
-                            }
-                        }
-                    }
+                    // Concurrent by derivation, not by preference. The model
+                    // records causality explicitly — a fact names its
+                    // predecessors — and it delivers specification results as
+                    // SETS precisely to say that no such relation holds among
+                    // them. The listeners in this group are independent
+                    // subscriptions to one specification, so the model records
+                    // no edge between them and dispatch order is not ours to
+                    // define. Do not reintroduce a mode toggle here: offering
+                    // "serial" would promise an ordering the model refuses to
+                    // make, and a consumer that came to depend on it would be
+                    // depending on an accident.
+                    //
+                    // Sequencing belongs only where an edge exists: predecessor
+                    // before successor, and a parent row before its child rows
+                    // (see the await in ObserverImpl.notifyAddedRow).
+                    //
+                    // notifyListener never rejects, so one listener can neither
+                    // leave a sibling rejection unhandled nor short-circuit the
+                    // others.
+                    const outcomes = await Promise.all(listenerSnapshot.map((specificationListener, i) =>
+                        this.notifyListener(specificationListener, results, i, listenerSnapshot.length, specificationKey, fact.type, hasNestedSpecs)));
+                    totalNotifications += outcomes.filter(completed => completed).length;
                 } else {
                     Trace.info(`[ObservableSource] Skipping spec ${specCount}/${listenersBySpecification.size} - No listeners or null group`);
                 }

--- a/src/observable/observable.ts
+++ b/src/observable/observable.ts
@@ -42,6 +42,7 @@ export class ObservableSource {
     private readonly listenerTimeoutMs: number;
     private readonly listenerDispatch: "parallel" | "serial";
     private notificationDepth = 0;
+    private listenerDispatchDepth = 0;
 
     constructor(private store: Storage, options: ObservableSourceOptions = {}) {
         this.listenerTimeoutMs = options.listenerTimeoutMs ?? DEFAULT_LISTENER_TIMEOUT_MS;
@@ -71,13 +72,21 @@ export class ObservableSource {
     }
 
     /**
-     * True while at least one `notify` is in flight. Lets the network layer
-     * recognize a feed whose load is parked in notification, so it does not
-     * wait on a promise that cannot make progress until the notification
-     * returns (issue #246).
+     * True while at least one listener callback is executing. Lets the network
+     * layer recognize a feed whose load is parked behind a listener that may be
+     * this very caller, so it does not wait on a promise that cannot make
+     * progress until the callback returns (issue #246).
+     *
+     * This is narrower than "a notify turn is open" — it excludes the store
+     * reads `notifyFactSaved` performs between spec groups — but it is still
+     * not caller-scoped: it cannot distinguish "this call came from inside a
+     * listener" from "some unrelated listener happens to be running". Precise
+     * attribution needs async context propagation, which the browser target
+     * rules out. See `NetworkManager.joinWouldAwaitARunningListener` for what
+     * the remaining imprecision costs.
      */
-    public isNotifying(): boolean {
-        return this.notificationDepth > 0;
+    public isDispatchingListener(): boolean {
+        return this.listenerDispatchDepth > 0;
     }
 
     public addSpecificationListener(specification: Specification, onResult: (results: ProjectedResult[]) => Promise<void>): SpecificationListener {
@@ -274,13 +283,14 @@ export class ObservableSource {
         const notifyStart = Date.now();
         Trace.info(`[ObservableSource] Calling listener ${label} - Nested: ${hasNestedSpecs}`);
         Trace.counter("observable_listener_started", 1);
+        this.listenerDispatchDepth++;
         try {
             const outcome = await withTimeout(
                 specificationListener.onResult(results),
                 this.listenerTimeoutMs,
                 late => {
                     Trace.counter("observable_listener_late_settled", 1);
-                    if (late.error !== undefined) {
+                    if ("error" in late) {
                         Trace.error(`[ObservableSource] Abandoned listener ${label} rejected after ${late.elapsedMs}ms - Spec: ${specificationKey.substring(0, 8)}..., Type: ${givenType}, Error: ${late.error}`);
                     } else {
                         Trace.warn(`[ObservableSource] Abandoned listener ${label} finally completed after ${late.elapsedMs}ms - Spec: ${specificationKey.substring(0, 8)}..., Type: ${givenType}`);
@@ -311,6 +321,9 @@ export class ObservableSource {
             Trace.counter("observable_listener_failed", 1);
             Trace.error(`[ObservableSource] ERROR in listener notification - Listener ${label}, Nested: ${hasNestedSpecs}, Error: ${error}`);
             return false;
+        }
+        finally {
+            this.listenerDispatchDepth--;
         }
     }
 }

--- a/src/observable/observable.ts
+++ b/src/observable/observable.ts
@@ -2,10 +2,36 @@ import { describeSpecification } from '../specification/description';
 import { Specification } from "../specification/specification";
 import { FactEnvelope, FactRecord, ProjectedResult, Storage } from '../storage';
 import { computeStringHash } from '../util/encoding';
+import { TIMED_OUT, withTimeout } from '../util/promise';
 import { Trace } from '../util/trace';
 
 export interface SpecificationListener {
     onResult(results: ProjectedResult[]): Promise<void>;
+}
+
+/**
+ * Ceiling on a single listener's `onResult`, in milliseconds. Deliberately
+ * generous: it must never fire for a healthy handler, only for a wedged one.
+ */
+export const DEFAULT_LISTENER_TIMEOUT_MS = 30000;
+
+export interface ObservableSourceOptions {
+    /**
+     * Maximum time to wait for one listener's `onResult` to settle before
+     * abandoning the wait and continuing without it. A callback that never
+     * settles would otherwise block the save that triggered the notification,
+     * and every query behind it, forever (issue #246). Set to 0 to wait
+     * indefinitely, which is the behavior prior to that fix. Defaults to
+     * `DEFAULT_LISTENER_TIMEOUT_MS`.
+     */
+    listenerTimeoutMs?: number;
+    /**
+     * `"parallel"` (the default) dispatches every listener registered for a
+     * specification at once, so one slow listener does not delay its peers.
+     * `"serial"` restores one-at-a-time dispatch for a consumer that depends
+     * on ordering between listeners.
+     */
+    listenerDispatch?: "parallel" | "serial";
 }
 
 export class ObservableSource {
@@ -13,21 +39,45 @@ export class ObservableSource {
         specification: Specification,
         listeners: SpecificationListener[]
     }>> = new Map();
+    private readonly listenerTimeoutMs: number;
+    private readonly listenerDispatch: "parallel" | "serial";
+    private notificationDepth = 0;
 
-    constructor(private store: Storage) {
+    constructor(private store: Storage, options: ObservableSourceOptions = {}) {
+        this.listenerTimeoutMs = options.listenerTimeoutMs ?? DEFAULT_LISTENER_TIMEOUT_MS;
+        this.listenerDispatch = options.listenerDispatch ?? "parallel";
     }
 
     async notify(saved: FactEnvelope[]): Promise<void> {
-        // Collect all notification promises to ensure all callbacks complete
-        const notificationPromises: Promise<void>[] = [];
-        
-        for (let index = 0; index < saved.length; index++) {
-            const envelope = saved[index];
-            notificationPromises.push(this.notifyFactSaved(envelope.fact));
+        if (this.notificationDepth > 0) {
+            // A notification began while another is still in flight. Usually
+            // this is benign concurrency, such as two feeds delivering at once.
+            // It is also the signature of re-entrancy: a listener that saved or
+            // queried facts and came back through this path from inside its own
+            // notification. The two are indistinguishable here without async
+            // context propagation, which the browser target rules out, so warn
+            // and continue rather than throwing on a pattern that works today.
+            Trace.counter("observable_notify_overlapped", 1);
+            Trace.warn(`[ObservableSource] OVERLAPPING NOTIFY - Depth on entry: ${this.notificationDepth}, Envelopes: ${saved.length}. If a listener callback writes or queries facts, this notification is re-entrant and may block against an in-flight feed; the listener timeout (${this.listenerTimeoutMs}ms) bounds the stall.`);
         }
-        
-        // Wait for all notifications to complete before resolving
-        await Promise.all(notificationPromises);
+        this.notificationDepth++;
+        try {
+            // Wait for all notifications to complete before resolving
+            await Promise.all(saved.map(envelope => this.notifyFactSaved(envelope.fact)));
+        }
+        finally {
+            this.notificationDepth--;
+        }
+    }
+
+    /**
+     * True while at least one `notify` is in flight. Lets the network layer
+     * recognize a feed whose load is parked in notification, so it does not
+     * wait on a promise that cannot make progress until the notification
+     * returns (issue #246).
+     */
+    public isNotifying(): boolean {
+        return this.notificationDepth > 0;
     }
 
     public addSpecificationListener(specification: Specification, onResult: (results: ProjectedResult[]) => Promise<void>): SpecificationListener {
@@ -177,30 +227,20 @@ export class ObservableSource {
                     
                     // Create a snapshot of listeners to avoid modification during iteration
                     const listenerSnapshot = [...listeners.listeners];
-                    if (listenerSnapshot.length !== listeners.listeners.length) {
-                        Trace.warn(`[ObservableSource] RACE CONDITION DETECTED - Listener count changed during snapshot: ${listenerSnapshot.length} vs ${listeners.listeners.length}`);
+
+                    // notifyListener never rejects, so no dispatch strategy can
+                    // leave a sibling rejection unhandled or short-circuit the
+                    // listeners behind it.
+                    if (this.listenerDispatch === "parallel") {
+                        const outcomes = await Promise.all(listenerSnapshot.map((specificationListener, i) =>
+                            this.notifyListener(specificationListener, results, i, listenerSnapshot.length, specificationKey, fact.type, hasNestedSpecs)));
+                        totalNotifications += outcomes.filter(completed => completed).length;
                     }
-                    
-                    for (let i = 0; i < listenerSnapshot.length; i++) {
-                        const specificationListener = listenerSnapshot[i];
-                        if (specificationListener) {
-                            try {
-                                const notifyStart = Date.now();
-                                Trace.info(`[ObservableSource] Calling listener ${i+1}/${listenerSnapshot.length} - Nested: ${hasNestedSpecs}`);
-                                await specificationListener.onResult(results);
-                                const notifyDuration = Date.now() - notifyStart;
+                    else {
+                        for (let i = 0; i < listenerSnapshot.length; i++) {
+                            if (await this.notifyListener(listenerSnapshot[i], results, i, listenerSnapshot.length, specificationKey, fact.type, hasNestedSpecs)) {
                                 totalNotifications++;
-                                
-                                if (notifyDuration > 100) {
-                                    Trace.warn(`[ObservableSource] SLOW notification - Listener ${i+1}/${listenerSnapshot.length}, Duration: ${notifyDuration}ms, Nested: ${hasNestedSpecs}`);
-                                } else {
-                                    Trace.info(`[ObservableSource] Listener completed - ${i+1}/${listenerSnapshot.length}, Duration: ${notifyDuration}ms`);
-                                }
-                            } catch (error) {
-                                Trace.error(`[ObservableSource] ERROR in listener notification - Listener ${i+1}/${listenerSnapshot.length}, Nested: ${hasNestedSpecs}, Error: ${error}`);
                             }
-                        } else {
-                            Trace.warn(`[ObservableSource] NULL listener encountered at index ${i}`);
                         }
                     }
                 } else {
@@ -212,6 +252,65 @@ export class ObservableSource {
             Trace.info(`[ObservableSource] NOTIFY COMPLETE - Fact: ${fact.hash.substring(0, 8)}..., Type: ${fact.type}, Specs processed: ${specCount} (${nestedSpecCount} nested), Total notifications: ${totalNotifications}, Duration: ${totalDuration}ms`);
         } else {
             Trace.info(`[ObservableSource] No listeners for fact type: ${fact.type} - Available types: [${Array.from(this.listenersByTypeAndSpecification.keys()).join(', ')}]`);
+        }
+    }
+
+    /**
+     * Dispatch one listener, bounding how long we wait for it. Never rejects:
+     * a listener that throws, or one that never settles, is reported and
+     * stepped over so it cannot hold the save that triggered this notification
+     * (issue #246). Returns whether the listener actually completed.
+     */
+    private async notifyListener(
+        specificationListener: SpecificationListener,
+        results: ProjectedResult[],
+        index: number,
+        count: number,
+        specificationKey: string,
+        givenType: string,
+        hasNestedSpecs: boolean
+    ): Promise<boolean> {
+        const label = `${index + 1}/${count}`;
+        const notifyStart = Date.now();
+        Trace.info(`[ObservableSource] Calling listener ${label} - Nested: ${hasNestedSpecs}`);
+        Trace.counter("observable_listener_started", 1);
+        try {
+            const outcome = await withTimeout(
+                specificationListener.onResult(results),
+                this.listenerTimeoutMs,
+                late => {
+                    Trace.counter("observable_listener_late_settled", 1);
+                    if (late.error !== undefined) {
+                        Trace.error(`[ObservableSource] Abandoned listener ${label} rejected after ${late.elapsedMs}ms - Spec: ${specificationKey.substring(0, 8)}..., Type: ${givenType}, Error: ${late.error}`);
+                    } else {
+                        Trace.warn(`[ObservableSource] Abandoned listener ${label} finally completed after ${late.elapsedMs}ms - Spec: ${specificationKey.substring(0, 8)}..., Type: ${givenType}`);
+                    }
+                });
+            const notifyDuration = Date.now() - notifyStart;
+
+            if (outcome === TIMED_OUT) {
+                Trace.counter("observable_listener_timed_out", 1);
+                Trace.warn(`[ObservableSource] LISTENER TIMEOUT - Listener ${label} did not settle within ${this.listenerTimeoutMs}ms; abandoning the wait so the save can complete. Spec: ${specificationKey.substring(0, 8)}..., Type: ${givenType}, Nested: ${hasNestedSpecs}`);
+                Trace.metric("observable_listener_timeout", {
+                    durationMs: notifyDuration,
+                    listenerIndex: index,
+                    listenerCount: count
+                });
+                return false;
+            }
+
+            Trace.counter("observable_listener_completed", 1);
+            if (notifyDuration > 100) {
+                Trace.warn(`[ObservableSource] SLOW notification - Listener ${label}, Duration: ${notifyDuration}ms, Nested: ${hasNestedSpecs}`);
+            } else {
+                Trace.info(`[ObservableSource] Listener completed - ${label}, Duration: ${notifyDuration}ms`);
+            }
+            return true;
+        }
+        catch (error) {
+            Trace.counter("observable_listener_failed", 1);
+            Trace.error(`[ObservableSource] ERROR in listener notification - Listener ${label}, Nested: ${hasNestedSpecs}, Error: ${error}`);
+            return false;
         }
     }
 }

--- a/src/observable/observable.ts
+++ b/src/observable/observable.ts
@@ -64,7 +64,12 @@ export class ObservableSource {
             // Tracked separately; do not treat this fan-out as evidence that
             // predecessor order is unimportant.
             //
-            // Wait for all notifications to complete before resolving
+            // Every fact's notification is awaited to a conclusion, but a
+            // conclusion is not the same as completion: a listener either
+            // finishes, fails, or is abandoned once it exceeds
+            // `listenerTimeoutMs`. So `notify()` resolving does NOT imply that
+            // every listener ran to completion, and neither does the `save()`
+            // above it. Bounding that wait is the point of issue #246.
             await Promise.all(saved.map(envelope => this.notifyFactSaved(envelope.fact)));
         }
         finally {

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -713,6 +713,12 @@ export class ObserverImpl<T> implements Observer<T> {
                 return;
             }
             Trace.info(`[Observer] CALLING HANDLER - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}...`);
+            // Awaiting this handler before the recursion below is a causal
+            // requirement, not a convenience. `injectObservers` captured THIS
+            // row's tupleHash in the onAdded closure it put on `result`, so a
+            // child handler enters `addedHandlers` only when this callback
+            // reaches into `result.<component>.onAdded`. Descending before that
+            // returns finds no handler and buffers instead of delivering.
             const promiseMaybe = resultAdded(result);
             if (promiseMaybe instanceof Promise) {
                 // Mark this row as having a genuine in-flight async add so
@@ -759,7 +765,13 @@ export class ObserverImpl<T> implements Observer<T> {
             Trace.info(`[Observer] Skipping already notified row - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}...`);
         }
 
-        // Recursively notify added for specification results.
+        // Recursively notify added for specification results. Parent before
+        // child is the model's causal edge here — the closure capture in
+        // injectObservers is what records it — so this must stay downstream of
+        // the awaited handler above and must not become a Promise.all with it.
+        // Sibling ROWS carry no such edge (results are a set), which is why
+        // notifyAdded's loop is merely conservative rather than required; see
+        // ObservableSource's listener fan-out for the same rule stated there.
         if (projection.type === "composite") {
             for (const component of projection.components) {
                 if (component.type === "specification") {

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -3,3 +3,60 @@ export function delay(ms: number) {
     setTimeout(() => resolve(), ms);
   });
 }
+
+/** Resolved value of `withTimeout` when the deadline passes before the promise settles. */
+export const TIMED_OUT: unique symbol = Symbol("jinaga.timed-out");
+
+export interface LateSettle {
+  /** Present when the abandoned promise eventually rejected. */
+  error?: unknown;
+  /** Milliseconds from the call to the late settle. */
+  elapsedMs: number;
+}
+
+/**
+ * Await `promise` for at most `timeoutMs`. Resolves with the promise's value,
+ * or with `TIMED_OUT` when the deadline passes first. A rejection that arrives
+ * before the deadline propagates normally, so a caller's existing error
+ * handling is unchanged.
+ *
+ * `timeoutMs <= 0` (or a non-finite value) disables the bound: the original
+ * promise is returned unchanged and no timer is created.
+ *
+ * The timer is always cleared, so a fast promise never leaves a pending
+ * `setTimeout` handle holding the event loop open. `Promise.race` attaches a
+ * rejection handler to `promise`, so a rejection arriving after the race is
+ * decided cannot escape as an unhandled rejection; `onLateSettle` additionally
+ * reports it.
+ *
+ * Note that abandoning the wait does not cancel the work. A promise that never
+ * settles is retained by these handlers for the lifetime of the process. That
+ * is inherent to continuing without it, and is bounded by the number of
+ * timed-out waits.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onLateSettle?: (late: LateSettle) => void
+): Promise<T | typeof TIMED_OUT> {
+  if (!(timeoutMs > 0) || !isFinite(timeoutMs)) {
+    return promise;
+  }
+  const start = Date.now();
+  let timer: ReturnType<typeof setTimeout>;
+  let timedOut = false;
+  const expiry = new Promise<typeof TIMED_OUT>(resolve => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      resolve(TIMED_OUT);
+    }, timeoutMs);
+  });
+  if (onLateSettle) {
+    promise.then(
+      () => { if (timedOut) onLateSettle({ elapsedMs: Date.now() - start }); },
+      error => { if (timedOut) onLateSettle({ error, elapsedMs: Date.now() - start }); }
+    );
+  }
+  return Promise.race([promise, expiry])
+    .finally(() => clearTimeout(timer));
+}

--- a/test/managers/NetworkManagerSpec.ts
+++ b/test/managers/NetworkManagerSpec.ts
@@ -127,4 +127,73 @@ describe("NetworkManager", () => {
             await expect(manager.fetch([], spec)).resolves.toEqual([]);
         });
     });
+
+    describe("in-flight feed joining (issue #246)", () => {
+        // A network whose fetchFeed is held open until the test releases it,
+        // so a second fetch is guaranteed to arrive while the first is active.
+        class GatedNetwork implements Network {
+            public fetchFeedCalls = 0;
+            private release: (() => void) | undefined;
+            public readonly gate: Promise<void>;
+
+            constructor() {
+                this.gate = new Promise<void>(resolve => { this.release = resolve; });
+            }
+
+            open() {
+                this.release?.();
+            }
+
+            feeds(): Promise<FeedsResponse> {
+                return Promise.resolve({ feeds: ["feed1"] });
+            }
+
+            async fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
+                this.fetchFeedCalls++;
+                await this.gate;
+                return { references: [], bookmark };
+            }
+
+            streamFeed(): () => void {
+                return () => { };
+            }
+
+            load(): Promise<FactEnvelope[]> {
+                return Promise.resolve([]);
+            }
+
+            intersectForSubscribe(start: FactReference[], specification: Specification) {
+                return Promise.resolve([{ start, specification }]);
+            }
+        }
+
+        it("still joins an in-flight feed when no notification is in progress", async () => {
+            const gated = new GatedNetwork();
+            // isNotifying reports false, so the re-entrancy escape hatch never
+            // applies and the second call must share the first call's work.
+            const gatedManager = new NetworkManager(gated, new MemoryStore(), async () => { }, undefined, () => false);
+
+            const first = gatedManager.fetch([], spec);
+            const second = gatedManager.fetch([], spec);
+            gated.open();
+            await Promise.all([first, second]);
+
+            expect(gated.fetchFeedCalls).toBe(1);
+        });
+
+        it("still joins an in-flight feed while notifying, unless that feed is awaiting the notification", async () => {
+            const gated = new GatedNetwork();
+            // A notification is in flight, but this feed is parked on the
+            // network rather than on a notification, so joining it makes
+            // progress and must not be skipped.
+            const gatedManager = new NetworkManager(gated, new MemoryStore(), async () => { }, undefined, () => true);
+
+            const first = gatedManager.fetch([], spec);
+            const second = gatedManager.fetch([], spec);
+            gated.open();
+            await Promise.all([first, second]);
+
+            expect(gated.fetchFeedCalls).toBe(1);
+        });
+    });
 });

--- a/test/observable/listenerTimeoutSpec.ts
+++ b/test/observable/listenerTimeoutSpec.ts
@@ -8,8 +8,12 @@ import { waitForCondition } from "../utils/async-test-utils";
  */
 class CountingTracer extends NoOpTracer implements Tracer {
     public readonly counters: { [name: string]: number } = {};
+    public readonly errors: string[] = [];
     counter(name: string, value: number): void {
         this.counters[name] = (this.counters[name] ?? 0) + value;
+    }
+    error(error: any): void {
+        this.errors.push(String(error));
     }
 }
 
@@ -22,11 +26,12 @@ const managersInOffice = model.given(Office).match((office, facts) =>
         .join(manager => manager.office, office)
 );
 
-function createClient(listenerTimeoutMs: number): Jinaga {
+function createClient(listenerTimeoutMs: number, listenerDispatch?: "parallel" | "serial"): Jinaga {
     return JinagaTest.create({
         model,
         initialState: [creator, company, office],
-        listenerTimeoutMs
+        listenerTimeoutMs,
+        listenerDispatch
     });
 }
 
@@ -166,6 +171,32 @@ describe("a listener that never settles (issue #246)", () => {
         finally {
             process.off("unhandledRejection", onUnhandled);
         }
+    }, 15000);
+
+    it("serializes dispatch when the caller opts out of parallel", async () => {
+        // The serial opt-out is reachable from the public harness, and restores
+        // the behavior where a wedged listener holds up its peers until it
+        // times out.
+        const j = createClient(300, "serial");
+
+        const wedged = j.watch(managersInOffice, office, () => new Promise<void>(() => { }));
+        const received: number[] = [];
+        const healthy = j.watch(managersInOffice, office, manager => {
+            received.push(manager.employeeNumber);
+        });
+        await wedged.loaded();
+        await healthy.loaded();
+
+        const start = Date.now();
+        await j.fact(new Manager(office, 8));
+        const elapsed = Date.now() - start;
+
+        expect(received).toEqual([8]);
+        // The healthy listener ran only after the wedged one timed out.
+        expect(elapsed).toBeGreaterThanOrEqual(250);
+
+        wedged.stop();
+        healthy.stop();
     }, 15000);
 
     it("waits indefinitely when the timeout is disabled", async () => {

--- a/test/observable/listenerTimeoutSpec.ts
+++ b/test/observable/listenerTimeoutSpec.ts
@@ -26,12 +26,11 @@ const managersInOffice = model.given(Office).match((office, facts) =>
         .join(manager => manager.office, office)
 );
 
-function createClient(listenerTimeoutMs: number, listenerDispatch?: "parallel" | "serial"): Jinaga {
+function createClient(listenerTimeoutMs: number): Jinaga {
     return JinagaTest.create({
         model,
         initialState: [creator, company, office],
-        listenerTimeoutMs,
-        listenerDispatch
+        listenerTimeoutMs
     });
 }
 
@@ -171,32 +170,6 @@ describe("a listener that never settles (issue #246)", () => {
         finally {
             process.off("unhandledRejection", onUnhandled);
         }
-    }, 15000);
-
-    it("serializes dispatch when the caller opts out of parallel", async () => {
-        // The serial opt-out is reachable from the public harness, and restores
-        // the behavior where a wedged listener holds up its peers until it
-        // times out.
-        const j = createClient(300, "serial");
-
-        const wedged = j.watch(managersInOffice, office, () => new Promise<void>(() => { }));
-        const received: number[] = [];
-        const healthy = j.watch(managersInOffice, office, manager => {
-            received.push(manager.employeeNumber);
-        });
-        await wedged.loaded();
-        await healthy.loaded();
-
-        const start = Date.now();
-        await j.fact(new Manager(office, 8));
-        const elapsed = Date.now() - start;
-
-        expect(received).toEqual([8]);
-        // The healthy listener ran only after the wedged one timed out.
-        expect(elapsed).toBeGreaterThanOrEqual(250);
-
-        wedged.stop();
-        healthy.stop();
     }, 15000);
 
     it("waits indefinitely when the timeout is disabled", async () => {

--- a/test/observable/listenerTimeoutSpec.ts
+++ b/test/observable/listenerTimeoutSpec.ts
@@ -1,0 +1,182 @@
+import { Jinaga, JinagaTest, NoOpTracer, Trace, Tracer, User } from "@src";
+import { Company, Manager, Office, model } from "../companyModel";
+import { waitForCondition } from "../utils/async-test-utils";
+
+/**
+ * Records Trace.counter names so a stall is asserted as observable, not merely
+ * as a duration (issue #246).
+ */
+class CountingTracer extends NoOpTracer implements Tracer {
+    public readonly counters: { [name: string]: number } = {};
+    counter(name: string, value: number): void {
+        this.counters[name] = (this.counters[name] ?? 0) + value;
+    }
+}
+
+const creator = new User("--- PUBLIC KEY GOES HERE ---");
+const company = new Company(creator, "TestCo");
+const office = new Office(company, "TestOffice");
+
+const managersInOffice = model.given(Office).match((office, facts) =>
+    facts.ofType(Manager)
+        .join(manager => manager.office, office)
+);
+
+function createClient(listenerTimeoutMs: number): Jinaga {
+    return JinagaTest.create({
+        model,
+        initialState: [creator, company, office],
+        listenerTimeoutMs
+    });
+}
+
+/** Race a promise against a deadline. Always clears the timer. */
+function raceDeadline<T>(promise: Promise<T>, ms: number): Promise<"settled" | "timed-out"> {
+    let timer: ReturnType<typeof setTimeout>;
+    return Promise.race([
+        promise.then(() => "settled" as const, () => "settled" as const),
+        new Promise<"timed-out">(resolve => { timer = setTimeout(() => resolve("timed-out"), ms); })
+    ]).finally(() => clearTimeout(timer!));
+}
+
+describe("a listener that never settles (issue #246)", () => {
+    let tracer: CountingTracer;
+
+    beforeEach(() => {
+        // Trace is global static state, so it must be restored in afterEach.
+        tracer = new CountingTracer();
+        Trace.configure(tracer);
+    });
+
+    afterEach(() => {
+        Trace.off();
+    });
+
+    it("does not wedge j.fact()", async () => {
+        const j = createClient(200);
+
+        let calls = 0;
+        const observer = j.watch(managersInOffice, office, () => {
+            calls++;
+            return new Promise<void>(() => { });
+        });
+        // No managers exist yet, so the handler has not run and loaded() settles.
+        await observer.loaded();
+        expect(calls).toBe(0);
+
+        const start = Date.now();
+        // Before the fix this never settles: notifyFactSaved awaits onResult
+        // with no bound, so save() and every query behind it hang forever.
+        await j.fact(new Manager(office, 1));
+        const elapsed = Date.now() - start;
+
+        expect(calls).toBe(1);
+        expect(elapsed).toBeGreaterThanOrEqual(150);
+        expect(elapsed).toBeLessThan(3000);
+        expect(tracer.counters["observable_listener_started"]).toBeGreaterThan(0);
+        expect(tracer.counters["observable_listener_timed_out"]).toBeGreaterThan(0);
+
+        // Deliberately no `await observer.processed()`: the abandoned
+        // notification stays pending by design, so processed() never settles.
+        observer.stop();
+    }, 15000);
+
+    it("does not block a query issued after the wedged save", async () => {
+        const j = createClient(200);
+
+        const observer = j.watch(managersInOffice, office, () => new Promise<void>(() => { }));
+        await observer.loaded();
+
+        await j.fact(new Manager(office, 2));
+        const managers = await j.query(managersInOffice, office);
+
+        expect(managers.map(m => m.employeeNumber)).toEqual([2]);
+        observer.stop();
+    }, 15000);
+
+    it("delivers to a healthy listener while a sibling on the same specification is wedged", async () => {
+        // Two observers on the SAME specification land in one spec group with
+        // two listeners. The healthy one must receive the row without waiting
+        // out the wedged one's timeout.
+        const j = createClient(1000);
+
+        const wedged = j.watch(managersInOffice, office, () => new Promise<void>(() => { }));
+        const received: number[] = [];
+        const healthy = j.watch(managersInOffice, office, manager => {
+            received.push(manager.employeeNumber);
+        });
+        await wedged.loaded();
+        await healthy.loaded();
+
+        const start = Date.now();
+        const saved = j.fact(new Manager(office, 3));
+        await waitForCondition(() => received.length > 0, 500);
+        const elapsed = Date.now() - start;
+
+        expect(received).toEqual([3]);
+        // Well under the 1000ms timeout the wedged sibling is burning: a
+        // serial dispatch would have made the healthy listener wait it out.
+        expect(elapsed).toBeLessThan(400);
+
+        // Let the wedged listener time out so the save settles and its timer
+        // is cleared before the test ends.
+        await saved;
+
+        wedged.stop();
+        healthy.stop();
+    }, 15000);
+
+    it("still catches a listener that throws, without rejecting the save", async () => {
+        const j = createClient(200);
+
+        const observer = j.watch(managersInOffice, office, () => {
+            throw new Error("listener blew up");
+        });
+        await observer.loaded();
+
+        await expect(j.fact(new Manager(office, 4))).resolves.toBeDefined();
+        expect(tracer.counters["observable_listener_failed"]).toBeGreaterThan(0);
+        expect(tracer.counters["observable_listener_timed_out"] ?? 0).toBe(0);
+
+        observer.stop();
+    }, 15000);
+
+    it("reports an abandoned listener that rejects later, without an unhandled rejection", async () => {
+        const j = createClient(100);
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => unhandled.push(reason);
+        process.on("unhandledRejection", onUnhandled);
+
+        try {
+            const observer = j.watch(managersInOffice, office, () =>
+                new Promise<void>((_, reject) => setTimeout(() => reject(new Error("late")), 300)));
+            await observer.loaded();
+
+            await j.fact(new Manager(office, 5));
+            expect(tracer.counters["observable_listener_timed_out"]).toBeGreaterThan(0);
+
+            // Give the abandoned promise time to reject.
+            await waitForCondition(() => (tracer.counters["observable_listener_late_settled"] ?? 0) > 0, 2000);
+            // Let any unhandled rejection surface.
+            await new Promise(resolve => setTimeout(resolve, 50));
+            expect(unhandled).toEqual([]);
+
+            observer.stop();
+        }
+        finally {
+            process.off("unhandledRejection", onUnhandled);
+        }
+    }, 15000);
+
+    it("waits indefinitely when the timeout is disabled", async () => {
+        const j = createClient(0);
+
+        const observer = j.watch(managersInOffice, office, () => new Promise<void>(() => { }));
+        await observer.loaded();
+
+        // The opt-out restores the pre-#246 behavior, so the save must not settle.
+        await expect(raceDeadline(j.fact(new Manager(office, 6)), 300)).resolves.toBe("timed-out");
+
+        observer.stop();
+    }, 15000);
+});

--- a/test/observable/reentrantNotificationSpec.ts
+++ b/test/observable/reentrantNotificationSpec.ts
@@ -1,0 +1,138 @@
+import { NoOpTracer, Trace, Tracer, User } from "@src";
+import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
+import { Dehydration } from "../../src/fact/hydrate";
+import { PassThroughFork } from "../../src/fork/pass-through-fork";
+import { FeedResponse, FeedsResponse } from "../../src/http/messages";
+import { FactManager } from "../../src/managers/factManager";
+import { Network } from "../../src/managers/NetworkManager";
+import { MemoryStore } from "../../src/memory/memory-store";
+import { ObservableSource } from "../../src/observable/observable";
+import { Specification } from "../../src/specification/specification";
+import { FactEnvelope, FactReference } from "../../src/storage";
+import { Company, Manager, Office, model } from "../companyModel";
+import { waitForCondition } from "../utils/async-test-utils";
+
+class CountingTracer extends NoOpTracer implements Tracer {
+    public readonly counters: { [name: string]: number } = {};
+    counter(name: string, value: number): void {
+        this.counters[name] = (this.counters[name] ?? 0) + value;
+    }
+}
+
+/**
+ * Maps every specification to one feed, delivers a single graph on the first
+ * fetchFeed, then reports end-of-feed. Because every query resolves to the same
+ * feed hash, a query issued from inside a notification joins the in-flight
+ * processFeed through `activeFeeds` — exactly the shape reported in issue #246.
+ */
+class OneShotFeedNetwork implements Network {
+    private delivered = false;
+
+    constructor(private readonly envelopes: FactEnvelope[]) { }
+
+    feeds(): Promise<FeedsResponse> {
+        return Promise.resolve({ feeds: ["feed-1"] });
+    }
+
+    fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
+        if (this.delivered) {
+            return Promise.resolve({ references: [], bookmark });
+        }
+        this.delivered = true;
+        return Promise.resolve({
+            references: this.envelopes.map(e => ({ type: e.fact.type, hash: e.fact.hash })),
+            bookmark: "1"
+        });
+    }
+
+    streamFeed(): () => void {
+        return () => { };
+    }
+
+    load(): Promise<FactEnvelope[]> {
+        return Promise.resolve(this.envelopes);
+    }
+
+    intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+        return Promise.resolve([{ start, specification }]);
+    }
+}
+
+/** Race a promise against a deadline. Always clears the timer. */
+function raceDeadline<T>(promise: Promise<T>, ms: number): Promise<"settled" | "timed-out"> {
+    let timer: ReturnType<typeof setTimeout>;
+    return Promise.race([
+        promise.then(() => "settled" as const, () => "settled" as const),
+        new Promise<"timed-out">(resolve => { timer = setTimeout(() => resolve("timed-out"), ms); })
+    ]).finally(() => clearTimeout(timer!));
+}
+
+const managersInOffice = model.given(Office).match((office, facts) =>
+    facts.ofType(Manager)
+        .join(manager => manager.office, office)
+).specification;
+
+describe("a listener that queries while its own feed is loading (issue #246)", () => {
+    let tracer: CountingTracer;
+
+    beforeEach(() => {
+        tracer = new CountingTracer();
+        Trace.configure(tracer);
+    });
+
+    afterEach(() => {
+        Trace.off();
+    });
+
+    it("does not deadlock against the in-flight feed", async () => {
+        const creator = new User("--- PUBLIC KEY GOES HERE ---");
+        const company = new Company(creator, "TestCo");
+        const office = new Office(company, "TestOffice");
+        const manager = new Manager(office, 42);
+
+        const dehydration = new Dehydration();
+        const officeReference = dehydration.dehydrate(office);
+        dehydration.dehydrate(manager);
+        const envelopes = dehydration.factRecords().map(fact => <FactEnvelope>{ fact, signatures: [] });
+
+        const store = new MemoryStore();
+        // A long listener timeout, so a pass here proves the deadlock was
+        // broken by the re-entrancy fix rather than merely survived by the
+        // listener timeout.
+        const observableSource = new ObservableSource(store, { listenerTimeoutMs: 30000 });
+        const network = new OneShotFeedNetwork(envelopes);
+        const factManager = new FactManager(new PassThroughFork(store), observableSource, store, network, []);
+
+        let innerSettled = false;
+        let innerError: unknown;
+        factManager.addSpecificationListener(managersInOffice, async () => {
+            // A re-entrant query from inside the notification, the shape the
+            // issue reports: subscribe, then read before writing a completion
+            // fact. It joins activeFeeds["feed-1"], whose processFeed is parked
+            // on a batch that is awaiting this very callback.
+            try {
+                await factManager.fetch([officeReference], managersInOffice);
+            }
+            catch (e) {
+                innerError = e;
+            }
+            finally {
+                innerSettled = true;
+            }
+        });
+
+        // Before the fix neither of these ever settles.
+        await expect(raceDeadline(factManager.fetch([officeReference], managersInOffice), 5000))
+            .resolves.toBe("settled");
+        await waitForCondition(() => innerSettled, 2000);
+
+        expect(innerError).toBeUndefined();
+        expect(tracer.counters["network_feed_join_skipped_reentrant"]).toBeGreaterThan(0);
+        // The cycle was broken directly, so no listener had to be abandoned.
+        expect(tracer.counters["observable_listener_timed_out"] ?? 0).toBe(0);
+
+        // The re-entrant read saw the facts the outer load had already saved.
+        const results = await factManager.read([officeReference], managersInOffice);
+        expect(results.length).toBe(1);
+    }, 15000);
+});

--- a/test/util/promiseSpec.ts
+++ b/test/util/promiseSpec.ts
@@ -1,0 +1,86 @@
+import { LateSettle, TIMED_OUT, withTimeout } from "../../src/util/promise";
+
+describe("withTimeout", () => {
+    it("resolves with the value when the promise settles first", async () => {
+        await expect(withTimeout(Promise.resolve("value"), 1000)).resolves.toBe("value");
+    });
+
+    it("propagates a rejection that arrives before the deadline", async () => {
+        await expect(withTimeout(Promise.reject(new Error("boom")), 1000)).rejects.toThrow("boom");
+    });
+
+    it("resolves with TIMED_OUT when the deadline passes first", async () => {
+        await expect(withTimeout(new Promise<void>(() => { }), 50)).resolves.toBe(TIMED_OUT);
+    });
+
+    it("returns the promise untouched when the bound is disabled", async () => {
+        const promise = Promise.resolve("value");
+        expect(withTimeout(promise, 0)).toBe(promise);
+        expect(withTimeout(promise, -1)).toBe(promise);
+        expect(withTimeout(promise, Number.POSITIVE_INFINITY)).toBe(promise);
+    });
+
+    it("reports a late completion", async () => {
+        const late: LateSettle[] = [];
+        const slow = new Promise<string>(resolve => setTimeout(() => resolve("late"), 100));
+
+        await expect(withTimeout(slow, 20, l => late.push(l))).resolves.toBe(TIMED_OUT);
+        await slow;
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(late.length).toBe(1);
+        expect("error" in late[0]).toBe(false);
+        expect(late[0].elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("reports a late rejection, including one whose reason is undefined", async () => {
+        // Classification keys on the property being present rather than on its
+        // value, so `reject(undefined)` is not mistaken for a completion.
+        const late: LateSettle[] = [];
+        const slow = new Promise<void>((_, reject) => setTimeout(() => reject(undefined), 100));
+
+        await expect(withTimeout(slow, 20, l => late.push(l))).resolves.toBe(TIMED_OUT);
+        await slow.catch(() => { });
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(late.length).toBe(1);
+        expect("error" in late[0]).toBe(true);
+        expect(late[0].error).toBeUndefined();
+    });
+
+    it("does not leave a late rejection unhandled", async () => {
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => unhandled.push(reason);
+        process.on("unhandledRejection", onUnhandled);
+
+        try {
+            const slow = new Promise<void>((_, reject) => setTimeout(() => reject(new Error("late")), 60));
+            await expect(withTimeout(slow, 20)).resolves.toBe(TIMED_OUT);
+            await new Promise(resolve => setTimeout(resolve, 120));
+            expect(unhandled).toEqual([]);
+        }
+        finally {
+            process.off("unhandledRejection", onUnhandled);
+        }
+    });
+
+    it("clears its timer once the promise settles", async () => {
+        // A pending timer would keep the event loop alive well past the await,
+        // which is what makes a long default bound safe to use everywhere.
+        // `getActiveResourcesInfo` landed in Node 17; older runtimes just skip
+        // the assertion rather than failing the suite.
+        const activeTimeouts = () => {
+            const info = (process as any).getActiveResourcesInfo;
+            return typeof info === "function"
+                ? (info.call(process) as string[]).filter(r => r === "Timeout").length
+                : undefined;
+        };
+        const before = activeTimeouts();
+        await withTimeout(Promise.resolve("value"), 60000);
+        const after = activeTimeouts();
+
+        if (before !== undefined && after !== undefined) {
+            expect(after).toBeLessThanOrEqual(before);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #246.

## What was wrong

`ObservableSource.notify()` is on the critical path of every write, and `notifyFactSaved` awaited each listener's `onResult` with no timeout, guarded only against *throws*. A consumer callback returning a promise that never settles blocked that listener, every listener behind it (the loop was serial), the enclosing `notify()`, the `save()` that triggered it, and every `query()` whose load path saves that fact type. Nothing rejected, so retry/backoff wrappers never fired.

## H1 is confirmed

The issue left H1 (re-entrant `save()`/`query()` from inside `onResult`) unsettled against H2. It is H1, and there is a specific cycle:

- `LoadBatch.load()` awaits `notifyFactsAdded` **before** resolving `completed`.
- `processFeed` parks on `await batch.completed` while the feed is still in `activeFeeds`; `activeFeeds.delete(feed)` runs only in its `finally`.
- `NetworkManager.fetch` joins an already-running feed via `activeFeeds.get(feed)`.

So a `j.subscribe` handler that queries a specification sharing a feed with the outer in-flight `processFeed` awaits a promise that cannot resolve until the handler returns. That matches the incident trace exactly, and explains why 175 of 215 stalls landed on the one type whose handler writes.

`test/observable/reentrantNotificationSpec.ts` reproduces this deterministically: with the fix disabled it hangs and fails on the deadline; with it enabled it passes.

## What changed

**1. Bound the wait on `onResult`.** New `withTimeout` in `src/util/promise.ts` — clears its timer on both paths, so no pending handle is left behind, and `Promise.race` keeps a late rejection from escaping as an unhandled rejection. `ObservableSource` takes `listenerTimeoutMs` (default `DEFAULT_LISTENER_TIMEOUT_MS`, 30 s; `0` to opt out), plumbed through `JinagaBrowserConfig` and `JinagaTestConfig`. The default is deliberately generous: it should never fire for a healthy handler.

**2. Dispatch listeners concurrently, by derivation rather than preference.** The listeners registered for one specification now dispatch at once through a per-listener wrapper that never rejects, so a slow peer cannot delay the others.

This follows from the model rather than from a tuning choice. Jinaga records causality explicitly — a fact names its predecessors — and delivers specification results as **sets** precisely to document that no such relation holds among them. So order should be *derived* from the specification structure, and sequencing belongs only where an edge exists. There are three:

1. **Predecessor → successor**, explicit in the fact graph.
2. **Parent row → child row**, implicit via closure capture: `injectObservers` captures the parent's `tupleHash` (`observer.ts:852`), so a child handler enters `addedHandlers` only when the parent's callback reaches into the nested collection on its result and calls `onAdded` (`:861`). Honored by the `await resultAdded(...)` that precedes the child recursion.
3. **Row identity, not array position** — two entries of one result array sharing a `rowHash` are the same row reached by different auth paths (`rowAndVoteHashes`, `:624`), so the set carrying no causality is the set of *distinct rows*.

The listeners in a group are independent subscriptions with no edge between them, so concurrency is correct there unconditionally. An earlier revision of this PR added `listenerDispatch: "parallel" | "serial"` as an escape hatch; it has been **removed**, because `"serial"` promises an ordering the model refuses to make. The rule is now stated in comments at the two sites that must not drift — the fan-out in `observable.ts`, and the awaited add handler in `observer.ts`.

By that same rule, everywhere the code is currently serial (sibling rows, branch delivery, spec groups) is correct but not maximal, so this PR loosens nothing beyond the listener group. Loosening the rest is blocked anyway: `addedHandlers.find` (`:677`) races a sibling's `push` (`:861`).

**3. Break the deadlock.** `NetworkManager` tracks which feed is parked on which batch, and `LoadBatch` exposes whether it is in its notification phase. `fetch` declines to join a feed when that feed's batch is mid-notification *and* a listener callback is currently executing (`ObservableSource.isDispatchingListener()`). The batch's graph is already durable in the store at that point, so the caller still reads those facts; only pages the feed has not fetched yet are forgone.

That signal is deliberately not claimed to be caller-scoped, and `joinWouldAwaitARunningListener` is named for what it detects. Precise attribution would need async context propagation: `AsyncLocalStorage` is Node-only and this ships to the browser. The residual is documented at the guard.

**4. Make the stall observable.** Paired counters — `observable_listener_started` / `_completed` / `_timed_out` / `_failed` / `_late_settled`, plus `observable_notify_overlapped` and `network_feed_join_skipped_reentrant`.

**5. Dead code removed.** The "RACE CONDITION DETECTED" check compared a snapshot against the array it was spread from one line earlier; `splice` never leaves the holes the `NULL listener` guard looked for. Flagging so it does not read as an accidental deletion.

## Behavior change worth knowing

Once a listener exceeds the bound, `fact()` may resolve before that callback has run, and `processed()` on the affected observer may never settle. That is the deliberate trade: a bounded, logged, counted delivery gap in place of an unbounded wedge. Documented on the config field, and stated at the fan-out so `notify()` is not read as implying every listener finished.

## Found but not fixed here

The batch fan-out (`await Promise.all(saved.map(...))`) discards a topological order that `Dehydration` establishes and both stores preserve — the one causal edge the model states explicitly that dispatch does not honor. `pendingAddsByKey` is the standing compensation, and it has no eviction and is not cleared by `stop()`. That is a different defect from this wedge, so it is #248 with a `KNOWN GAP` comment at the fan-out pointing there.

## Tests

`test/observable/listenerTimeoutSpec.ts`, through the public API: a never-settling handler does not wedge `j.fact()`; a query after the wedged save still resolves; a healthy listener is delivered while a sibling on the same specification is wedged, well inside the sibling's timeout; a throwing listener is still caught; an abandoned listener that rejects later produces no unhandled rejection; `listenerTimeoutMs: 0` restores the unbounded await.

`test/observable/reentrantNotificationSpec.ts`: the H1 deadlock, with a 30 s listener timeout so a pass proves the cycle was broken directly rather than survived by the timeout.

`test/util/promiseSpec.ts` covers `withTimeout` directly, including a late rejection whose reason is `undefined`. That case is unreachable through the public API, because `ObserverImpl.notifyAdded` (`observer.ts:661`) treats an `undefined` rejection reason as "no error" and swallows it — pre-existing and unrelated, so not touched here.

New cases in `test/managers/NetworkManagerSpec.ts`: a non-re-entrant concurrent `fetch` still joins the in-flight feed, both when notifying and when not.

Every new regression test was verified to fail first against the pre-fix behavior — the wedge and deadlock cases fail on the deadline, not on an assertion.

```
npm test                                                 # 620 passing
npx jest test/observable test/util --detectOpenHandles   # no open handles
```

The ordering-sensitive suites (`nestedSubscriptionSpec`, `watchSpec`, `inverseSubscriptionRace*`, `observerSettlesSpec`, `test/ws`, …) were run repeatedly under `--runInBand` for flakiness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiS93Lvocjm7VxoyQeZuWo)_