### PR TITLE
Bound listener notification so one stuck callback cannot wedge the client (#246)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export { Network, NetworkManager, NetworkNoOp } from "./managers/NetworkManager"
 export { QueueProcessor, Saver } from './managers/QueueProcessor';
 export { MemoryStore } from './memory/memory-store';
 export { Device, User, UserName } from "./model/user";
-export { ObservableSource, ObservableSource as ObservableSourceImpl, SpecificationListener } from './observable/observable';
+export { DEFAULT_LISTENER_TIMEOUT_MS, ObservableSource, ObservableSource as ObservableSourceImpl, SpecificationListener } from './observable/observable';
 export { ObservableCollection } from './observer/observer';
 export { Subscriber } from './observer/subscriber';
 export { PurgeConditions } from './purge/purgeConditions';

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -47,13 +47,30 @@ export type JinagaBrowserConfig = {
      * every mode by default (issue jinaga-server#179). Development mode only
      * adds the console logging on top.
      */
-    developmentMode?: boolean
+    developmentMode?: boolean,
+    /**
+     * Maximum milliseconds to wait for a single watch or subscribe callback to
+     * settle before continuing without it (issue #246). A callback that never
+     * settles would otherwise block `fact()`, and every query behind it,
+     * forever. Set to 0 to wait indefinitely. Defaults to
+     * `DEFAULT_LISTENER_TIMEOUT_MS`.
+     *
+     * Once a listener exceeds this bound, `fact()` resolves without waiting for
+     * it. The callback is not skipped -- it was already entered and still runs
+     * to completion later -- but `fact()` no longer implies it finished, and
+     * `processed()` on the affected observer may never settle. That is the
+     * deliberate trade: a bounded, logged loss of the delivery guarantee in
+     * place of an unbounded wedge.
+     */
+    listenerTimeoutMs?: number
 }
 
 export class JinagaBrowser {
     static create(config: JinagaBrowserConfig) {
         const store = createStore(config);
-        const observableSource = new ObservableSource(store);
+        const observableSource = new ObservableSource(store, {
+            listenerTimeoutMs: config.listenerTimeoutMs
+        });
         const syncStatusNotifier = new SyncStatusNotifier();
         const webClient = createWebClient(config, syncStatusNotifier);
         const fork = createFork(config, store, webClient);

--- a/src/jinaga-test.ts
+++ b/src/jinaga-test.ts
@@ -24,14 +24,22 @@ export type JinagaTestConfig = {
   device?: {},
   initialState?: {}[],
   purgeConditions?: (p: PurgeConditions) => PurgeConditions,
-  feedRefreshIntervalSeconds?: number
+  feedRefreshIntervalSeconds?: number,
+  /**
+   * Maximum milliseconds to wait for a single watch or subscribe callback to
+   * settle before continuing without it (issue #246). Set to 0 to wait
+   * indefinitely. Defaults to `DEFAULT_LISTENER_TIMEOUT_MS`.
+   */
+  listenerTimeoutMs?: number
 }
 
 export class JinagaTest {
   static create(config: JinagaTestConfig) {
     const store = new MemoryStore();
     this.saveInitialState(config, store);
-    const observableSource = new ObservableSource(store);
+    const observableSource = new ObservableSource(store, {
+      listenerTimeoutMs: config.listenerTimeoutMs
+    });
     const syncStatusNotifier = new SyncStatusNotifier();
     const fork = new PassThroughFork(store);
     const authentication = this.createAuthentication(config, store);

--- a/src/observable/observable.ts
+++ b/src/observable/observable.ts
@@ -2,10 +2,34 @@ import { describeSpecification } from '../specification/description';
 import { Specification } from "../specification/specification";
 import { FactEnvelope, FactRecord, ProjectedResult, Storage } from '../storage';
 import { computeStringHash } from '../util/encoding';
+import { TIMED_OUT, withTimeout } from '../util/promise';
 import { Trace } from '../util/trace';
 
 export interface SpecificationListener {
     onResult(results: ProjectedResult[]): Promise<void>;
+}
+
+/**
+ * Ceiling on a single listener's `onResult`, in milliseconds. Deliberately
+ * generous: it must never fire for a healthy handler, only for a wedged one.
+ */
+export const DEFAULT_LISTENER_TIMEOUT_MS = 30000;
+
+export interface ObservableSourceOptions {
+    /**
+     * Maximum time to wait for one listener's `onResult` to settle before
+     * abandoning the wait and continuing without it. A callback that never
+     * settles would otherwise block the save that triggered the notification,
+     * and every query behind it, forever (issue #246). Set to 0 to wait
+     * indefinitely, which is the behavior prior to that fix. Defaults to
+     * `DEFAULT_LISTENER_TIMEOUT_MS`.
+     *
+     * This bounds one listener, not one save. Listeners registered for the
+     * same specification are dispatched concurrently, but specification groups
+     * are notified in sequence, so a fact type with K wedged groups can delay
+     * its save by up to K times this value.
+     */
+    listenerTimeoutMs?: number;
 }
 
 export class ObservableSource {
@@ -13,21 +37,49 @@ export class ObservableSource {
         specification: Specification,
         listeners: SpecificationListener[]
     }>> = new Map();
+    private readonly listenerTimeoutMs: number;
+    private listenerDispatchDepth = 0;
 
-    constructor(private store: Storage) {
+    constructor(private store: Storage, options: ObservableSourceOptions = {}) {
+        this.listenerTimeoutMs = options.listenerTimeoutMs ?? DEFAULT_LISTENER_TIMEOUT_MS;
     }
 
     async notify(saved: FactEnvelope[]): Promise<void> {
-        // Collect all notification promises to ensure all callbacks complete
-        const notificationPromises: Promise<void>[] = [];
-        
-        for (let index = 0; index < saved.length; index++) {
-            const envelope = saved[index];
-            notificationPromises.push(this.notifyFactSaved(envelope.fact));
+        if (this.listenerDispatchDepth > 0) {
+            // A notification entered while a listener callback is running. Two
+            // overlapping notifications are ordinary concurrency -- two feeds
+            // delivering at once -- and keying on that would warn on nearly
+            // every busy client, drowning the signal. Keying on a listener
+            // being mid-dispatch is what actually distinguishes re-entrancy:
+            // a callback that wrote or queried facts and came back through
+            // this path from inside its own notification.
+            //
+            // Still not caller-scoped -- an unrelated listener may simply
+            // happen to be running -- because precise attribution needs async
+            // context propagation that the browser target rules out. So this
+            // warns and continues rather than throwing on a pattern that works
+            // today.
+            Trace.counter("observable_notify_reentrant", 1);
+            Trace.warn(`[ObservableSource] RE-ENTRANT NOTIFY - Listener dispatch depth on entry: ${this.listenerDispatchDepth}, Envelopes: ${saved.length}. A listener callback appears to be writing or querying facts from inside its own notification; the listener timeout (${this.listenerTimeoutMs}ms) bounds any stall this causes.`);
         }
-        
-        // Wait for all notifications to complete before resolving
-        await Promise.all(notificationPromises);
+
+        // KNOWN GAP: `saved` arrives in topological order — Dehydration
+        // pushes a fact's predecessors before the fact itself, and both
+        // stores preserve input order — and this line discards it. That is
+        // the one causal edge the model states explicitly and this dispatch
+        // does not honor. `ObserverImpl.pendingAddsByKey` is the standing
+        // compensation: a child row whose parent has not been delivered
+        // buffers and replays when the parent's onAdded registers.
+        // Tracked separately; do not treat this fan-out as evidence that
+        // predecessor order is unimportant.
+        //
+        // Every fact's notification is awaited to a conclusion, but a
+        // conclusion is not the same as completion: a listener either
+        // finishes, fails, or is abandoned once it exceeds
+        // `listenerTimeoutMs`. So `notify()` resolving does NOT imply that
+        // every listener ran to completion, and neither does the `save()`
+        // above it. Bounding that wait is the point of issue #246.
+        await Promise.all(saved.map(envelope => this.notifyFactSaved(envelope.fact)));
     }
 
     public addSpecificationListener(specification: Specification, onResult: (results: ProjectedResult[]) => Promise<void>): SpecificationListener {
@@ -177,32 +229,38 @@ export class ObservableSource {
                     
                     // Create a snapshot of listeners to avoid modification during iteration
                     const listenerSnapshot = [...listeners.listeners];
-                    if (listenerSnapshot.length !== listeners.listeners.length) {
-                        Trace.warn(`[ObservableSource] RACE CONDITION DETECTED - Listener count changed during snapshot: ${listenerSnapshot.length} vs ${listeners.listeners.length}`);
-                    }
-                    
-                    for (let i = 0; i < listenerSnapshot.length; i++) {
-                        const specificationListener = listenerSnapshot[i];
-                        if (specificationListener) {
-                            try {
-                                const notifyStart = Date.now();
-                                Trace.info(`[ObservableSource] Calling listener ${i+1}/${listenerSnapshot.length} - Nested: ${hasNestedSpecs}`);
-                                await specificationListener.onResult(results);
-                                const notifyDuration = Date.now() - notifyStart;
-                                totalNotifications++;
-                                
-                                if (notifyDuration > 100) {
-                                    Trace.warn(`[ObservableSource] SLOW notification - Listener ${i+1}/${listenerSnapshot.length}, Duration: ${notifyDuration}ms, Nested: ${hasNestedSpecs}`);
-                                } else {
-                                    Trace.info(`[ObservableSource] Listener completed - ${i+1}/${listenerSnapshot.length}, Duration: ${notifyDuration}ms`);
-                                }
-                            } catch (error) {
-                                Trace.error(`[ObservableSource] ERROR in listener notification - Listener ${i+1}/${listenerSnapshot.length}, Nested: ${hasNestedSpecs}, Error: ${error}`);
-                            }
-                        } else {
-                            Trace.warn(`[ObservableSource] NULL listener encountered at index ${i}`);
-                        }
-                    }
+
+                    // Concurrent by derivation, not by preference. The model
+                    // records causality explicitly — a fact names its
+                    // predecessors — and it delivers specification results as
+                    // SETS precisely to say that no such relation holds among
+                    // them. The listeners in this group are independent
+                    // subscriptions to one specification, so the model records
+                    // no edge between them and dispatch order is not ours to
+                    // define. Do not reintroduce a mode toggle here: offering
+                    // "serial" would promise an ordering the model refuses to
+                    // make, and a consumer that came to depend on it would be
+                    // depending on an accident.
+                    //
+                    // Sequencing belongs only where an edge exists: predecessor
+                    // before successor, and a parent row before its child rows
+                    // (see the await in ObserverImpl.notifyAddedRow).
+                    //
+                    // notifyListener never rejects, so one listener can neither
+                    // leave a sibling rejection unhandled nor short-circuit the
+                    // others.
+                    //
+                    // The fan-out is within a spec group only; the loop over
+                    // spec groups above is still serial, so a wedged listener
+                    // delays the groups after it by up to listenerTimeoutMs
+                    // each. A fact type with K wedged groups therefore costs
+                    // K * listenerTimeoutMs, not one. Distinct specifications
+                    // carry no causal edge either, so hoisting this Promise.all
+                    // to that loop would be sound; it is left serial here to
+                    // keep this change to the wait that caused issue #246.
+                    const outcomes = await Promise.all(listenerSnapshot.map((specificationListener, i) =>
+                        this.notifyListener(specificationListener, results, i, listenerSnapshot.length, specificationKey, fact.type, hasNestedSpecs)));
+                    totalNotifications += outcomes.filter(completed => completed).length;
                 } else {
                     Trace.info(`[ObservableSource] Skipping spec ${specCount}/${listenersBySpecification.size} - No listeners or null group`);
                 }
@@ -212,6 +270,69 @@ export class ObservableSource {
             Trace.info(`[ObservableSource] NOTIFY COMPLETE - Fact: ${fact.hash.substring(0, 8)}..., Type: ${fact.type}, Specs processed: ${specCount} (${nestedSpecCount} nested), Total notifications: ${totalNotifications}, Duration: ${totalDuration}ms`);
         } else {
             Trace.info(`[ObservableSource] No listeners for fact type: ${fact.type} - Available types: [${Array.from(this.listenersByTypeAndSpecification.keys()).join(', ')}]`);
+        }
+    }
+
+    /**
+     * Dispatch one listener, bounding how long we wait for it. Never rejects:
+     * a listener that throws, or one that never settles, is reported and
+     * stepped over so it cannot hold the save that triggered this notification
+     * (issue #246). Returns whether the listener actually completed.
+     */
+    private async notifyListener(
+        specificationListener: SpecificationListener,
+        results: ProjectedResult[],
+        index: number,
+        count: number,
+        specificationKey: string,
+        givenType: string,
+        hasNestedSpecs: boolean
+    ): Promise<boolean> {
+        const label = `${index + 1}/${count}`;
+        const notifyStart = Date.now();
+        Trace.info(`[ObservableSource] Calling listener ${label} - Nested: ${hasNestedSpecs}`);
+        Trace.counter("observable_listener_started", 1);
+        this.listenerDispatchDepth++;
+        try {
+            const outcome = await withTimeout(
+                specificationListener.onResult(results),
+                this.listenerTimeoutMs,
+                late => {
+                    Trace.counter("observable_listener_late_settled", 1);
+                    if ("error" in late) {
+                        Trace.error(`[ObservableSource] Abandoned listener ${label} rejected after ${late.elapsedMs}ms - Spec: ${specificationKey.substring(0, 8)}..., Type: ${givenType}, Error: ${late.error}`);
+                    } else {
+                        Trace.warn(`[ObservableSource] Abandoned listener ${label} finally completed after ${late.elapsedMs}ms - Spec: ${specificationKey.substring(0, 8)}..., Type: ${givenType}`);
+                    }
+                });
+            const notifyDuration = Date.now() - notifyStart;
+
+            if (outcome === TIMED_OUT) {
+                Trace.counter("observable_listener_timed_out", 1);
+                Trace.warn(`[ObservableSource] LISTENER TIMEOUT - Listener ${label} did not settle within ${this.listenerTimeoutMs}ms; abandoning the wait so the save can complete. Spec: ${specificationKey.substring(0, 8)}..., Type: ${givenType}, Nested: ${hasNestedSpecs}`);
+                Trace.metric("observable_listener_timeout", {
+                    durationMs: notifyDuration,
+                    listenerIndex: index,
+                    listenerCount: count
+                });
+                return false;
+            }
+
+            Trace.counter("observable_listener_completed", 1);
+            if (notifyDuration > 100) {
+                Trace.warn(`[ObservableSource] SLOW notification - Listener ${label}, Duration: ${notifyDuration}ms, Nested: ${hasNestedSpecs}`);
+            } else {
+                Trace.info(`[ObservableSource] Listener completed - ${label}, Duration: ${notifyDuration}ms`);
+            }
+            return true;
+        }
+        catch (error) {
+            Trace.counter("observable_listener_failed", 1);
+            Trace.error(`[ObservableSource] ERROR in listener notification - Listener ${label}, Nested: ${hasNestedSpecs}, Error: ${error}`);
+            return false;
+        }
+        finally {
+            this.listenerDispatchDepth--;
         }
     }
 }

--- a/src/observer/observer.ts
+++ b/src/observer/observer.ts
@@ -28,6 +28,12 @@ export interface Observer<T> {
      * Returns a promise that resolves when all pending notifications have been processed.
      * This includes all observer callbacks triggered by facts that have been added.
      * Useful in tests to wait for async operations to complete.
+     *
+     * Not guaranteed to settle. A handler that never settles is abandoned by
+     * the listener timeout (issue #246) so that `fact()` can complete, but its
+     * notification stays pending here forever. Await this only where a handler
+     * is known to terminate, and never as a liveness guarantee in production
+     * code.
      */
     processed(): Promise<void>;
     stop(): void;
@@ -713,6 +719,12 @@ export class ObserverImpl<T> implements Observer<T> {
                 return;
             }
             Trace.info(`[Observer] CALLING HANDLER - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}...`);
+            // Awaiting this handler before the recursion below is a causal
+            // requirement, not a convenience. `injectObservers` captured THIS
+            // row's tupleHash in the onAdded closure it put on `result`, so a
+            // child handler enters `addedHandlers` only when this callback
+            // reaches into `result.<component>.onAdded`. Descending before that
+            // returns finds no handler and buffers instead of delivering.
             const promiseMaybe = resultAdded(result);
             if (promiseMaybe instanceof Promise) {
                 // Mark this row as having a genuine in-flight async add so
@@ -759,7 +771,13 @@ export class ObserverImpl<T> implements Observer<T> {
             Trace.info(`[Observer] Skipping already notified row - Path: ${displayPath}, Row hash: ${rowHash.substring(0, 8)}...`);
         }
 
-        // Recursively notify added for specification results.
+        // Recursively notify added for specification results. Parent before
+        // child is the model's causal edge here — the closure capture in
+        // injectObservers is what records it — so this must stay downstream of
+        // the awaited handler above and must not become a Promise.all with it.
+        // Sibling ROWS carry no such edge (results are a set), which is why
+        // notifyAdded's loop is merely conservative rather than required; see
+        // ObservableSource's listener fan-out for the same rule stated there.
         if (projection.type === "composite") {
             for (const component of projection.components) {
                 if (component.type === "specification") {

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -3,3 +3,60 @@ export function delay(ms: number) {
     setTimeout(() => resolve(), ms);
   });
 }
+
+/** Resolved value of `withTimeout` when the deadline passes before the promise settles. */
+export const TIMED_OUT: unique symbol = Symbol("jinaga.timed-out");
+
+export interface LateSettle {
+  /** Present when the abandoned promise eventually rejected. */
+  error?: unknown;
+  /** Milliseconds from the call to the late settle. */
+  elapsedMs: number;
+}
+
+/**
+ * Await `promise` for at most `timeoutMs`. Resolves with the promise's value,
+ * or with `TIMED_OUT` when the deadline passes first. A rejection that arrives
+ * before the deadline propagates normally, so a caller's existing error
+ * handling is unchanged.
+ *
+ * `timeoutMs <= 0` (or a non-finite value) disables the bound: the original
+ * promise is returned unchanged and no timer is created.
+ *
+ * The timer is always cleared, so a fast promise never leaves a pending
+ * `setTimeout` handle holding the event loop open. `Promise.race` attaches a
+ * rejection handler to `promise`, so a rejection arriving after the race is
+ * decided cannot escape as an unhandled rejection; `onLateSettle` additionally
+ * reports it.
+ *
+ * Note that abandoning the wait does not cancel the work. A promise that never
+ * settles is retained by these handlers for the lifetime of the process. That
+ * is inherent to continuing without it, and is bounded by the number of
+ * timed-out waits.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  onLateSettle?: (late: LateSettle) => void
+): Promise<T | typeof TIMED_OUT> {
+  if (!(timeoutMs > 0) || !isFinite(timeoutMs)) {
+    return promise;
+  }
+  const start = Date.now();
+  let timer: ReturnType<typeof setTimeout>;
+  let timedOut = false;
+  const expiry = new Promise<typeof TIMED_OUT>(resolve => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      resolve(TIMED_OUT);
+    }, timeoutMs);
+  });
+  if (onLateSettle) {
+    promise.then(
+      () => { if (timedOut) onLateSettle({ elapsedMs: Date.now() - start }); },
+      error => { if (timedOut) onLateSettle({ error, elapsedMs: Date.now() - start }); }
+    );
+  }
+  return Promise.race([promise, expiry])
+    .finally(() => clearTimeout(timer));
+}

--- a/src/util/promise.ts
+++ b/src/util/promise.ts
@@ -1,3 +1,5 @@
+import { Trace } from './trace';
+
 export function delay(ms: number) {
   return new Promise<void>((resolve, reject) => {
     setTimeout(() => resolve(), ms);
@@ -29,6 +31,11 @@ export interface LateSettle {
  * decided cannot escape as an unhandled rejection; `onLateSettle` additionally
  * reports it.
  *
+ * `onLateSettle` runs in a `then` handler on a promise nobody holds, so a
+ * reporter that throws is contained here rather than escaping as an unhandled
+ * rejection. The reporters this exists for end in a consumer-supplied `Tracer`,
+ * which is the same untrusted code the timeout exists to contain.
+ *
  * Note that abandoning the wait does not cancel the work. A promise that never
  * settles is retained by these handlers for the lifetime of the process. That
  * is inherent to continuing without it, and is bounded by the number of
@@ -52,9 +59,23 @@ export function withTimeout<T>(
     }, timeoutMs);
   });
   if (onLateSettle) {
+    const report = (late: LateSettle) => {
+      try {
+        onLateSettle(late);
+      }
+      catch (reporterError) {
+        try {
+          Trace.error(reporterError);
+        }
+        catch (tracerError) {
+          // The tracer itself threw. There is nowhere left to report this, and
+          // rethrowing would produce the unhandled rejection this guards.
+        }
+      }
+    };
     promise.then(
-      () => { if (timedOut) onLateSettle({ elapsedMs: Date.now() - start }); },
-      error => { if (timedOut) onLateSettle({ error, elapsedMs: Date.now() - start }); }
+      () => { if (timedOut) report({ elapsedMs: Date.now() - start }); },
+      error => { if (timedOut) report({ error, elapsedMs: Date.now() - start }); }
     );
   }
   return Promise.race([promise, expiry])

--- a/test/managers/concurrentFeedJoinSpec.ts
+++ b/test/managers/concurrentFeedJoinSpec.ts
@@ -1,0 +1,108 @@
+import { User } from "@src";
+import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
+import { Dehydration } from "../../src/fact/hydrate";
+import { PassThroughFork } from "../../src/fork/pass-through-fork";
+import { FeedResponse, FeedsResponse } from "../../src/http/messages";
+import { FactManager } from "../../src/managers/factManager";
+import { Network } from "../../src/managers/NetworkManager";
+import { MemoryStore } from "../../src/memory/memory-store";
+import { ObservableSource } from "../../src/observable/observable";
+import { Specification } from "../../src/specification/specification";
+import { FactEnvelope, FactReference } from "../../src/storage";
+import { Company, Manager, Office, model } from "../companyModel";
+import { waitForCondition } from "../utils/async-test-utils";
+
+const managersInOffice = model.given(Office).match((office, facts) =>
+    facts.ofType(Manager).join(manager => manager.office, office)
+).specification;
+
+/**
+ * One feed delivering two pages. Page two is only reachable by a caller that
+ * waits for the whole feed, so a caller that bails out early is detectable as
+ * a short result set rather than as a timing difference.
+ */
+class TwoPageNetwork implements Network {
+    constructor(
+        private readonly page1: FactEnvelope[],
+        private readonly page2: FactEnvelope[]
+    ) { }
+
+    feeds(): Promise<FeedsResponse> {
+        return Promise.resolve({ feeds: ["feed-1"] });
+    }
+
+    fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
+        if (bookmark === "") {
+            return Promise.resolve({ references: this.page1.map(e => ({ type: e.fact.type, hash: e.fact.hash })), bookmark: "1" });
+        }
+        if (bookmark === "1") {
+            return Promise.resolve({ references: this.page2.map(e => ({ type: e.fact.type, hash: e.fact.hash })), bookmark: "2" });
+        }
+        return Promise.resolve({ references: [], bookmark });
+    }
+
+    streamFeed(): () => void {
+        return () => { };
+    }
+
+    load(references: FactReference[]): Promise<FactEnvelope[]> {
+        return Promise.resolve([...this.page1, ...this.page2]
+            .filter(e => references.some(r => r.hash === e.fact.hash)));
+    }
+
+    intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+        return Promise.resolve([{ start, specification }]);
+    }
+}
+
+/**
+ * A guard that declines to join an in-flight feed while a listener is running
+ * was considered for issue #246, to break the re-entrant cycle directly rather
+ * than waiting out the listener timeout. It cannot be scoped to the re-entrant
+ * caller without async context propagation, so it also fires for an ordinary
+ * concurrent caller -- which then reads a partially loaded feed and returns a
+ * short result set with no error. This test pins the behavior that must hold:
+ * a caller outside any listener always gets the whole feed.
+ */
+describe("joining an in-flight feed during a notification (issue #246)", () => {
+    it("gives a concurrent caller the complete feed, not just what is already saved", async () => {
+        const creator = new User("--- PUBLIC KEY GOES HERE ---");
+        const company = new Company(creator, "TestCo");
+        const office = new Office(company, "TestOffice");
+
+        const first = new Dehydration();
+        const officeReference = first.dehydrate(office);
+        first.dehydrate(new Manager(office, 1));
+        const page1 = first.factRecords().map(fact => <FactEnvelope>{ fact, signatures: [] });
+
+        const second = new Dehydration();
+        second.dehydrate(new Manager(office, 2));
+        const page2 = second.factRecords().map(fact => <FactEnvelope>{ fact, signatures: [] });
+
+        const store = new MemoryStore();
+        const observableSource = new ObservableSource(store, { listenerTimeoutMs: 30000 });
+        const factManager = new FactManager(new PassThroughFork(store),
+            observableSource, store, new TwoPageNetwork(page1, page2), []);
+
+        // A healthy but slow listener, so the first page's notification is
+        // still in flight when the second caller arrives. It settles on its
+        // own; nothing here depends on that caller returning.
+        let dispatching = false;
+        factManager.addSpecificationListener(managersInOffice, async () => {
+            dispatching = true;
+            await new Promise<void>(resolve => setTimeout(resolve, 300));
+            dispatching = false;
+        });
+
+        const loading = factManager.fetch([officeReference], managersInOffice);
+        await waitForCondition(() => dispatching, 3000);
+
+        // An ordinary caller, outside every listener. It must share the
+        // in-flight load rather than reading around it.
+        await factManager.fetch([officeReference], managersInOffice);
+        const concurrent = await factManager.read([officeReference], managersInOffice);
+
+        await loading;
+        expect(concurrent.length).toBe(2);
+    }, 15000);
+});

--- a/test/observable/listenerTimeoutSpec.ts
+++ b/test/observable/listenerTimeoutSpec.ts
@@ -1,0 +1,240 @@
+import { Jinaga, JinagaTest, NoOpTracer, Trace, Tracer, User } from "@src";
+import { Company, Manager, ManagerName, Office, model } from "../companyModel";
+import { waitForCondition } from "../utils/async-test-utils";
+
+/**
+ * Records Trace.counter names so a stall is asserted as observable, not merely
+ * as a duration (issue #246).
+ */
+class CountingTracer extends NoOpTracer implements Tracer {
+    public readonly counters: { [name: string]: number } = {};
+    public readonly errors: string[] = [];
+    public readonly warnings: string[] = [];
+    counter(name: string, value: number): void {
+        this.counters[name] = (this.counters[name] ?? 0) + value;
+    }
+    warn(warning: string): void {
+        this.warnings.push(warning);
+    }
+    error(error: any): void {
+        this.errors.push(String(error));
+    }
+}
+
+const creator = new User("--- PUBLIC KEY GOES HERE ---");
+const company = new Company(creator, "TestCo");
+const office = new Office(company, "TestOffice");
+
+const managersInOffice = model.given(Office).match((office, facts) =>
+    facts.ofType(Manager)
+        .join(manager => manager.office, office)
+);
+
+function createClient(listenerTimeoutMs: number): Jinaga {
+    return JinagaTest.create({
+        model,
+        initialState: [creator, company, office],
+        listenerTimeoutMs
+    });
+}
+
+/** Race a promise against a deadline. Always clears the timer. */
+function raceDeadline<T>(promise: Promise<T>, ms: number): Promise<"settled" | "timed-out"> {
+    let timer: ReturnType<typeof setTimeout>;
+    return Promise.race([
+        promise.then(() => "settled" as const, () => "settled" as const),
+        new Promise<"timed-out">(resolve => { timer = setTimeout(() => resolve("timed-out"), ms); })
+    ]).finally(() => clearTimeout(timer!));
+}
+
+describe("a listener that never settles (issue #246)", () => {
+    let tracer: CountingTracer;
+
+    beforeEach(() => {
+        // Trace is global static state, so it must be restored in afterEach.
+        tracer = new CountingTracer();
+        Trace.configure(tracer);
+    });
+
+    afterEach(() => {
+        Trace.off();
+    });
+
+    it("does not wedge j.fact()", async () => {
+        const j = createClient(200);
+
+        let calls = 0;
+        const observer = j.watch(managersInOffice, office, () => {
+            calls++;
+            return new Promise<void>(() => { });
+        });
+        // No managers exist yet, so the handler has not run and loaded() settles.
+        await observer.loaded();
+        expect(calls).toBe(0);
+
+        const start = Date.now();
+        // Before the fix this never settles: notifyFactSaved awaits onResult
+        // with no bound, so save() and every query behind it hang forever.
+        await j.fact(new Manager(office, 1));
+        const elapsed = Date.now() - start;
+
+        expect(calls).toBe(1);
+        expect(elapsed).toBeGreaterThanOrEqual(150);
+        expect(elapsed).toBeLessThan(3000);
+        expect(tracer.counters["observable_listener_started"]).toBeGreaterThan(0);
+        expect(tracer.counters["observable_listener_timed_out"]).toBeGreaterThan(0);
+
+        // Deliberately no `await observer.processed()`: the abandoned
+        // notification stays pending by design, so processed() never settles.
+        observer.stop();
+    }, 15000);
+
+    it("does not block a query issued after the wedged save", async () => {
+        const j = createClient(200);
+
+        const observer = j.watch(managersInOffice, office, () => new Promise<void>(() => { }));
+        await observer.loaded();
+
+        await j.fact(new Manager(office, 2));
+        const managers = await j.query(managersInOffice, office);
+
+        expect(managers.map(m => m.employeeNumber)).toEqual([2]);
+        observer.stop();
+    }, 15000);
+
+    it("delivers to a healthy listener while a sibling on the same specification is wedged", async () => {
+        // Two observers on the SAME specification land in one spec group with
+        // two listeners. The healthy one must receive the row without waiting
+        // out the wedged one's timeout.
+        const j = createClient(1000);
+
+        const wedged = j.watch(managersInOffice, office, () => new Promise<void>(() => { }));
+        const received: number[] = [];
+        const healthy = j.watch(managersInOffice, office, manager => {
+            received.push(manager.employeeNumber);
+        });
+        await wedged.loaded();
+        await healthy.loaded();
+
+        const start = Date.now();
+        const saved = j.fact(new Manager(office, 3));
+        await waitForCondition(() => received.length > 0, 500);
+        const elapsed = Date.now() - start;
+
+        expect(received).toEqual([3]);
+        // Well under the 1000ms timeout the wedged sibling is burning: a
+        // serial dispatch would have made the healthy listener wait it out.
+        expect(elapsed).toBeLessThan(400);
+
+        // Let the wedged listener time out so the save settles and its timer
+        // is cleared before the test ends.
+        await saved;
+
+        wedged.stop();
+        healthy.stop();
+    }, 15000);
+
+    it("still catches a listener that throws, without rejecting the save", async () => {
+        const j = createClient(200);
+
+        const observer = j.watch(managersInOffice, office, () => {
+            throw new Error("listener blew up");
+        });
+        await observer.loaded();
+
+        await expect(j.fact(new Manager(office, 4))).resolves.toBeDefined();
+        expect(tracer.counters["observable_listener_failed"]).toBeGreaterThan(0);
+        expect(tracer.counters["observable_listener_timed_out"] ?? 0).toBe(0);
+
+        observer.stop();
+    }, 15000);
+
+    it("reports an abandoned listener that rejects later, without an unhandled rejection", async () => {
+        const j = createClient(100);
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => unhandled.push(reason);
+        process.on("unhandledRejection", onUnhandled);
+
+        try {
+            const observer = j.watch(managersInOffice, office, () =>
+                new Promise<void>((_, reject) => setTimeout(() => reject(new Error("late")), 300)));
+            await observer.loaded();
+
+            await j.fact(new Manager(office, 5));
+            expect(tracer.counters["observable_listener_timed_out"]).toBeGreaterThan(0);
+
+            // Give the abandoned promise time to reject.
+            await waitForCondition(() => (tracer.counters["observable_listener_late_settled"] ?? 0) > 0, 2000);
+            // Let any unhandled rejection surface.
+            await new Promise(resolve => setTimeout(resolve, 50));
+            expect(unhandled).toEqual([]);
+
+            observer.stop();
+        }
+        finally {
+            process.off("unhandledRejection", onUnhandled);
+        }
+    }, 15000);
+
+    it("waits indefinitely when the timeout is disabled", async () => {
+        const j = createClient(0);
+
+        const observer = j.watch(managersInOffice, office, () => new Promise<void>(() => { }));
+        await observer.loaded();
+
+        // The opt-out restores the pre-#246 behavior, so the save must not settle.
+        await expect(raceDeadline(j.fact(new Manager(office, 6)), 300)).resolves.toBe("timed-out");
+
+        observer.stop();
+    }, 15000);
+});
+
+describe("the re-entrant notify warning (issue #246)", () => {
+    let tracer: CountingTracer;
+
+    beforeEach(() => {
+        tracer = new CountingTracer();
+        Trace.configure(tracer);
+    });
+
+    afterEach(() => {
+        Trace.off();
+    });
+
+    it("stays quiet for concurrent writes that merely overlap", async () => {
+        // Two saves in flight at once is ordinary concurrency, not re-entrancy.
+        // Keying the warning on overlapping notifications rather than on a
+        // listener being mid-dispatch made every busy client log this, which
+        // buries the case it exists to surface.
+        const j = createClient(1000);
+
+        await Promise.all([
+            j.fact(new Manager(office, 10)),
+            j.fact(new Manager(office, 11)),
+            j.fact(new Manager(office, 12))
+        ]);
+
+        expect(tracer.counters["observable_notify_reentrant"] ?? 0).toBe(0);
+        expect(tracer.warnings.filter(w => w.includes("RE-ENTRANT NOTIFY"))).toEqual([]);
+    }, 15000);
+
+    it("fires for a handler that writes from inside its own notification", async () => {
+        // The idiomatic "observe a fact, then write a completion fact" shape
+        // the issue calls out. It works, and must keep working, but it is the
+        // shape that can stall against an in-flight feed, so it is worth one
+        // warning.
+        const j = createClient(1000);
+
+        const observer = j.watch(managersInOffice, office, async manager => {
+            await j.fact(new ManagerName(manager, `M${manager.employeeNumber}`, []));
+        });
+        await observer.loaded();
+
+        await j.fact(new Manager(office, 13));
+
+        expect(tracer.counters["observable_notify_reentrant"]).toBeGreaterThan(0);
+        expect(tracer.counters["observable_listener_timed_out"] ?? 0).toBe(0);
+
+        observer.stop();
+    }, 15000);
+});

--- a/test/observable/reentrantNotificationSpec.ts
+++ b/test/observable/reentrantNotificationSpec.ts
@@ -1,0 +1,154 @@
+import { NoOpTracer, Trace, Tracer, User } from "@src";
+import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
+import { Dehydration } from "../../src/fact/hydrate";
+import { PassThroughFork } from "../../src/fork/pass-through-fork";
+import { FeedResponse, FeedsResponse } from "../../src/http/messages";
+import { FactManager } from "../../src/managers/factManager";
+import { Network } from "../../src/managers/NetworkManager";
+import { MemoryStore } from "../../src/memory/memory-store";
+import { ObservableSource } from "../../src/observable/observable";
+import { Specification } from "../../src/specification/specification";
+import { FactEnvelope, FactReference } from "../../src/storage";
+import { Company, Manager, Office, model } from "../companyModel";
+import { waitForCondition } from "../utils/async-test-utils";
+
+class CountingTracer extends NoOpTracer implements Tracer {
+    public readonly counters: { [name: string]: number } = {};
+    counter(name: string, value: number): void {
+        this.counters[name] = (this.counters[name] ?? 0) + value;
+    }
+}
+
+/**
+ * Maps every specification to one feed, delivers a single graph on the first
+ * fetchFeed, then reports end-of-feed. Because every query resolves to the same
+ * feed hash, a query issued from inside a notification joins the in-flight
+ * processFeed through `activeFeeds` — exactly the shape reported in issue #246.
+ */
+class OneShotFeedNetwork implements Network {
+    private delivered = false;
+
+    constructor(private readonly envelopes: FactEnvelope[]) { }
+
+    feeds(): Promise<FeedsResponse> {
+        return Promise.resolve({ feeds: ["feed-1"] });
+    }
+
+    fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
+        if (this.delivered) {
+            return Promise.resolve({ references: [], bookmark });
+        }
+        this.delivered = true;
+        return Promise.resolve({
+            references: this.envelopes.map(e => ({ type: e.fact.type, hash: e.fact.hash })),
+            bookmark: "1"
+        });
+    }
+
+    streamFeed(): () => void {
+        return () => { };
+    }
+
+    load(): Promise<FactEnvelope[]> {
+        return Promise.resolve(this.envelopes);
+    }
+
+    intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+        return Promise.resolve([{ start, specification }]);
+    }
+}
+
+/** Race a promise against a deadline. Always clears the timer. */
+function raceDeadline<T>(promise: Promise<T>, ms: number): Promise<"settled" | "timed-out"> {
+    let timer: ReturnType<typeof setTimeout>;
+    return Promise.race([
+        promise.then(() => "settled" as const, () => "settled" as const),
+        new Promise<"timed-out">(resolve => { timer = setTimeout(() => resolve("timed-out"), ms); })
+    ]).finally(() => clearTimeout(timer!));
+}
+
+const managersInOffice = model.given(Office).match((office, facts) =>
+    facts.ofType(Manager)
+        .join(manager => manager.office, office)
+).specification;
+
+/**
+ * The re-entrant cycle reported in issue #246: `processFeed` parks on
+ * `LoadBatch.completed`, the batch awaits `notifyFactsAdded`, and a listener
+ * dispatched from that notification queries a specification resolving to the
+ * same feed. It joins `activeFeeds` and waits on a promise that cannot resolve
+ * until the listener returns.
+ *
+ * Nothing here detects that cycle. The listener timeout breaks it: the wait on
+ * the callback is abandoned, the notification concludes, the batch resolves,
+ * and the inner query completes on the way out. The cost is one stall bounded
+ * by `listenerTimeoutMs`, which is what makes this recoverable instead of
+ * permanent.
+ */
+describe("a listener that queries while its own feed is loading (issue #246)", () => {
+    let tracer: CountingTracer;
+
+    beforeEach(() => {
+        tracer = new CountingTracer();
+        Trace.configure(tracer);
+    });
+
+    afterEach(() => {
+        Trace.off();
+    });
+
+    it("does not deadlock against the in-flight feed", async () => {
+        const creator = new User("--- PUBLIC KEY GOES HERE ---");
+        const company = new Company(creator, "TestCo");
+        const office = new Office(company, "TestOffice");
+        const manager = new Manager(office, 42);
+
+        const dehydration = new Dehydration();
+        const officeReference = dehydration.dehydrate(office);
+        dehydration.dehydrate(manager);
+        const envelopes = dehydration.factRecords().map(fact => <FactEnvelope>{ fact, signatures: [] });
+
+        const store = new MemoryStore();
+        // Short enough to keep the test quick, long enough that the stall is
+        // unambiguously the timeout firing rather than incidental scheduling.
+        const listenerTimeoutMs = 300;
+        const observableSource = new ObservableSource(store, { listenerTimeoutMs });
+        const network = new OneShotFeedNetwork(envelopes);
+        const factManager = new FactManager(new PassThroughFork(store), observableSource, store, network, []);
+
+        let innerSettled = false;
+        let innerError: unknown;
+        factManager.addSpecificationListener(managersInOffice, async () => {
+            // A re-entrant query from inside the notification, the shape the
+            // issue reports: subscribe, then read before writing a completion
+            // fact. It joins activeFeeds["feed-1"], whose processFeed is parked
+            // on a batch that is awaiting this very callback.
+            try {
+                await factManager.fetch([officeReference], managersInOffice);
+            }
+            catch (e) {
+                innerError = e;
+            }
+            finally {
+                innerSettled = true;
+            }
+        });
+
+        // Before the fix neither of these ever settles.
+        const start = Date.now();
+        await expect(raceDeadline(factManager.fetch([officeReference], managersInOffice), 5000))
+            .resolves.toBe("settled");
+        const elapsed = Date.now() - start;
+        await waitForCondition(() => innerSettled, 2000);
+
+        expect(innerError).toBeUndefined();
+        // The cycle is broken by abandoning the wait on the callback, so the
+        // outer fetch settles at roughly the bound rather than never.
+        expect(tracer.counters["observable_listener_timed_out"]).toBeGreaterThan(0);
+        expect(elapsed).toBeGreaterThanOrEqual(listenerTimeoutMs - 50);
+
+        // The re-entrant read saw the facts the outer load had already saved.
+        const results = await factManager.read([officeReference], managersInOffice);
+        expect(results.length).toBe(1);
+    }, 15000);
+});

--- a/test/util/promiseSpec.ts
+++ b/test/util/promiseSpec.ts
@@ -1,3 +1,4 @@
+import { NoOpTracer, Trace, Tracer } from "@src";
 import { LateSettle, TIMED_OUT, withTimeout } from "../../src/util/promise";
 
 describe("withTimeout", () => {
@@ -60,6 +61,35 @@ describe("withTimeout", () => {
             expect(unhandled).toEqual([]);
         }
         finally {
+            process.off("unhandledRejection", onUnhandled);
+        }
+    });
+
+    it("contains a reporter that throws", async () => {
+        // `onLateSettle` runs in a `then` handler on a promise nobody holds, so
+        // a throw there has no caller to catch it. The reporters this exists
+        // for end in a consumer-supplied Tracer, which is exactly the code the
+        // timeout is here to contain.
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => unhandled.push(reason);
+        process.on("unhandledRejection", onUnhandled);
+        const reported: unknown[] = [];
+        Trace.configure(new class extends NoOpTracer implements Tracer {
+            error(error: any): void { reported.push(error); }
+        }());
+
+        try {
+            const slow = new Promise<void>(resolve => setTimeout(resolve, 60));
+            await expect(withTimeout(slow, 20, () => { throw new Error("reporter blew up"); }))
+                .resolves.toBe(TIMED_OUT);
+            await slow;
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            expect(unhandled).toEqual([]);
+            expect(reported.map(String)).toEqual(["Error: reporter blew up"]);
+        }
+        finally {
+            Trace.off();
             process.off("unhandledRejection", onUnhandled);
         }
     });

--- a/test/util/promiseSpec.ts
+++ b/test/util/promiseSpec.ts
@@ -1,0 +1,86 @@
+import { LateSettle, TIMED_OUT, withTimeout } from "../../src/util/promise";
+
+describe("withTimeout", () => {
+    it("resolves with the value when the promise settles first", async () => {
+        await expect(withTimeout(Promise.resolve("value"), 1000)).resolves.toBe("value");
+    });
+
+    it("propagates a rejection that arrives before the deadline", async () => {
+        await expect(withTimeout(Promise.reject(new Error("boom")), 1000)).rejects.toThrow("boom");
+    });
+
+    it("resolves with TIMED_OUT when the deadline passes first", async () => {
+        await expect(withTimeout(new Promise<void>(() => { }), 50)).resolves.toBe(TIMED_OUT);
+    });
+
+    it("returns the promise untouched when the bound is disabled", async () => {
+        const promise = Promise.resolve("value");
+        expect(withTimeout(promise, 0)).toBe(promise);
+        expect(withTimeout(promise, -1)).toBe(promise);
+        expect(withTimeout(promise, Number.POSITIVE_INFINITY)).toBe(promise);
+    });
+
+    it("reports a late completion", async () => {
+        const late: LateSettle[] = [];
+        const slow = new Promise<string>(resolve => setTimeout(() => resolve("late"), 100));
+
+        await expect(withTimeout(slow, 20, l => late.push(l))).resolves.toBe(TIMED_OUT);
+        await slow;
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(late.length).toBe(1);
+        expect("error" in late[0]).toBe(false);
+        expect(late[0].elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("reports a late rejection, including one whose reason is undefined", async () => {
+        // Classification keys on the property being present rather than on its
+        // value, so `reject(undefined)` is not mistaken for a completion.
+        const late: LateSettle[] = [];
+        const slow = new Promise<void>((_, reject) => setTimeout(() => reject(undefined), 100));
+
+        await expect(withTimeout(slow, 20, l => late.push(l))).resolves.toBe(TIMED_OUT);
+        await slow.catch(() => { });
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(late.length).toBe(1);
+        expect("error" in late[0]).toBe(true);
+        expect(late[0].error).toBeUndefined();
+    });
+
+    it("does not leave a late rejection unhandled", async () => {
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => unhandled.push(reason);
+        process.on("unhandledRejection", onUnhandled);
+
+        try {
+            const slow = new Promise<void>((_, reject) => setTimeout(() => reject(new Error("late")), 60));
+            await expect(withTimeout(slow, 20)).resolves.toBe(TIMED_OUT);
+            await new Promise(resolve => setTimeout(resolve, 120));
+            expect(unhandled).toEqual([]);
+        }
+        finally {
+            process.off("unhandledRejection", onUnhandled);
+        }
+    });
+
+    it("clears its timer once the promise settles", async () => {
+        // A pending timer would keep the event loop alive well past the await,
+        // which is what makes a long default bound safe to use everywhere.
+        // `getActiveResourcesInfo` landed in Node 17; older runtimes just skip
+        // the assertion rather than failing the suite.
+        const activeTimeouts = () => {
+            const info = (process as any).getActiveResourcesInfo;
+            return typeof info === "function"
+                ? (info.call(process) as string[]).filter(r => r === "Timeout").length
+                : undefined;
+        };
+        const before = activeTimeouts();
+        await withTimeout(Promise.resolve("value"), 60000);
+        const after = activeTimeouts();
+
+        if (before !== undefined && after !== undefined) {
+            expect(after).toBeLessThanOrEqual(before);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #246.

`ObservableSource.notify()` is on the critical path of every write, and `notifyFactSaved` awaited each listener's `onResult` with no timeout, guarded only against throws. A consumer callback returning a promise that never settles blocked that listener, every listener behind it, the enclosing `notify()`, the `save()` that triggered it, and every `query()` whose load path saves that fact type. Nothing rejected, so retry wrappers never fired. That is the 13-minute outage on 2026-08-26.

## What this does

- **`withTimeout`** (`src/util/promise.ts`) — bounded wait that resolves with `TIMED_OUT` rather than hanging. Timer always cleared; an early rejection passes through unchanged; a late settle is reported and cannot escape as an unhandled rejection; `0` opts out.
- **Bound each `onResult`** at `DEFAULT_LISTENER_TIMEOUT_MS` (30s), configurable through `JinagaBrowserConfig.listenerTimeoutMs` and `JinagaTestConfig.listenerTimeoutMs`.
- **Dispatch listeners on one specification concurrently**, so a slow peer no longer delays its siblings.
- **Paired counters** — `started` / `completed` / `timed_out` / `failed` / `late_settled` — so an unbalanced pair is a live signal instead of a trace-line count after the fact (issue point 4).
- **Warn on re-entrancy**, keyed on a notification entering while a listener is mid-dispatch.

## The re-entrant cycle is fixed by the bound, not by detecting it

`LoadBatch.load` awaits `notifyFactsAdded` before resolving `completed`, and `processFeed` parks on that promise while holding the feed in `activeFeeds`. A listener that queries a specification sharing that feed joins `activeFeeds` and waits on a promise that cannot resolve until the listener returns. Abandoning the wait on the callback concludes the notification, resolves the batch, and lets the inner query complete on the way out — the cycle costs one bounded stall instead of a dead client. `test/observable/reentrantNotificationSpec.ts` pins that.

An earlier revision also declined to join an in-flight feed while a listener was running, to cut that stall to zero. **That is deliberately not here.** The guard cannot be scoped to the re-entrant caller without async context propagation the browser target rules out, so it also fires for an ordinary concurrent caller — which then reads a partially loaded feed and returns a short result set with no error. Measured on a two-page feed with one healthy 300ms listener and a second `fetch` issued from outside every listener: 1 fact instead of 2. Trading a loud hang for a silent under-read is the wrong direction for a data layer, and the timeout restores liveness on its own. `test/managers/concurrentFeedJoinSpec.ts` pins the behavior that must hold.

## Known limits, recorded in the code

- Once a listener exceeds the bound, `fact()` resolves without waiting for it. The callback is **not** skipped — it was already entered and still completes later — but `fact()` no longer implies it finished, and `processed()` on the affected observer may never settle. Noted on `Observer.processed()`.
- The fan-out is within a spec group; the loop over spec groups stays serial, so a fact type with K wedged groups costs K timeouts rather than one. Noted on the public option. Hoisting the `Promise.all` to that loop would be sound but is out of scope here.

## Follow-ups worth their own issues

1. Precise re-entrancy detection via injected `AsyncLocalStorage` — available in Node, which is where the incident happened and where the concurrency that defeats a global flag is highest.
2. Decouple notification from `fetch` completion: resolve `LoadBatch.completed` after `store.save` and run `notifyFactsAdded` on a serial queue `processFeed` does not await. The cycle then cannot form at all.

## Verification

`npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.test.json` clean. `jest`: **623 passing** (main: 603).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAxeLAJZgujNxoaddPfhkm