### PR TITLE
Record the night-shift protocol for ready-labelled issues

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm ci)",
+      "Bash(npm run build)",
+      "Bash(npm test)",
+      "Bash(npx tsc --noEmit --project tsconfig.test.json)",
+      "Bash(./scripts/register-stack.sh:*)",
+      "mcp__github__get_me",
+      "mcp__github__issue_read",
+      "mcp__github__list_issues",
+      "mcp__github__search_issues",
+      "mcp__github__get_label",
+      "mcp__github__list_pull_requests",
+      "mcp__github__search_pull_requests",
+      "mcp__github__pull_request_read",
+      "mcp__github__list_branches",
+      "mcp__github__list_commits",
+      "mcp__github__get_commit",
+      "mcp__github__get_file_contents",
+      "mcp__github__get_check_run",
+      "mcp__github__get_job_logs",
+      "mcp__github__actions_list",
+      "mcp__github__actions_get",
+      "mcp__github__search_code",
+      "mcp__Claude_Code_Remote__get_session",
+      "mcp__Claude_Code_Remote__list_sessions",
+      "mcp__Claude_Code_Remote__list_environments",
+      "mcp__Claude_Code_Remote__list_repos",
+      "mcp__Claude_Code_Remote__list_triggers"
+    ]
+  }
+}

