### PR TITLE
Reject a match that no query can start from

### DIFF
--- a/src/authorization/authorizationRules.ts
+++ b/src/authorization/authorizationRules.ts
@@ -5,6 +5,7 @@ import { describeSpecification } from '../specification/description';
 import { FactConstructor, FactRepository, LabelOf, Model, Traversal, getPayload } from '../specification/model';
 import { Condition, Label, Match, PathCondition, Specification, splitBeforeFirstSuccessor } from '../specification/specification';
 import { SpecificationParser } from '../specification/specification-parser';
+import { validateSpecificationOrThrow } from '../specification/specification-validation';
 import { FactEnvelope, FactRecord, FactReference, ReferencesByName, Storage, factReferenceEquals } from '../storage';
 import { distinct, filterAsync, flatten, flattenAsync } from '../util/fn';
 import { Trace } from '../util/trace';
@@ -224,7 +225,11 @@ export class AuthorizationRuleNone implements AuthorizationRule {
 export class AuthorizationRuleSpecification implements AuthorizationRule {
     constructor(
         private specification: Specification
-    ) { }
+    ) {
+        // A rule is stored once and run on every save of the type it governs.
+        // Refuse a specification that could never run, at the point it is written.
+        validateSpecificationOrThrow(specification, "The specification of an authorization rule");
+    }
 
     describe(type: string): string {
         const description = describeSpecification(this.specification, 1);

--- a/src/distribution/distribution-rules.ts
+++ b/src/distribution/distribution-rules.ts
@@ -3,7 +3,9 @@ import { describeSpecification } from "../specification/description";
 import { buildFeeds } from "../specification/feed-builder";
 import { SpecificationOf } from "../specification/model";
 import { Specification } from "../specification/specification";
+import { skeletonOfSpecification } from "../specification/skeleton";
 import { SpecificationParser } from "../specification/specification-parser";
+import { validateSpecificationOrThrow } from "../specification/specification-validation";
 
 interface DistributionRule {
   specification: Specification;
@@ -18,25 +20,11 @@ class ShareTarget<T, U> {
   ) { }
 
   with(user: SpecificationOf<T, User>): DistributionRules {
-    return new DistributionRules([
-      ...this.rules,
-      {
-        specification: this.specification,
-        feeds: buildFeeds(this.specification),
-        user: user.specification
-      }
-    ]);
+    return DistributionRules.combine(new DistributionRules(this.rules), this.specification, user.specification);
   }
 
   withEveryone(): DistributionRules {
-    return new DistributionRules([
-      ...this.rules,
-      {
-        specification: this.specification,
-        feeds: buildFeeds(this.specification),
-        user: null
-      }
-    ]);
+    return DistributionRules.combine(new DistributionRules(this.rules), this.specification, null);
   }
 }
 
@@ -78,8 +66,8 @@ export class DistributionRules {
       ...distributionRules.rules,
       {
         specification,
-        feeds: buildFeeds(specification),
-        user
+        feeds: buildFeedsOfRule(specification),
+        user: validatedUserSpecification(user)
       }
     ]);
   }
@@ -98,6 +86,39 @@ export class DistributionRules {
     }
     return distributionRules;
   }
