### PR TITLE
Derive a diagnostic's reactive flag from its denial code (#242)

### DIFF
--- a/docs/analysis/specification-invariants.md
+++ b/docs/analysis/specification-invariants.md
@@ -516,7 +516,7 @@ successor walk or existential.
 | Symptom | Invariant violated |
 |---|---|
 | #238 `"Label u1 not found"` on incremental re-evaluation | MI.1 — W3 broken by `shakeTree`, since fixed by `relocateConditions` (O4) |
-| #242 repro 1/2: silent empty result, `spec-more-restrictive-than-rule` | **Correct authorization, misleading diagnostic** when the query projects a child collection the rule does not share (§10.2). Repro 1 as literally quoted (`=> u4`) still authorizes under test |
+| #242 repro 1/2: silent empty result, `spec-more-restrictive-than-rule` | **Correct authorization, misleading diagnostic** when the query projects a child collection the rule does not share (§10.2). Repro 1 as literally quoted (`=> u4`) still authorizes under test, including through the policy-text path (§10.4). The silence itself was a client-side defect, since fixed (§10.4) |
 | #242 comment 1: HTTP 500 `"Label u4 not found"` from `/feeds` | MI.1 — W3 broken by `buildFeeds`'s projection attachment to a truncated restoring feed (§9.3) |
 | #242 comment 1: JinagaTest and replicator disagree | L3 vs L6/L7 — the two paths evaluate different laws; agreement is a *consequence* of MI, not an axiom |
 | #242 comment 3: unbounded write amplification | **Unattributed.** L4b holds for this shape under test (§10.1); the mechanism is still unidentified |
@@ -792,7 +792,9 @@ the parser tolerate unknown codes is the prerequisite for ever splitting it, and
 was not done here.
 
 The `reactive` degradation on `/feeds` (a `200` that leaves `query()` returning
-`[]` with no error) is a client-contract change and was not altered.
+`[]` with no error) was left alone here as a client-contract change. It turned
+out to be a defect in this library rather than a contract worth keeping; see
+§10.4.
 
 ### 10.3 Operational note on the L6c fix
 
@@ -803,3 +805,72 @@ one additional feed appears per positive branch. Existing bookmarks for those
 feeds no longer resolve, so clients re-read them from the beginning. Fact
 delivery is idempotent, so this is benign, but it is a one-time re-read on
 upgrade and worth expecting in replicator logs.