--- a/.claude/skills/night-shift/SKILL.md
+++ b/.claude/skills/night-shift/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: night-shift
+description: Work the queue of GitHub issues labelled `ready` in jinaga/jinaga.js, unattended. Use when sweeping for ready issues, deciding which are actually available to work, ordering them, opening a fix as a stacked pull request, or recording a blocking question instead of guessing. Covers the claim rule, the stacked-PR registration step, and the stop condition for PR monitoring.
+---
+
+# Night shift: working `ready` issues
+
+This is the protocol for automated work on `jinaga/jinaga.js`. It exists so a scheduled agent can pick up work at night without a person watching, and so two agents never work the same issue twice.
+
+Read `CLAUDE.md` first for build commands, subsystem layout, and testing rules.
+
+## 1. Find the queue
+
+Issues labelled `ready` are the queue. Nothing else is in scope. Do not pick up unlabelled issues, and do not add the `ready` label to anything yourself.
+
+## 2. Decide what is actually available: artifacts are the state
+
+The `ready` label alone does not mean an issue is available. Labels go stale, because closing a pull request does not remove them. **The work artifacts are the source of truth, and you check them in this order.**
+
+For each `ready` issue, search pull requests that reference it (by `#<number>` in the title or body, and by branch names matching `claude/issue-<number>-*`):
+
+| What you find | What it means | What to do |
+|---|---|---|
+| An **open** pull request | Someone is already working it | Skip. Do not start a second session on it. |
+| A **merged** pull request | A fix already landed | **Do not re-fix.** Verify whether the issue actually survives on current `main`. See below. |
+| A **closed, unmerged** pull request | An attempt was abandoned | Read it before starting. It usually records why. |
+| An unmerged branch on `origin` with no pull request | Work in progress, or abandoned | Read the branch. Build on it rather than starting over. |
+| Nothing | Genuinely available | Work it. |
+
+This has already caught a real case. Issue #242 carried `ready` for six days after PR #244 fixed it and merged, because merging did not clear the label. An agent trusting the label alone would have rebuilt a fix that already shipped.
+
+### When a merged pull request exists
+
+Your job changes from *fix* to *verify*, and that is a complete and valuable outcome. Do not manufacture a change to justify the session.
+
+1. Read the merged diff and any analysis document it added.
+2. Enumerate every symptom the issue and its comments describe, separately. A large fix often resolves some and not others.
+3. Test each symptom against current `main` and record a verdict per item.
+4. If everything is resolved: open a pull request carrying only the regression coverage that is still missing, or open none at all if coverage is complete. Then comment on the issue with your per-symptom verdicts and evidence, and recommend closing.
+5. If part survives: fix that part, and say plainly in the pull request which symptoms the earlier fix handled and which yours addresses.
+
+**Never close an issue yourself, and never remove the `ready` label from an issue you believe is resolved.** Recommend, and let the maintainer decide. The one label change you may make is the question swap in section 6.
+
+## 3. Order the work
+
+Group the available issues by subsystem. Issues touching the same files are not independent, and running them in parallel produces conflicting patches for one root cause.
+
+Within a group, sequence by dependency: the change that others build on goes first. A foundational fix (label registration, feed decomposition) precedes the issues that may fall out of it. When one issue is plausibly a duplicate of another's root cause, put it last and have it verify before it fixes.
+
+Across groups, work in parallel freely.
+
+## 4. Work the issue
+
+Reproduce first. An issue's repro may be reconstructed rather than verified by its reporter; if it does not reproduce, that is a finding, not a failure.
+
+Then fix, with a regression test that fails before and passes after. Keep the change minimal. Record anything you notice beyond the issue's scope as a note in the pull request rather than widening the diff.
+
+Run `npm ci && npm run build && npm test` green before every push.
+
+## 5. Open the pull request, stacked
+
+Branch name: `claude/issue-<number>-<slug>`.
+
+When your issue is sequenced behind another in the same subsystem, branch from **that issue's branch**, not from `main`, and open your pull request with its base set to that branch. This is a stacked pull request. It lets the chain proceed without waiting for anything to merge, and GitHub retargets each pull request to `main` automatically as the bases land.
+
+### Registering the stack is required, not cosmetic
+
+Setting base branches is necessary but not sufficient. `.github/workflows/main.yml` triggers on `pull_request` with `branches: [main]`, and that filter matches the pull request's **base**. An unregistered upper layer therefore gets **zero check runs**, not failing ones.
+
+Registering the chain as a GitHub stack makes Actions fire as if every pull request in it targets `main`, and it also gives branch protections, required checks and CODEOWNERS evaluation against `main`, a stack map for reviewers, and bottom-up atomic merge.
+
+There is no MCP tool for the Stacks API. Use the committed script, which is pre-approved for this repository:
+
+```
+./scripts/register-stack.sh list                       # inspect existing stacks
+./scripts/register-stack.sh create <lower-pr> <upper-pr> [...]   # bottom to top, min 2
+./scripts/register-stack.sh add <stack-number> <pr>    # append above the current top
+```
+
+Register as soon as the second pull request in a chain exists. Two timing notes:
+
+- `pull_request.opened` never carries stack information, because a pull request is created before it joins a stack, and the `stacked` action is not among the workflow's default `pull_request` types. So an upper layer's first check run normally arrives on its **next push** after registration.
+- Until then, absent checks are expected. **Never push an empty commit, and never close and reopen a pull request, to provoke a run.** `main.yml` declares `workflow_dispatch` if a run genuinely needs forcing.
+
+## 6. When to stop and ask instead
+
+Record a blocking question when proceeding either way could produce the wrong patch and you cannot settle it from the code, the tests, or the issue text. A question about a detail you can work around is not blocking: do everything that does not depend on the answer first.
+
+To record one:
+
+1. Comment on the issue. State what you found, why it blocks you, the candidate answers, and what you would do under each. Make it answerable in one reply. If a pull request already exists, post it there too and link it from the issue comment.
+2. Remove the `ready` label and add `question`.
+3. Stop. Do not guess and push a speculative fix.
+
+The label swap moves the issue out of the queue, so the next night's sweep will not pick it up again while it waits on an answer.
+
+## 7. Monitor the pull request, then stop
+
+After opening a pull request:
+
+1. Subscribe to its activity.
+2. Request a GitHub Copilot review.
+3. Drive CI to green. A red check on your own pull request is work now, at every wake: diagnose, fix, push. Never skip, disable, or quarantine a test to get green. If a failure is genuinely not yours, meaning it is red on the base branch too, say so in one comment rather than going silent.
+4. Complete **one round** with Copilot. Address every suggestion with a pushed commit, or reply on the thread explaining why it is wrong or out of scope. Resolve the threads you addressed.
+
+**Stop when CI is green on the current head and that one Copilot round is complete**, either because Copilot left no suggested changes or because you have addressed all of them. Then unsubscribe. Do not cycle into further rounds.
+
+Until both conditions hold, schedule a check-in roughly an hour out before ending a turn, and re-arm it each time.
+
+## 8. Hard limits
+
+- Never push to `main`, and never push to another session's branch.
+- Never merge a pull request.
+- Never close an issue, and never remove `ready` except as part of the question swap.
+- Never skip, disable, or quarantine a test to get a green build.
+- Never push an empty commit to re-trigger CI.
+- End every GitHub comment with the Claude Code attribution footer.
+- Do not put model identifiers in commit messages, pull request text, or code comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# Jinaga.js
+
+TypeScript library for end-to-end application state management. Data is modelled as **facts**: immutable records forming a directed acyclic graph. Queries over that graph are **specifications**.
+
+## Build and test
+
+```
+npm ci
+npm run build      # tsc
+npm test           # npx tsc --noEmit --project tsconfig.test.json, then jest
+npm run test:watch # during development
+```
+
+CI (`.github/workflows/main.yml`) runs `npm ci && npm run build && npm test` on Node 22. Run the same three locally before pushing. A green local run is the real gate: do not push on the assumption CI will catch it.
+
+## Where things live
+
+| Area | Path |
+|---|---|
+| Public API surface | `src/index.ts`, `src/jinaga.ts` |
+| Specifications (parser, skeleton, feeds, inverses, runner) | `src/specification/` |
+| Distribution rules and the engine that matches them | `src/distribution/` |
+| Authorization rules | `src/authorization/` |
+| Storage, forks, observers | `src/storage.ts`, `src/fork/`, `src/observer/` |
+| HTTP and WebSocket transport | `src/http/`, `src/ws/` |
+| Tests, mirroring `src/` | `test/` |
+
+`.cursor/rules/*.mdc` holds detailed per-area guidance (testing standards, fact patterns, TypeScript standards, async coordination). Read the relevant rule before working in an unfamiliar area.
+
+`docs/analysis/` holds deep write-ups produced while fixing hard bugs. `specification-invariants.md` in particular records the invariants the feed builder and skeleton must preserve. Read it before changing `src/specification/feed-builder.ts` or `src/specification/skeleton.ts`.
+
+## The specification and distribution subsystem
+
+Most of the hard bugs in this repository concentrate here, and they interact:
+
+- `skeletonOfSpecification` (`src/specification/skeleton.ts`) reduces a specification to a comparable shape. Its `edgeIndex` assignment is order-sensitive, so two structurally identical specifications can produce unequal skeletons if built by different paths.
+- `buildFeeds` (`src/specification/feed-builder.ts`) decomposes a specification into feeds. Negative existential conditions branch: at odd nesting depth the branch is an *excluding* feed that stops, at even depth it is a *restoring* feed that must continue matching the rest of the specification.
+- `DistributionEngine.canDistributeTo` (`src/distribution/distribution-engine.ts`) compares the skeleton of a client's specification against the skeletons of a rule's feeds. A mismatch surfaces as `spec-more-restrictive-than-rule`, which reaches users as a 403 on `/read` or, worse, a silent `"decision": "reactive"` on `/feeds`.
+
+This engine backs both `JinagaTest` and the real replicator (jinaga-server). They are intended to stay in lock-step, but that has not always held in practice. **A passing `JinagaTest` run is not sufficient evidence that a distribution or feed-decomposition fix works.** Test at the level of the failing mechanism, not only end to end.
+
+## Writing tests
+
+Full guidance is in `contributing.md`. The rule that matters most:
+
+**Never use arbitrary timeouts to wait for async work.** Do not write `await new Promise(resolve => setTimeout(resolve, 50))`. Use `await observer.processed()`, which resolves when all pending notifications have been processed, or the helpers in `test/utils/async-test-utils.ts` (`waitForObserver`, `waitForCondition`, `waitForCallbackCount`).
+
+Timeouts are acceptable only when testing a race condition deliberately, polling an external system with no event notification, or simulating a user delay for a buffering test. Document why in a comment when you do.
+
+Every bug fix needs a regression test that fails before the change and passes after. State both results in the pull request body.
+
+## Working from issues
+
+Issues labelled `ready` are queued for automated work. `.claude/skills/night-shift/SKILL.md` documents that protocol: how to tell whether an issue is already claimed or already fixed, how ordering is decided, when to stop and ask a question instead of guessing, and how stacked pull requests are opened and registered.
+
+Read it before picking up a `ready` issue, whether you are a scheduled agent or a person driving one.
+
+## Conventions
+
+- Branch from `main`. Name branches `claude/issue-<number>-<slug>` for issue work.
+- Never push to `main`. Never merge your own pull request.
+- Never skip, disable, or quarantine a test to get a green build.
+- Never push an empty commit to re-trigger CI.
+- End every comment you post on GitHub with the Claude Code attribution footer.
+- Do not put model identifiers in commit messages, pull request text, or code comments.