+}
+
+/**
+ * Build the feeds of a distribution rule, refusing a specification that cannot
+ * produce them.
+ *
+ * A rule enters a set that lives as long as the process does, and
+ * `canAuthorizeByComposition` builds the skeleton of *every* rule's feeds each
+ * time it authorizes a query. One rule that cannot be built therefore fails
+ * authorization for queries that have nothing to do with it, so the rule is
+ * rejected here, where the specification that carries the defect can still be
+ * named.
+ */
+function buildFeedsOfRule(specification: Specification): Specification[] {
+  validateSpecificationOrThrow(specification, "The specification of a distribution rule");
+  const feeds = buildFeeds(specification);
+  for (const feed of feeds) {
+    try {
+      skeletonOfSpecification(feed);
+    }
+    catch (error) {
+      const message = error instanceof Error ? error.message : `${error}`;
+      throw new Error(`A feed of a distribution rule could not be built. ${message}\n${describeSpecification(specification, 1)}`);
+    }
+  }
+  return feeds;
+}
+
+function validatedUserSpecification(user: Specification | null): Specification | null {
+  if (user) {
+    validateSpecificationOrThrow(user, "The user specification of a distribution rule");
+  }
+  return user;
 }
 
 export function describeDistributionRules(rules: (r: DistributionRules) => DistributionRules): string {

--- a/src/distribution/distribution-rules.ts
+++ b/src/distribution/distribution-rules.ts
@@ -117,6 +117,13 @@ function buildFeedsOfRule(specification: Specification): Specification[] {
 function validatedUserSpecification(user: Specification | null): Specification | null {
   if (user) {
     validateSpecificationOrThrow(user, "The user specification of a distribution rule");
+    // `DistributionEngine.canDistributeTo` reads the principal out of this
+    // projection, and throws while distributing if it is anything else. A rule
+    // that projects a composite could never authorize anyone, so refuse it here
+    // instead.
+    if (user.projection.type !== "fact") {
+      throw new Error(`The user specification of a distribution rule must project a single fact, not a ${user.projection.type}.\n${describeSpecification(user, 1)}`);
+    }
   }
   return user;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export { buildModel, FactRepository, LabelOf, Model, ModelBuilder, ProjectionOf,
 export { EdgeDescription, emptySkeleton, FactDescription, InputDescription, NotExistsConditionDescription, OutputDescription, Skeleton, skeletonOfSpecification } from './specification/skeleton';
 export { ComponentProjection, CompositeProjection, Condition, emptySpecification, ExistentialCondition, FactProjection, FieldProjection, getAllFactTypes, getAllRoles, HashProjection, isExistentialCondition, isPathCondition, Label, Match, NamedComponentProjection, PathCondition, Projection, reduceSpecification, Role, SingularProjection, Specification, SpecificationGiven, specificationIsDeterministic, specificationIsIdentity, specificationIsNotDeterministic, SpecificationProjection, splitBeforeFirstSuccessor, TimeProjection } from './specification/specification';
 export { Invalid, SpecificationParser } from './specification/specification-parser';
+export { validateSpecification, validateSpecificationOrThrow } from './specification/specification-validation';
 export { detectDisconnectedSpecification, DisconnectedSpecificationError } from "./specification/UnionFind";
 export { computeTupleSubsetHash, FactEnvelope, factEnvelopeEquals, FactFeed, FactRecord, FactReference, factReferenceEquals, FactSignature, FactTuple, PredecessorCollection, ProjectedResult, Queue, ReferencesByName, Storage, uniqueFactReferences, validateGiven } from './storage';
 export { UserIdentity } from './user-identity';

--- a/src/specification/specification-parser.ts
+++ b/src/specification/specification-parser.ts
@@ -5,6 +5,7 @@ import { PurgeConditions } from "../purge/purgeConditions";
 import { PredecessorCollection } from "../storage";
 import { Declaration, DeclaredFact } from "./declaration";
 import { Condition, ExistentialCondition, SpecificationGiven, Label, Match, NamedComponentProjection, PathCondition, Projection, Role, Specification } from "./specification";
+import { matchStructureError } from "./specification-validation";
 
 type FieldValue = string | number | boolean;
 
@@ -233,7 +234,12 @@ export class SpecificationParser {
         while (!this.consume("]")) {
             conditions.push(this.parseCondition(unknown, labels));
         }
-        return { unknown, conditions };
+        const match = { unknown, conditions };
+        const error = matchStructureError(match);
+        if (error) {
+            throw new Invalid(error);
+        }
+        return match;
     }
 
     parseMatches(labels: Label[]): { matches: Match[], labels: Label[] } {

--- a/src/specification/specification-validation.ts
+++ b/src/specification/specification-validation.ts
@@ -1,17 +1,19 @@
 import { Match, Projection, Specification, isPathCondition } from "./specification";
 
 /**
- * Every match must be *rooted*: its first condition has to be a path condition
- * that joins the unknown to a given or to a label bound by an earlier match.
+ * A match must begin with a path condition. That is the condition that roots the
+ * match: it names the label the unknown is reached from. Whether that label is
+ * actually in scope is a question about the surrounding specification, not about
+ * this match, and is checked where the scope is known --
+ * `SpecificationParser.parsePathCondition` while it reads the text, and
+ * `SpecificationRunner` when it runs.
  *
- * That is not a stylistic rule. Jinaga reaches facts only by walking edges out
+ * Rooting is not a stylistic rule. Jinaga reaches facts only by walking edges out
  * of the facts it was given -- `SpecificationRunner.executeMatch` starts a match
  * by following its first path condition, and `skeletonOfSpecification` registers
- * the unknown while it walks one. There is no "all facts of this type"
- * operation for either of them to fall back on. An existential condition can
- * only filter the candidates a path condition produced; on its own it names no
- * candidates at all, even though `SpecificationParser` is happy to parse a match
- * whose sole condition is one.
+ * the unknown while it walks one. Neither has an "all facts of this type"
+ * operation to fall back on. An existential condition only filters the candidates
+ * a path condition produced, so a match that has none names no candidates at all.
  *
  * @param match The match to inspect.
  * @returns A description of the defect, or null if the match is rooted.
@@ -34,15 +36,18 @@ export function matchStructureError(match: Match): string | null {
 }
 
 /**
- * Collect the structural defects that would keep a specification from being
- * executed or decomposed into feeds.
+ * Collect the unrooted matches of a specification -- in its matches, in the
+ * matches nested in existential conditions, in the conditions on its givens, and
+ * in the matches of its projections.
  *
  * Use this at an authoring boundary -- wherever a specification is accepted from
  * outside and stored -- so that a defect is reported where it was written rather
- * than much later, from deep inside feed generation.
+ * than much later, from deep inside feed generation. It answers one question,
+ * not every question: `detectDisconnectedSpecification` covers connectedness,
+ * which no single match can decide.
  *
  * @param specification The specification to validate.
- * @returns One message per defect, or an empty array if the specification is sound.
+ * @returns One message per unrooted match, or an empty array if every match is rooted.
  */
 export function validateSpecification(specification: Specification): string[] {
     const errors: string[] = [];
@@ -57,7 +62,8 @@ export function validateSpecification(specification: Specification): string[] {
 }
 
 /**
- * Validate a specification, throwing if it has any structural defect.
+ * Validate a specification with {@link validateSpecification}, throwing if any of
+ * its matches is unrooted.
  *
  * @param specification The specification to validate.
  * @param description Names the specification in the error message.

--- a/src/specification/specification-validation.ts
+++ b/src/specification/specification-validation.ts
@@ -1,0 +1,95 @@
+import { Match, Projection, Specification, isPathCondition } from "./specification";
+
+/**
+ * Every match must be *rooted*: its first condition has to be a path condition
+ * that joins the unknown to a given or to a label bound by an earlier match.
+ *
+ * That is not a stylistic rule. Jinaga reaches facts only by walking edges out
+ * of the facts it was given -- `SpecificationRunner.executeMatch` starts a match
+ * by following its first path condition, and `skeletonOfSpecification` registers
+ * the unknown while it walks one. There is no "all facts of this type"
+ * operation for either of them to fall back on. An existential condition can
+ * only filter the candidates a path condition produced; on its own it names no
+ * candidates at all, even though `SpecificationParser` is happy to parse a match
+ * whose sole condition is one.
+ *
+ * @param match The match to inspect.
+ * @returns A description of the defect, or null if the match is rooted.
+ */
+export function matchStructureError(match: Match): string | null {
+    if (match.conditions.length === 0) {
+        return `The match for '${match.unknown.name}' has no conditions. ` +
+            `A match must be joined to a given or a prior label by a path condition.`;
+    }
+    if (!isPathCondition(match.conditions[0])) {
+        if (match.conditions.some(isPathCondition)) {
+            return `The match for '${match.unknown.name}' begins with an existential condition. ` +
+                `A match must begin with a path condition that joins it to a given or a prior label.`;
+        }
+        return `The match for '${match.unknown.name}' has no path condition. ` +
+            `An existential condition can only filter a match, so it cannot be the only condition. ` +
+            `Join '${match.unknown.name}' to a given or a prior label with a path condition.`;
+    }
+    return null;
+}
+
+/**
+ * Collect the structural defects that would keep a specification from being
+ * executed or decomposed into feeds.
+ *
+ * Use this at an authoring boundary -- wherever a specification is accepted from
+ * outside and stored -- so that a defect is reported where it was written rather
+ * than much later, from deep inside feed generation.
+ *
+ * @param specification The specification to validate.
+ * @returns One message per defect, or an empty array if the specification is sound.
+ */
+export function validateSpecification(specification: Specification): string[] {
+    const errors: string[] = [];
+    for (const given of specification.given) {
+        for (const condition of given.conditions) {
+            validateMatches(condition.matches, errors);
+        }
+    }
+    validateMatches(specification.matches, errors);
+    validateProjection(specification.projection, errors);
+    return errors;
+}
+
+/**
+ * Validate a specification, throwing if it has any structural defect.
+ *
+ * @param specification The specification to validate.
+ * @param description Names the specification in the error message.
+ */
+export function validateSpecificationOrThrow(specification: Specification, description: string): void {
+    const errors = validateSpecification(specification);
+    if (errors.length > 0) {
+        throw new Error(`${description} is not valid. ${errors.join(" ")}`);
+    }
+}
+
+function validateMatches(matches: Match[], errors: string[]) {
+    for (const match of matches) {
+        const error = matchStructureError(match);
+        if (error) {
+            errors.push(error);
+        }
+        for (const condition of match.conditions) {
+            if (!isPathCondition(condition)) {
+                validateMatches(condition.matches, errors);
+            }
+        }
+    }
+}
+
+function validateProjection(projection: Projection, errors: string[]) {
+    if (projection.type === "composite") {
+        for (const component of projection.components) {
+            if (component.type === "specification") {
+                validateMatches(component.matches, errors);
+                validateProjection(component.projection, errors);
+            }
+        }
+    }
+}

--- a/test/specification/specificationValidationSpec.ts
+++ b/test/specification/specificationValidationSpec.ts
@@ -1,0 +1,230 @@
+import { DistributionRules, Match, Specification, SpecificationParser, buildFeeds, skeletonOfSpecification, validateSpecification } from "@src";
+import { AuthorizationRuleSpecification } from "../../src/authorization/authorizationRules";
+
+// Issue #226: a match whose only condition is a positive existential parses, but
+// nothing can run it. `SpecificationRunner` starts a match by following its first
+// path condition, and `skeletonOfSpecification` registers the match's label while
+// it walks one, so a match with no path condition names no facts at all. The
+// defect used to survive parsing and feed building, and only surfaced as
+// "Label workspace not found" from deep inside skeleton building -- in
+// `DistributionRules`' case, from a rule unrelated to the query being authorized.
+
+function parse(text: string): Specification {
+    const parser = new SpecificationParser(text);
+    parser.skipWhitespace();
+    return parser.parseSpecification();
+}
+
+const existentialOnlyMatch = `(user: Some.User) {
+    workspace: Some.Workspace [
+        E {
+            admin: Some.Administrator [
+                admin->user: Some.User = user
+                admin->workspace: Some.Workspace = workspace
+            ]
+        }
+    ]
+} => {
+    name = workspace.name
+}`;
+
+// The same intent, written as a traversal: reach the administrators of the user,
+// then take the workspace each one names as its predecessor.
+const traversal = `(user: Some.User) {
+    admin: Some.Administrator [
+        admin->user: Some.User = user
+    ]
+    workspace: Some.Workspace [
+        workspace = admin->workspace: Some.Workspace
+    ]
+} => {
+    name = workspace.name
+}`;
+
+// Built by hand rather than parsed, standing in for a specification that a
+// downstream authoring tool composed without going through the parser.
+const workspaceMatch: Match = {
+    unknown: { name: "workspace", type: "Some.Workspace" },
+    conditions: [
+        {
+            type: "existential",
+            exists: true,
+            matches: [
+                {
+                    unknown: { name: "admin", type: "Some.Administrator" },
+                    conditions: [
+                        {
+                            type: "path",
+                            rolesLeft: [{ name: "user", predecessorType: "Some.User" }],
+                            labelRight: "user",
+                            rolesRight: []
+                        },
+                        {
+                            type: "path",
+                            rolesLeft: [{ name: "workspace", predecessorType: "Some.Workspace" }],
+                            labelRight: "workspace",
+                            rolesRight: []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+const unbuildableSpecification: Specification = {
+    given: [{ label: { name: "user", type: "Some.User" }, conditions: [] }],
+    matches: [workspaceMatch],
+    projection: { type: "fact", label: "workspace" }
+};
+
+describe("specification validation", () => {
+    it("rejects a match whose only condition is an existential", () => {
+        expect(() => parse(existentialOnlyMatch))
+            .toThrow(/The match for 'workspace' has no path condition/);
+    });
+
+    it("rejects a match that begins with an existential condition", () => {
+        expect(() => parse(`(user: Some.User) {
+            workspace: Some.Workspace [
+                E {
+                    admin: Some.Administrator [
+                        admin->user: Some.User = user
+                        admin->workspace: Some.Workspace = workspace
+                    ]
+                }
+                workspace->creator: Some.User = user
+            ]
+        }`)).toThrow(/The match for 'workspace' begins with an existential condition/);
+    });
+
+    it("rejects an unrooted match nested in an existential condition", () => {
+        expect(() => parse(`(user: Some.User) {
+            admin: Some.Administrator [
+                admin->user: Some.User = user
+                E {
+                    workspace: Some.Workspace [
+                        E {
+                            other: Some.Administrator [
+                                other->workspace: Some.Workspace = workspace
+                                other->user: Some.User = user
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }`)).toThrow(/The match for 'workspace' has no path condition/);
+    });
+
+    it("accepts the traversal that expresses the same intent", () => {
+        const specification = parse(traversal);
+
+        expect(validateSpecification(specification)).toEqual([]);
+        for (const feed of buildFeeds(specification)) {
+            expect(() => skeletonOfSpecification(feed)).not.toThrow();
+        }
+    });
+
+    it("reports the defect in a specification that did not come from the parser", () => {
+        const errors = validateSpecification(unbuildableSpecification);
+
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toMatch(/The match for 'workspace' has no path condition/);
+    });
+
+    it("reports the defect in a match of a projection", () => {
+        const errors = validateSpecification({
+            given: [{ label: { name: "user", type: "Some.User" }, conditions: [] }],
+            matches: [
+                {
+                    unknown: { name: "admin", type: "Some.Administrator" },
+                    conditions: [
+                        {
+                            type: "path",
+                            rolesLeft: [{ name: "user", predecessorType: "Some.User" }],
+                            labelRight: "user",
+                            rolesRight: []
+                        }
+                    ]
+                }
+            ],
+            projection: {
+                type: "composite",
+                components: [
+                    {
+                        type: "specification",
+                        name: "workspaces",
+                        matches: [workspaceMatch],
+                        projection: { type: "fact", label: "workspace" }
+                    }
+                ]
+            }
+        });
+
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toMatch(/The match for 'workspace' has no path condition/);
+    });
+
+    it("finds nothing wrong with a sound specification", () => {
+        expect(validateSpecification(parse(`(user: Some.User) {
+            admin: Some.Administrator [
+                admin->user: Some.User = user
+                !E {
+                    revoked: Some.Administrator.Revoked [
+                        revoked->admin: Some.Administrator = admin
+                    ]
+                }
+            ]
+        }`))).toEqual([]);
+    });
+
+    it("would have built the skeleton of the feed, had the specification been sound", () => {
+        // The shape of the failure this validation prevents. `buildFeeds` flattens
+        // the positive existential, leaving a `workspace` match with no conditions
+        // at all, which skeleton building cannot root.
+        const feeds = buildFeeds(unbuildableSpecification);
+
+        expect(feeds.length).toBeGreaterThan(0);
+        expect(() => feeds.forEach(feed => skeletonOfSpecification(feed)))
+            .toThrow("Label workspace not found. Known labels: user, admin");
+    });
+});
+
+describe("rules that carry a specification", () => {
+    it("refuses to load a distribution rule that cannot be built", () => {
+        // The rule from the issue: it was accepted at load time, and every
+        // subsequent authorization -- including of queries that had nothing to do
+        // with this rule -- threw from `canAuthorizeByComposition`.
+        expect(() => DistributionRules.combine(DistributionRules.empty, unbuildableSpecification, null))
+            .toThrow(/The specification of a distribution rule is not valid\. The match for 'workspace' has no path condition/);
+    });
+
+    it("refuses to load a distribution rule whose user specification cannot be built", () => {
+        expect(() => DistributionRules.combine(DistributionRules.empty, parse(traversal), unbuildableSpecification))
+            .toThrow(/The user specification of a distribution rule is not valid/);
+    });
+
+    it("refuses to load a distribution policy that contains one", () => {
+        expect(() => DistributionRules.loadFromDescription(`distribution {
+            share ${existentialOnlyMatch}
+            with everyone
+        }`)).toThrow(/The match for 'workspace' has no path condition/);
+    });
+
+    it("still loads a sound distribution policy", () => {
+        const rules = DistributionRules.loadFromDescription(`distribution {
+            share ${traversal}
+            with everyone
+        }`);
+
+        expect(rules.rules.length).toBe(1);
+        for (const feed of rules.rules[0].feeds) {
+            expect(() => skeletonOfSpecification(feed)).not.toThrow();
+        }
+    });
+
+    it("refuses to build an authorization rule that cannot be run", () => {
+        expect(() => new AuthorizationRuleSpecification(unbuildableSpecification))
+            .toThrow(/The specification of an authorization rule is not valid/);
+    });
+});

--- a/test/specification/specificationValidationSpec.ts
+++ b/test/specification/specificationValidationSpec.ts
@@ -223,6 +223,24 @@ describe("rules that carry a specification", () => {
         }
     });
 
+    it("refuses a distribution rule whose user specification projects a composite", () => {
+        // `DistributionEngine.canDistributeTo` reads the principal out of a fact
+        // projection, and throws while distributing if the rule projects anything
+        // else -- the same deferred failure, one step further on.
+        const composite: Specification = {
+            ...parse(traversal),
+            projection: {
+                type: "composite",
+                components: [
+                    { type: "fact", name: "workspace", label: "workspace" }
+                ]
+            }
+        };
+
+        expect(() => DistributionRules.combine(DistributionRules.empty, parse(traversal), composite))
+            .toThrow(/must project a single fact, not a composite/);
+    });
+
     it("refuses to build an authorization rule that cannot be run", () => {
         expect(() => new AuthorizationRuleSpecification(unbuildableSpecification))
             .toThrow(/The specification of an authorization rule is not valid/);


### PR DESCRIPTION
Fixes #226

## The judgment call first

The issue asks, implicitly, whether a match whose only condition is a positive existential is *unbuildable* or merely *unsupported by the skeleton builder*. If it were representable, the right fix would be to register the label in `skeletonOfSpecification` independently of path conditions. It is not representable, and the code says so in three places:

1. **`SpecificationRunner.executeMatch`** (`src/specification/specification-runner.ts:81`) throws `A match must have at least one condition.` and `The first condition must be a path condition.` A match is *started* by following its first path condition. The in-memory and IndexedDB stores share this runner, so even if skeleton building were taught to accept the shape, `query()` and `watch()` would still refuse it — a specification that works over `/feeds` but throws in the client is worse than one rejected up front.
2. **`FactSource`** offers only `findFact`, `getPredecessors`, `getSuccessors`. There is no "all facts of this type" operation for either the runner or the skeleton to fall back on. "All workspaces, filtered by the existence of an admin" needs one: an existential condition filters candidates that a path condition produced, so on its own it names none.
3. **`buildFeeds` produces a feed the parser itself rejects.** The positive existential is flattened inline, so the feed of the issue's specification is

   ```
   (user: Some.User) {
       workspace: Some.Workspace [
       ]
       admin: Some.Administrator [
           admin->user: Some.User = user
           admin->workspace: Some.Workspace = workspace
       ]
   }
   ```

   `parseMatch` has always rejected a match with no conditions (`The match for 'workspace' has no conditions`). The existential-only match is the same defect wearing a condition that cannot root it.

So the fix is validation, as the issue proposed, not a change to label registration. The intent is expressible today as a traversal, which builds fine:

```
(user: Some.User) {
    admin: Some.Administrator [ admin->user: Some.User = user ]
    workspace: Some.Workspace [ workspace = admin->workspace: Some.Workspace ]
}
```

## Root cause

`addPathCondition` registers a match's unknown into `knownFacts` only while walking one of that match's *own* path conditions. A match with none never registers, so the nested `admin->workspace: Some.Workspace = workspace` threw `Label workspace not found. Known labels: user, admin` — deep inside `skeletonOfSpecification`, long after the specification was written and stored. In `DistributionRules`' case, `canAuthorizeByComposition` builds the skeleton of *every* loaded rule's feeds, so one malformed rule aborted authorization for every query.

This is not under-registration in general: registration through path conditions is complete precisely *because* every match must be rooted by one. The invariant was simply never enforced.

## What changed

- **`src/specification/specification-validation.ts`** (new). `matchStructureError(match)` holds the rule; `validateSpecification(spec): string[]` walks matches, matches nested in existential conditions, conditions on givens, and projection specifications; `validateSpecificationOrThrow(spec, description)` is the throwing form. Exported from the package index, so a downstream authoring tool no longer has to rediscover `buildFeeds` + `skeletonOfSpecification` (issue item 2).
- **`SpecificationParser.parseMatch`** rejects the shape as it reads it, next to the existing check for a match with no conditions (issue item 3). This is a match-local rule, like the parser's existing `The label 'x' has not been defined` and `The existential condition must be based on the unknown 'x'`; whole-graph properties stay where they are — `detectDisconnectedSpecification` is still called from `jinaga.ts` and `inverse.ts`, not from the parser.
- **`DistributionRules.combine`** validates the rule's specification and its user specification, and confirms every feed it stores can be built into a skeleton, naming the offending rule (issue item 1). `ShareTarget.with` / `.withEveryone` now route through `combine`, so the fluent API is held to the same standard instead of duplicating `buildFeeds`.
- **`AuthorizationRuleSpecification`** validates in its constructor — the analogous deferred failure, since an authorization rule is stored once and run on every save of the type it governs. All three construction sites (parser and the two model-builder paths) go through it.

Second commit, from review: the validation doc no longer claims to check label scope (it cannot, from one match), and `DistributionRules` also refuses a user specification that does not project a fact — `DistributionEngine.canDistributeTo` reads the principal out of that projection and throws while distributing otherwise, which is this same deferred failure one step further on.

## Test evidence

`test/specification/specificationValidationSpec.ts` — 14 tests.

Before (the fix reverted; the new module present but nothing calling it, so the `validateSpecification` unit tests can still compile and run):

```
✕ rejects a match whose only condition is an existential
✕ rejects a match that begins with an existential condition
✕ rejects an unrooted match nested in an existential condition
✓ accepts the traversal that expresses the same intent
✓ reports the defect in a specification that did not come from the parser
✓ reports the defect in a match of a projection
✓ finds nothing wrong with a sound specification
✓ would have built the skeleton of the feed, had the specification been sound
✕ refuses to load a distribution rule that cannot be built
✕ refuses to load a distribution rule whose user specification cannot be built
✕ refuses to load a distribution policy that contains one
✓ still loads a sound distribution policy
✕ refuses to build an authorization rule that cannot be run
Tests: 7 failed, 6 passed, 13 total
```

After: all pass, plus the user-projection test the second commit added. Full suite `npm run build && npm test`: **636 passing** (622 before, all of which still pass — the stricter parser rejects nothing the repository already relies on).

One test asserts the original failure still happens if you bypass validation (`would have built the skeleton of the feed…` expects `Label workspace not found. Known labels: user, admin`), so the regression stays pinned to its cause rather than to the error message the validation now produces.

## Deliberately out of scope

- **#242 / #241.** Issue #242's comment reports `Label u4 not found. Known labels: p1, u1, u2, u3` from the `/feeds` decomposition of a composite `.select()`. That is a different cause: `buildFeeds` emitted a feed whose path condition named a label the feed does not bind (D2 in `nestedNotExistsFeedSpec.ts`, already fixed on `main`). It is not under-registration in `skeleton.ts`, and nothing here touches it. The feed-skeleton check added to `DistributionRules.combine` would surface that *class* of feed-builder defect at load time rather than during authorization, but it does not prevent one.
- **Validating generated feeds for well-orderedness.** `expectWellOrdered` in the test helpers checks a stronger property (every referenced label bound by the given or an earlier match) that is really a check on `buildFeeds` output rather than on authored specifications. Wiring it into `validateSpecification` would mix "the author wrote this wrong" with "the feed builder generated this wrong", so it stays in the tests.
- **`AuthorizationRuleSpecification`'s projection guard.** `isAuthorized` throws if the projection is not a single fact, the same shape as the distribution user projection now rejected at load. Moving it to construction time would change when an app's model fails to build, so it is worth deciding separately.
- **A typed error class.** `validateSpecificationOrThrow` throws a plain `Error`; the parser path throws `Invalid`, as it does for every other structural defect. If you would rather have a `SpecificationValidationError` alongside `DisconnectedSpecificationError`, say so and I will add it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3FdgDHMo1AuDMGAVX2jFF)_