+
+### 10.4 The silence, attributed: `reactive` was copied, not derived
+
+§10.2 recorded the `/feeds` silence as untouched. It is a client-side defect,
+and it is the reason issue #242 repro 2 outlived #244.
+
+Two independent signals travel with each per-feed decision, and they answer
+different questions:
+
+- `decision` (`authorized` / `reactive` / `denied`) is the replicator's
+  *prediction* about whether the feed will start delivering.
+- `code` names *why* it did not. `no-matching-rule` and
+  `spec-more-restrictive-than-rule` compare the target's shape against every
+  rule's shape. Neither reads a fact or a principal, so no fact that later
+  arrives can change either verdict.
+
+`toDistributionDiagnostics` set `reactive: d.decision === 'reactive'`, copying
+the prediction. `isStructuralDenial` — the predicate that decides whether
+`query` throws (W8) — then required `!reactive`, so a decision that said
+`reactive` suppressed the throw no matter what its code said.
+
+Replicator 3.7.7 reports exactly that pairing for the #242 shape: `200`, every
+decomposed feed `"decision": "reactive"`, each carrying
+`"code": "spec-more-restrictive-than-rule"`. Measured against the reporter's
+captured response, `query()` resolved to `[]` with no error and no throw. The
+loud-failure work of #207 W8 had covered only the `denied` spelling of the same
+verdict.
+
+**Fix.** Derive `reactive` from the code instead of copying it from the
+decision: a structural code is never reactive. The claims conflict, and the
+code is the checkable one. `decision` still carries what the replicator said,
+so nothing is hidden from a consumer that wants it.
+
+This corrects every consumer at one point, because `reactive` is the field the
+interface documents as load-bearing: `query` throws `DistributionDeniedError`,
+the development handler logs the actionable "no rule / narrowed rule" message at
+error level instead of "pending authorization" at info, and an application
+branching on `diagnostic.reactive` stops waiting for a resolution that cannot
+arrive.
+
+What deliberately did not change: a `reactive` decision with no code, or with a
+non-structural code (`principal-excluded`, `not-authenticated`), stays reactive.
+Those are auth states — the rule's shape matched and the authorizing fact may
+still arrive — so the subscription race is untouched. `observer.ts`'s keep-alive
+for clearing diagnostics reads the raw wire `decision`, not this field, so
+`subscribe` is unaffected either way.
+
+#### On the JinagaTest / replicator divergence (#242 comment 1)
+
+The engine is shared, as `distribution-engine.ts` says. What is *not* shared is
+everything on either side of it, and both halves matter:
+
+- **Rules reach the engine by different routes.** `JinagaTest` passes the rule
+  objects built in TypeScript; the replicator loads a policy file, so its rules
+  come from `saveToDescription` through the parser. §9.1 measured these to agree
+  for the #242 shape; that is now pinned by a test rather than a one-off
+  measurement (`nestedNotExistsFeedSpec.ts`, "authorizes the specification
+  against a rule loaded from policy text"), because skeleton indices are
+  assigned by traversal order and a text diff cannot see an ordering divergence.
+- **Verdicts are reported by different mechanisms.** `NetworkManager` throws
+  `Error("Not authorized: ...")` for any failure, so under `JinagaTest` a
+  denial is always loud. The replicator answers `200` with per-feed decisions,
+  and the client decides what to do with them. That is where the two paths
+  diverged on loudness for one and the same engine verdict, and it is what the
+  fix above closes.
+
+So the lock-step claim holds for the *decision* and not, previously, for its
+*consequences*. A passing `JinagaTest` run is still not sufficient evidence for
+a distribution fix, for the reason `CLAUDE.md` gives.

--- a/src/managers/distributionDiagnostic.ts
+++ b/src/managers/distributionDiagnostic.ts
@@ -52,7 +52,16 @@ export interface DistributionDiagnostic {
  * later arrives can change either verdict. That is what makes them structural,
  * and it is a property of the code alone.
  */
-const structuralDenialCodes: readonly string[] = ['no-matching-rule', 'spec-more-restrictive-than-rule'];
+const structuralDenialCodes: readonly DistributionDenialCode[] = ['no-matching-rule', 'spec-more-restrictive-than-rule'];
+
+/**
+ * True when a denial code is one of those. A decision need not carry a code at
+ * all — the replicator may report the pending case without one — and an absent
+ * code claims nothing about the shapes, so it is not structural.
+ */
+function isStructuralCode(code: DistributionDenialCode | undefined): boolean {
+    return code !== undefined && structuralDenialCodes.includes(code);
+}
 
 /**
  * Map the replicator's per-feed decisions (issue #207 W4) to developer-facing
@@ -80,7 +89,7 @@ export function toDistributionDiagnostics(
             specification,
             decision: d.decision as 'reactive' | 'denied',
             code: d.code,
-            reactive: d.decision === 'reactive' && !structuralDenialCodes.includes(d.code ?? ''),
+            reactive: d.decision === 'reactive' && !isStructuralCode(d.code),
             reason: d.reason,
             feed: d.feed
         }));
@@ -129,7 +138,7 @@ export function toClearingDiagnostic(
  */
 export function isStructuralDenial(diagnostic: DistributionDiagnostic): boolean {
     return !diagnostic.reactive
-        && structuralDenialCodes.includes(diagnostic.code ?? '');
+        && isStructuralCode(diagnostic.code);
 }
 
 /**

--- a/src/managers/distributionDiagnostic.ts
+++ b/src/managers/distributionDiagnostic.ts
@@ -12,6 +12,10 @@ import { FeedDecision } from "../http/messages";
  * as fatal. When `false`, the denial is structural (a missing or narrowed-past
  * rule, or a principal the rule excludes) and will not self-heal on its own.
  *
+ * It is therefore *not* a copy of `decision`: a replicator that reports
+ * `decision: "reactive"` for a structurally denied feed yields `reactive:
+ * false` here. See `toDistributionDiagnostics`.
+ *
  * `code` is optional because a `reactive` decision need not carry one (the
  * replicator may report the pending case without a denial code); a `denied`
  * decision always carries one.
@@ -42,10 +46,27 @@ export interface DistributionDiagnostic {
 }
 
 /**
+ * The denial codes that describe the *shape* of the specification against the
+ * shape of every rule: no rule matched it, or it carries structure no rule has.
+ * Neither depends on which facts exist or on who is logged in, so no fact that
+ * later arrives can change either verdict. That is what makes them structural,
+ * and it is a property of the code alone.
+ */
+const structuralDenialCodes: readonly string[] = ['no-matching-rule', 'spec-more-restrictive-than-rule'];
+
+/**
  * Map the replicator's per-feed decisions (issue #207 W4) to developer-facing
  * diagnostics. Only `denied` and `reactive` feeds produce a diagnostic;
  * `authorized` feeds are silent. Old replicators report no decisions, so this
  * yields an empty array and the new APIs are inert.
+ *
+ * `reactive` is derived from the *code* rather than copied from the decision.
+ * A replicator can report `decision: "reactive"` alongside a structural code
+ * (observed on jinaga-replicator 3.7.7, issue #242), and the two disagree: the
+ * decision predicts the feed will self-heal, while the code says the shapes
+ * never matched, which no arriving fact can change. The code is the narrower,
+ * checkable claim, so it wins. `decision` still carries what the replicator
+ * actually said, for a consumer that wants to see it.
  */
 export function toDistributionDiagnostics(
     operation: DistributionDiagnostic['operation'],
@@ -59,7 +80,7 @@ export function toDistributionDiagnostics(
             specification,
             decision: d.decision as 'reactive' | 'denied',
             code: d.code,
-            reactive: d.decision === 'reactive',
+            reactive: d.decision === 'reactive' && !structuralDenialCodes.includes(d.code ?? ''),
             reason: d.reason,
             feed: d.feed
         }));
@@ -99,7 +120,8 @@ export function toClearingDiagnostic(
  * past its rule. These never self-heal (unlike the subscription race), so they
  * are the only cases `query` throws for (issue #207 W8) and the ones the
  * default dev handler reports at error level (W7). A `reactive` diagnostic is
- * never structural regardless of its code.
+ * never structural — but `reactive` is itself derived from the code, so a
+ * replicator calling a structural denial reactive does not suppress the throw.
  *
  * The throw is unconditional. `developmentMode` gates only the installation of
  * the console handler in `JinagaBrowser`, never `query`'s contract, so a
@@ -107,8 +129,7 @@ export function toClearingDiagnostic(
  */
 export function isStructuralDenial(diagnostic: DistributionDiagnostic): boolean {
     return !diagnostic.reactive
-        && (diagnostic.code === 'no-matching-rule'
-            || diagnostic.code === 'spec-more-restrictive-than-rule');
+        && structuralDenialCodes.includes(diagnostic.code ?? '');
 }
 
 /**

--- a/test/distribution/distributionDiagnosticHooksSpec.ts
+++ b/test/distribution/distributionDiagnosticHooksSpec.ts
@@ -219,4 +219,92 @@ describe("distribution diagnostic hooks (issue #207 W5/W6)", () => {
       observer.stop();
     });
   });
+
+  describe("issue #242 — a structural denial the replicator called reactive", () => {
+    // The reporter captured this exact `POST /feeds` response from
+    // jinaga-replicator 3.7.7: HTTP 200, every decomposed feed marked
+    // `reactive`, each carrying `spec-more-restrictive-than-rule`. Because the
+    // loud-failure path (W8) keyed on `decision === 'denied'`, `query` resolved
+    // to `[]` and the caller had no signal at all that the specification was
+    // never authorized. The two fields disagree, and the code is the one that
+    // can be checked: it says no rule's shape matched, which no arriving fact
+    // can change.
+    function reactiveStructuralResponse(): FeedsResponse {
+      return {
+        feeds: [FEED],
+        decisions: [
+          {
+            feed: FEED,
+            decision: "reactive",
+            code: "spec-more-restrictive-than-rule",
+            reason: "The specification adds a not-exists condition over Publish, which this rule does not contain.",
+          },
+        ],
+      };
+    }
+
+    it("throws from query rather than resolving to an empty array", async () => {
+      network.response = reactiveStructuralResponse();
+
+      await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
+    });
+
+    it("reports the diagnostic as non-reactive while preserving the reported decision", async () => {
+      network.response = reactiveStructuralResponse();
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
+
+      expect(received).toHaveLength(1);
+      // Not self-healing: a consumer branching on `reactive` must not wait for
+      // a resolution that cannot arrive.
+      expect(received[0].reactive).toBe(false);
+      // What the replicator actually said is still visible.
+      expect(received[0].decision).toBe("reactive");
+      expect(received[0].code).toBe("spec-more-restrictive-than-rule");
+    });
+
+    it("leaves a reactive decision with no structural code self-healing", async () => {
+      // The genuine subscription race: the rule's shape matched, the
+      // authorizing fact has not arrived yet. This must stay non-fatal.
+      network.response = reactiveResponse();
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].reactive).toBe(true);
+    });
+
+    it("leaves a reactive decision carrying a non-structural code self-healing", async () => {
+      // `principal-excluded` is an auth state, not an authoring error: it
+      // resolves the moment the user is granted the fact the rule requires.
+      network.response = {
+        feeds: [FEED],
+        decisions: [
+          { feed: FEED, decision: "reactive", code: "principal-excluded", reason: "excluded" },
+        ],
+      };
+      const received: DistributionDiagnostic[] = [];
+      j.onDistributionDiagnostic(d => received.push(d));
+
+      await expect(j.query(blogPosts, blog)).resolves.toEqual([]);
+
+      expect(received[0].reactive).toBe(true);
+    });
+
+    it("still throws when the replicator reports the same code as denied", async () => {
+      // The path W8 already covered, pinned alongside the one it missed.
+      network.response = {
+        feeds: [FEED],
+        decisions: [
+          { feed: FEED, decision: "denied", code: "spec-more-restrictive-than-rule", reason: "narrower than rule" },
+        ],
+      };
+
+      await expect(j.query(blogPosts, blog)).rejects.toBeInstanceOf(DistributionDeniedError);
+    });
+  });
 });

--- a/test/specification/nestedNotExistsFeedSpec.ts
+++ b/test/specification/nestedNotExistsFeedSpec.ts
@@ -1,4 +1,5 @@
-import { JinagaTest, LabelOf, SpecificationOf, User, buildFeeds, buildModel } from "@src";
+import { DistributionRules, JinagaTest, LabelOf, MemoryStore, SpecificationOf, User, buildFeeds, buildModel, dehydrateFact } from "@src";
+import { DistributionEngine } from "../../src/distribution/distribution-engine";
 import { skeletonOfSpecification } from "../../src/specification/skeleton";
 import { isExistentialCondition } from "../../src/specification/specification";
 import { expectWellOrdered } from "./specificationTestHelpers";
@@ -112,6 +113,8 @@ const accessPathsToConfigure = model.given(Tenant).match(tenant =>
         .notExists(accessPath => AccessPathConfigured.for(accessPath))
 );
 
+const servicePrincipals = model.given(Tenant).match(tenant => ServicePrincipal.usersOf(tenant));
+
 // The shape from issue #242 comment 1: a composite `select()` inside a
 // `selectMany` chain, three hops deep.
 const accessPathsWithConfiguration = model.given(Tenant).match(tenant =>
@@ -174,7 +177,7 @@ describe("feeds for nested notExists across two fact types", () => {
             user: new User("---SERVICE-PRINCIPAL---"),
             distribution: d => d
                 .share(accessPathsToConfigure)
-                .with(model.given(Tenant).match(tenant => ServicePrincipal.usersOf(tenant)))
+                .with(servicePrincipals)
         });
         const { userFact } = await j.login<User>();
         const tenant = await j.fact(new Tenant("tenant-1"));
@@ -185,6 +188,54 @@ describe("feeds for nested notExists across two fact types", () => {
         const results = await j.query(accessPathsToConfigure, tenant);
 
         expect(results.length).toBe(1);
+    });
+
+    it("authorizes the specification against a rule loaded from policy text", async () => {
+        // `JinagaTest` hands the engine the rule objects built here in
+        // TypeScript. The replicator never sees those: it loads a policy *file*,
+        // so its rule feeds come out of `saveToDescription` -> the parser. The
+        // reporter of issue #242 diffed the two texts and found them identical,
+        // yet was denied — so the text is not the only thing that has to agree.
+        // What has to agree is the feeds each path decomposes to. Exercise the
+        // parser path the replicator uses, against the same target the client
+        // sends, at the level of the engine rather than end to end.
+        const rules = new DistributionRules([]).share(accessPathsToConfigure).with(servicePrincipals);
+        const policyText = rules.saveToDescription();
+        const loaded = DistributionRules.loadFromDescription(policyText);
+
+        // The text survives a round trip, so a policy file written by one
+        // version and read by another describes the same rule.
+        expect(loaded.saveToDescription()).toEqual(policyText);
+
+        // And the rule decomposes to feeds skeleton-identical to the client's.
+        // Skeleton equality is what `canDistributeTo` actually compares, and
+        // `skeletonOfSpecification` assigns fact and edge indices by traversal
+        // order, so this catches an ordering divergence between the two paths
+        // that a text diff cannot see.
+        const loadedSkeletons = loaded.rules[0].feeds.map(feed => skeletonOfSpecification(feed));
+        const targetSkeletons = buildFeeds(accessPathsToConfigure.specification)
+            .map(feed => skeletonOfSpecification(feed));
+        expect(loadedSkeletons).toEqual(targetSkeletons);
+
+        // Finally, the decision itself.
+        const store = new MemoryStore();
+        const user = new User("---SERVICE-PRINCIPAL---");
+        const tenant = new Tenant("tenant-1");
+        const tenantRecords = dehydrateFact(tenant);
+        await store.save([
+            ...tenantRecords,
+            ...dehydrateFact(user),
+            ...dehydrateFact(new ServicePrincipal(tenant, user))
+        ].map(fact => ({ fact, signatures: [] })));
+
+        const engine = new DistributionEngine(loaded, store, false);
+        const givenLabel = accessPathsToConfigure.specification.given[0].label.name;
+        const result = await engine.canDistributeToAll(
+            buildFeeds(accessPathsToConfigure.specification),
+            { [givenLabel]: tenantRecords[tenantRecords.length - 1] },
+            dehydrateFact(user)[0]);
+
+        expect(result.type).toBe("success");
     });
 
     it("delivers the access path of a restored event through a feed", async () => {


### PR DESCRIPTION
Stacks on #253 (issue #226). Base is `claude/issue-226-specification-validation`; GitHub retargets this to `main` once that lands.

PR #244 shipped in 6.11.5 while the reporter of #242 was on 6.11.4, so most of that issue was already fixed. This does not redo that work. It reports a per-symptom verdict, fixes the one symptom that survived, and pins two paths that nothing held.

## Per-symptom verdict against this branch

| # | Symptom | Verdict |
|---|---|---|
| 1 | `/read` 403 `spec-more-restrictive-than-rule` for a byte-identical specification | **Fixed.** Does not reproduce. |
| 2 | `/feeds` 200, every feed `reactive`, `query()` silently `[]` | **Survived.** Fixed here. |
| 3 | Composite `.select()` three hops deep → 500 `Label u4 not found` | **Fixed by #244.** Covered. |
| 4 | Unbounded write amplification | **Not reproducible in-repo.** Converges under test. |
| 5 | JinagaTest / real-replicator divergence | **Partly real.** The loudness half is fixed here; the rule-loading half is now pinned. |

### 1 — does not reproduce

I rebuilt the reporter's specification from the same source construct they describe. `describeSpecification` emits their compiled text verbatim, down to the `u1`–`u5` labels and the `=> u4` projection. Against it:

- the rule's feeds and the client's feeds are element-wise skeleton-identical;
- the same holds after `saveToDescription()` → `loadFromDescription()`, and that text round trip is idempotent;
- `canDistributeToAll` returns `{ type: 'success' }` with rules loaded either way.

### 2 — survived, and is the fix here

Each per-feed decision carries two signals answering different questions. `decision` is the replicator's *prediction* that a feed will start delivering. `code` names *why* it did not — and `no-matching-rule` / `spec-more-restrictive-than-rule` compare the target's shape against every rule's shape, reading neither a fact nor a principal, so no fact that later arrives can change either verdict.

`toDistributionDiagnostics` copied the prediction into `reactive`, and `isStructuralDenial` — the predicate deciding whether `query` throws (#207 W8) — required `!reactive`. A decision spelled `reactive` therefore suppressed the throw whatever its code said. Replicator 3.7.7 reports exactly that pairing for this shape, which is why the loud-failure work of W8 missed the case the reporter hit:

```json
{ "feed": "…", "decision": "reactive", "code": "spec-more-restrictive-than-rule", "reason": "…" }
```

Fed that captured response, `query()` resolved to `[]` with no error — indistinguishable from having no data.

**Fix:** derive `reactive` from the code rather than copying it from the decision. The two claims conflict and the code is the checkable one; `decision` still carries what the replicator said, so nothing is hidden. This lands at the one point the interface documents as load-bearing, so it corrects every consumer at once: `query` throws `DistributionDeniedError`, the development handler logs the actionable "no rule / narrowed rule" message at error level instead of "pending authorization" at info, and an application branching on `diagnostic.reactive` stops waiting for a resolution that cannot arrive.

Deliberately unchanged: a `reactive` decision with no code, or with a non-structural one (`principal-excluded`, `not-authenticated`), stays reactive — the rule's shape matched and the authorizing fact may still arrive. `observer.ts`'s keep-alive for clearing diagnostics reads the raw wire `decision`, not this field, so `subscribe` is untouched.

### 4 — not reproducible in-repo

#244's `correlatedNotExistsRetractionSpec.ts` pins convergence: exactly one add and one remove per revision, no re-add, repeated completion facts do not re-fire. The `notExists` does recognize the fact just written, so the loop's premise does not hold under test. Its mechanism remains unattributed to this library; §10.1 of the analysis document lists the three candidates and what to capture against a live stack to tell them apart.

### 5 — what actually diverges

The engine is shared, as its comment says. What is not shared is everything on either side of it:

- **Rules reach the engine by different routes.** JinagaTest passes rule objects built in TypeScript; the replicator loads a policy file and parses it. §9.1 of the analysis document measured these to agree for this shape, but nothing held them there, and skeleton indices are assigned by traversal order — an ordering divergence is invisible to the text diff the reporter ran. Now pinned by a test.
- **Verdicts are reported by different mechanisms.** `NetworkManager` throws for any failure, so under JinagaTest a denial is always loud; the replicator answers 200 with per-feed decisions and the client decides. That is where the two paths disagreed on loudness for one and the same engine verdict, and symptom 2 is the consequence.

## Note for the session working #241

I did not work #241, but its shape is cheap to check from here and the answer may save that session time. Built from the issue's own minimal reproduction, the "broken" variant — a `notExists()` predicate walking two `.predecessor()` hops before reaching `.successors()` — on this branch:

- `buildFeeds` yields 3 feeds and every skeleton builds without throwing;
- `canDistributeToAll` returns success against a rule built from the same function, both via TypeScript and via the policy-text path;
- end to end through JinagaTest the query returns the expected `Grandchild`.

The restoring feed continues through the rest of the specification, which is #244's L6c fix, so that is the plausible reason. Caveat worth keeping: the reporter flagged their minimal repro as reconstructed from production behaviour rather than independently re-run, so a shape closer to their real model may still fail. Treat this as "verify before fixing", not as resolved.

## Tests

- `test/distribution/distributionDiagnosticHooksSpec.ts` — five tests for symptom 2. Two fail before the change (`Received promise resolved instead of rejected. Resolved to value: []`, the reporter's exact symptom) and pass after. Three pin what must not change: a reactive decision with no code, one with `principal-excluded`, and the `denied` spelling W8 already covered — all pass before and after.
- `test/specification/nestedNotExistsFeedSpec.ts` — one test for the policy-text path: the text round trip is idempotent, the parsed rule's feed skeletons equal the client's, and the engine authorizes.

`npm ci && npm run build && npm test` green locally: 642 passing, 83 suites.

`docs/analysis/specification-invariants.md` gains §10.4 recording the attribution, and §8 and §10.2 are corrected where they now read stale.

Not marked `Fixes #242`: symptom 4 remains unattributed, so this does not close the remainder.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VFG5LsQzrQDFC3mBTgEwS)_