--- a/scripts/register-stack.sh
+++ b/scripts/register-stack.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Register a chain of pull requests as a GitHub stack, or append to an existing one.
+#
+# GitHub's stacked pull requests are in public preview and are enabled on this
+# repository. Setting each PR's base to the branch below it is necessary but NOT
+# sufficient: until the chain is registered as a stack, GitHub treats the PRs as
+# ordinary PRs with unusual bases. In particular .github/workflows/main.yml runs
+# `on: pull_request: branches: [main]`, and that filter matches the PR's BASE, so
+# an unregistered upper layer gets zero check runs. Once registered, GitHub
+# triggers workflows as if every PR in the stack targets the stack base (main).
+#
+# There is no MCP tool for the Stacks API, which is why this script exists: it
+# gives automated sessions one narrow, allowlistable entry point instead of a
+# general-purpose HTTP client.
+#
+# Usage:
+#   scripts/register-stack.sh list
+#   scripts/register-stack.sh create <pr> <pr> [<pr> ...]   # bottom to top, min 2
+#   scripts/register-stack.sh add <stack_number> <pr> [...] # append above current top
+#
+# Requires GH_TOKEN or GITHUB_TOKEN with pull_requests write.
+# Override the target repository with STACK_REPO=owner/name.
+
+set -euo pipefail
+
+REPO="${STACK_REPO:-jinaga/jinaga.js}"
+API="https://api.github.com/repos/${REPO}"
+TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+
+die() { printf 'register-stack: %s\n' "$1" >&2; exit 1; }
+
+[ -n "$TOKEN" ] || die "no GH_TOKEN or GITHUB_TOKEN in the environment"
+
+# Only ever accept bare positive integers. This keeps the allowlisted invocation
+# from being widened by clever arguments. Validation must run in the calling
+# shell, never inside a command substitution: `exit` in a substitution ends only
+# the subshell, which would let a rejected argument through to the API.
+require_number() {
+  case "$1" in
+    ''|*[!0-9]*) die "expected a positive integer, got '$1'" ;;
+    *) : ;;
+  esac
+}
+
+require_numbers() {
+  local n
+  for n in "$@"; do require_number "$n"; done
+}
+
+# Build a JSON array from already-validated positional arguments.
+json_numbers() {
+  local out="" n
+  for n in "$@"; do out="${out:+$out,}$n"; done
+  printf '[%s]' "$out"
+}
+
+call() {
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -X "$method"
+    -H "Authorization: Bearer ${TOKEN}"
+    -H "Accept: application/vnd.github+json"
+    -w '\n%{http_code}')
+  [ -n "$body" ] && args+=(-H "Content-Type: application/json" -d "$body")
+  curl "${args[@]}" "${API}${path}"
+}
+
+report() {
+  local response="$1" expected="$2"
+  local code="${response##*$'\n'}"
+  local payload="${response%$'\n'*}"
+  printf '%s\n' "$payload"
+  case " $expected " in
+    *" $code "*) printf 'HTTP %s\n' "$code" >&2 ;;
+    *) printf 'HTTP %s (unexpected)\n' "$code" >&2; exit 1 ;;
+  esac
+}
+
+cmd="${1:-}"
+[ -n "$cmd" ] || die "usage: register-stack.sh {list|create|add} ..."
+shift || true
+
+case "$cmd" in
+  list)
+    # A 404 here means stacked PRs are not enabled for the repository.
+    report "$(call GET /stacks)" "200"
+    ;;
+  create)
+    [ "$#" -ge 2 ] || die "create needs at least 2 pull request numbers, bottom to top"
+    require_numbers "$@"
+    report "$(call POST /stacks "{\"pull_requests\":$(json_numbers "$@")}")" "201"
+    ;;
+  add)
+    [ "$#" -ge 2 ] || die "add needs a stack number and at least 1 pull request number"
+    stack="$1"; shift
+    require_number "$stack"
+    require_numbers "$@"
+    report "$(call POST "/stacks/${stack}/add" "{\"pull_requests\":$(json_numbers "$@")}")" "200"
+    ;;
+  *)
+    die "unknown command '$cmd' (expected list, create, or add)"
+    ;;
+esac

--- a/scripts/register-stack.sh
+++ b/scripts/register-stack.sh
@@ -19,7 +19,11 @@
 #   scripts/register-stack.sh create <pr> <pr> [<pr> ...]   # bottom to top, min 2
 #   scripts/register-stack.sh add <stack_number> <pr> [...] # append above current top
 #
-# Requires GH_TOKEN or GITHUB_TOKEN with pull_requests write.
+# Requires GH_TOKEN or GITHUB_TOKEN with write access to pull requests. That is
+# "Pull requests: Read and write" on a fine-grained token, `pull-requests: write`
+# in an Actions workflow, or the `repo` scope on a classic token. The API reports
+# the requirement itself as `X-Accepted-Github-Permissions: pull_requests=write`.
+#
 # Override the target repository with STACK_REPO=owner/name.
 
 set -euo pipefail
@@ -36,9 +40,11 @@ die() { printf 'register-stack: %s\n' "$1" >&2; exit 1; }
 # from being widened by clever arguments. Validation must run in the calling
 # shell, never inside a command substitution: `exit` in a substitution ends only
 # the subshell, which would let a rejected argument through to the API.
+# Pull request and stack numbers are always 1 or greater, so reject 0 and any
+# leading-zero form here rather than letting the API reject them for us.
 require_number() {
   case "$1" in
-    ''|*[!0-9]*) die "expected a positive integer, got '$1'" ;;
+    ''|*[!0-9]*|0*) die "expected a positive integer, got '$1'" ;;
     *) : ;;
   esac
 }


### PR DESCRIPTION
Preparation for a scheduled agent that sweeps `ready`-labelled issues nightly. Everything it needs to know currently lives in a session transcript and a scratchpad that dies with its container, so this commits it to the repository.

## What is here

**`CLAUDE.md`** — build and test commands, source layout, the rule against arbitrary timeouts in tests, and a map of the specification and distribution subsystem where most of the hard bugs concentrate. It records that a passing `JinagaTest` run is not sufficient evidence for a fix in that subsystem, which #242 demonstrated the hard way. Detailed per-area guidance already exists in `.cursor/rules/*.mdc`; `CLAUDE.md` points at it rather than duplicating it.

**`.claude/skills/night-shift/SKILL.md`** — the working protocol. The substance is the claim rule.

**`scripts/register-stack.sh`** — registers a chain of pull requests as a GitHub stack.

## The claim rule: artifacts decide, not the label

An issue's `ready` label does not mean it is available, because merging a pull request does not clear the label. The skill has the agent search pull requests referencing the issue and branches matching `claude/issue-{number}-*`, then decide from what it finds: an open PR means skip, a merged PR means verify rather than re-fix, a closed unmerged PR or an orphan branch means read it before starting.

This is not hypothetical. Issue #242 still carries `ready` today, six days after PR #244 fixed it and merged in 6.11.5. An agent trusting the label alone would have rebuilt a shipped fix. When a merged PR exists the job becomes verification per symptom, ending in a recommendation to the maintainer rather than a close, since the skill forbids the agent from closing issues or clearing `ready` itself.

The one label change the agent may make is the question swap: when genuinely blocked, it comments with the question, moves `ready` to `question`, and stops rather than guessing. That takes the issue out of the queue so the next sweep does not pick it up again while it waits on an answer.

## Why the stack script exists

Sequenced issues in one subsystem are worked as stacked pull requests so the chain proceeds without waiting for merges. Setting base branches is necessary but **not** sufficient: `.github/workflows/main.yml` triggers on `pull_request` with `branches: [main]`, and that filter matches the pull request's *base*. An unregistered upper layer therefore gets **zero check runs**, not failing ones — an agent told to drive CI green would find no CI to drive. Registering the chain makes Actions fire as if every layer targets `main`, and adds protections and CODEOWNERS evaluation against `main`, a stack map, and bottom-up atomic merge.

The Stacks API is in public preview and enabled on this repository (`GET /repos/jinaga/jinaga.js/stacks` returns `200 []` rather than `404`). No MCP tool covers it, so the script is the one narrow entry point an automated session needs. It accepts only bare integers and validates them in the calling shell before any request is made, so a malformed argument cannot reach the API.

Verified against the live endpoint: `list` returns 200, and both `create 1 'x; rm -rf /'` and `add abc 253` are rejected locally without issuing a request.

## One thing I could not apply

The permission allowlist belongs in `.claude/settings.json`, but writing that file was blocked by the auto-mode classifier. It needs to be added by hand:

```json
{
  "permissions": {
    "allow": [
      "Bash(npm ci)",
      "Bash(npm run build)",
      "Bash(npm test)",
      "Bash(npx tsc --noEmit --project tsconfig.test.json)",
      "Bash(./scripts/register-stack.sh:*)",
      "mcp__github__get_me",
      "mcp__github__issue_read",
      "mcp__github__list_issues",
      "mcp__github__search_issues",
      "mcp__github__get_label",
      "mcp__github__list_pull_requests",
      "mcp__github__search_pull_requests",
      "mcp__github__pull_request_read",
      "mcp__github__list_branches",
      "mcp__github__list_commits",
      "mcp__github__get_commit",
      "mcp__github__get_file_contents",
      "mcp__github__get_check_run",
      "mcp__github__get_job_logs",
      "mcp__github__actions_list",
      "mcp__github__actions_get",
      "mcp__github__search_code",
      "mcp__Claude_Code_Remote__get_session",
      "mcp__Claude_Code_Remote__list_sessions",
      "mcp__Claude_Code_Remote__list_environments",
      "mcp__Claude_Code_Remote__list_repos",
      "mcp__Claude_Code_Remote__list_triggers"
    ]
  }
}
```

The `register-stack.sh` entry is what makes stack registration a standing approval for nightly agents rather than a per-run prompt. Everything else is read-only, or a build command the repository already runs in CI. Interpreter and package-runner wildcards are deliberately absent: allowlisting `python3` or `npm run *` would amount to arbitrary code execution, so the three exact `npm` forms are listed instead.