### PR TITLE
Pin the predecessor-in-notExists shape from issue #241

### DIFF
--- a/docs/analysis/specification-invariants.md
+++ b/docs/analysis/specification-invariants.md
@@ -874,3 +874,66 @@ everything on either side of it, and both halves matter:
 So the lock-step claim holds for the *decision* and not, previously, for its
 *consequences*. A passing `JinagaTest` run is still not sufficient evidence for
 a distribution fix, for the reason `CLAUDE.md` gives.
+
+### 10.5 #241 — the shape is not a limitation, and #244 is not why
+
+Issue #241 reports that a `notExists` predicate resolving a **predecessor**
+chain before it reaches `successors` is denied by the distribution engine, even
+against a rule built from the literally identical function, while the same query
+restructured to walk successors end to end is authorized.
+
+**It does not reproduce.** Not on this branch, and — the part that matters — not
+at `0d6c13b` (`6.11.4`), the client version the reporter was running. PR #255's
+note to this session guessed that #244's restoring-feed continuation (L6c, in
+`6.11.5`) had fixed it under the reporter's feet. That guess is wrong:
+`6.11.4` predates #244 and answers the same way. Whatever denied the reporter's
+query, it was not this library's handling of the shape.
+
+Exercised on both, at the level each mechanism actually fails at rather than
+only end to end:
+
+| | verdict |
+|---|---|
+| `buildFeeds` on every variant | decomposes; no feed unordered, no skeleton throws |
+| one level of negation per feed (chapter 12) | holds; the predecessor walk smuggles no second level in |
+| rule feeds vs. query feeds, TypeScript objects | skeleton-identical |
+| rule feeds vs. query feeds, `saveToDescription` → parser | skeleton-identical, text round trip idempotent |
+| `canDistributeToAll`, both routes | `success` |
+| result set vs. the successors-only restructuring | equal, across live / deleted / restored |
+| the facts the feeds carry | every selected fact is delivered by some feed |
+
+Seven shapes were tried, not one: the issue's own generalized reproduction; the
+reporter's described model, where the predicate walks up a predecessor edge the
+query never walked down, so it binds fact types that appear nowhere else in the
+specification; that walk spelled compactly as one two-role path condition, which
+reaches a different branch of `addPathCondition`; a walk correlated back to an
+outer label by `join`; a single level of negation; a walk inside the *second*
+level of negation; and the walk reached through a chain that already carries its
+own delete/restore `notExists`. All seven authorize.
+
+`predecessorNotExistsDistributionSpec.ts` pins the two that correspond to what
+the issue and its production account describe.
+
+**What this rules out and what it does not.** Everything on the client side of
+the wire is measured. Nothing on the replicator side is: the reporter ran
+`jinaga-replicator` 3.7.7, whose embedded feed decomposition and rule loading no
+in-repo test reaches. `CLAUDE.md`'s warning cuts both ways here — a green
+`JinagaTest` run is not sufficient evidence that a distribution fix works, and
+seven green in-repo shapes are not sufficient evidence that a reported denial
+has no cause.
+
+**On the reporter's second ask.** They asked that, if predecessor traversal
+inside a `notExists` predicate is a genuine limitation, it surface as a
+validation error rather than a query-time `DistributionDeniedError`
+indistinguishable from an authorization failure. On this evidence it is not a
+limitation, so no such diagnostic is warranted: rejecting the shape would refuse
+specifications that work. `validateSpecification` (§ the #226 work) accepts every
+variant above, correctly.
+
+Two denials *do* produce the message the reporter saw, and both are already
+named: a query whose projection reaches fact types no rule shares (§10.2, whose
+reason text now says so), and a structural denial reported as `reactive` and
+therefore swallowed (§10.4, now derived from the code). The first reproduces the
+reporter's log prefix exactly —
+`Cannot distribute to (p1: <Tenant>) {` — from a cause that has nothing to do
+with `notExists`.

--- a/docs/analysis/specification-invariants.md
+++ b/docs/analysis/specification-invariants.md
@@ -892,7 +892,7 @@ query, it was not this library's handling of the shape.
 Exercised on both, at the level each mechanism actually fails at rather than
 only end to end:
 
-| | verdict |
+| check | verdict |
 |---|---|
 | `buildFeeds` on every variant | decomposes; no feed unordered, no skeleton throws |
 | one level of negation per feed (chapter 12) | holds; the predecessor walk smuggles no second level in |

--- a/test/specification/predecessorNotExistsDistributionSpec.ts
+++ b/test/specification/predecessorNotExistsDistributionSpec.ts
@@ -1,0 +1,394 @@
+import { DistributionRules, Jinaga, JinagaTest, LabelOf, MemoryStore, Specification, SpecificationOf, User, buildFeeds, buildModel, dehydrateFact } from "@src";
+import { DistributionEngine } from "../../src/distribution/distribution-engine";
+import { skeletonOfSpecification } from "../../src/specification/skeleton";
+import { isExistentialCondition } from "../../src/specification/specification";
+import { expectWellOrdered } from "./specificationTestHelpers";
+
+// Issue #241: a `notExists` predicate that resolves a *predecessor* chain before
+// it reaches a `successors` call was reported as denied by the distribution
+// engine, even against a rule built from the literally identical function, while
+// the same query restructured to walk successors end to end was authorized.
+//
+// The shape is not a limitation. It decomposes, it authorizes by both routes a
+// rule can reach the engine, and it selects the same facts as the successors-only
+// formulation. These tests pin all three so the shape cannot regress silently.
+//
+// What they do not cover is stated in the analysis document, §10.5: everything on
+// the replicator side of the wire, which no in-repo test reaches.
+
+// A rule and a query built from the same function must decompose to the same
+// feeds by both routes a rule can travel: the TypeScript objects `JinagaTest`
+// hands the engine, and the policy text the replicator parses. Skeleton equality
+// is what `canDistributeTo` compares, and `skeletonOfSpecification` numbers facts
+// and edges by traversal order, so this sees an ordering divergence that a diff
+// of the two texts cannot.
+function expectRuleToDecomposeLikeTheQuery(specification: Specification) {
+    const rules = new DistributionRules([]).share(new SpecificationOf(specification) as any).withEveryone();
+    const policyText = rules.saveToDescription();
+    const loaded = DistributionRules.loadFromDescription(policyText);
+
+    expect(loaded.saveToDescription()).toEqual(policyText);
+
+    const querySkeletons = buildFeeds(specification).map(feed => skeletonOfSpecification(feed));
+    expect(rules.rules[0].feeds.map(feed => skeletonOfSpecification(feed))).toEqual(querySkeletons);
+    expect(loaded.rules[0].feeds.map(feed => skeletonOfSpecification(feed))).toEqual(querySkeletons);
+}
+
+// Run the engine itself rather than a query, so the verdict is read where it is
+// decided. `viaPolicyText` selects the replicator's route: rule objects written
+// out by `saveToDescription` and read back by the parser.
+async function canDistribute(specification: Specification, given: any, viaPolicyText: boolean) {
+    let rules: DistributionRules = new DistributionRules([]).share(new SpecificationOf(specification) as any).withEveryone();
+    if (viaPolicyText) {
+        rules = DistributionRules.loadFromDescription(rules.saveToDescription());
+    }
+    const store = new MemoryStore();
+    const user = new User("---PRINCIPAL---");
+    const givenRecords = dehydrateFact(given);
+    await store.save([...dehydrateFact(user), ...givenRecords].map(fact => ({ fact, signatures: [] })));
+
+    const engine = new DistributionEngine(rules, store, false);
+    return await engine.canDistributeToAll(
+        buildFeeds(specification),
+        { [specification.given[0].label.name]: givenRecords[givenRecords.length - 1] },
+        dehydrateFact(user)[0]);
+}
+
+function expectEveryFeedToBuild(specification: Specification) {
+    const feeds = buildFeeds(specification);
+    expect(feeds.length).toBeGreaterThan(0);
+    for (const feed of feeds) {
+        expectWellOrdered(feed);
+        skeletonOfSpecification(feed);
+    }
+}
+
+// "The Art of Immutable Architecture", chapter 12: a feed carries only path
+// conditions and ONE level of negation, which is what keeps it append-only. A
+// predecessor walk inside the predicate must not smuggle a second level in.
+function expectSingleLevelOfNegation(specification: Specification) {
+    for (const feed of buildFeeds(specification)) {
+        for (const match of feed.matches) {
+            for (const condition of match.conditions.filter(isExistentialCondition)) {
+                for (const inner of condition.matches) {
+                    expect(inner.conditions.filter(isExistentialCondition)).toEqual([]);
+                }
+            }
+        }
+    }
+}
+
+// Project each feed down to the fact type the query returns, and collect what
+// the feeds between them deliver. A feed may over-deliver — the client's
+// specification filters — but a fact the query matches and no feed carries is
+// data the client can never see.
+async function deliveredByFeeds(j: Jinaga, specification: Specification, factType: string, given: any): Promise<string[]> {
+    const delivered = new Set<string>();
+    for (const feed of buildFeeds(specification)) {
+        const label = feed.matches.map(match => match.unknown).find(unknown => unknown.type === factType);
+        if (!label) {
+            continue;
+        }
+        const projected = new SpecificationOf<any, any>({ ...feed, projection: { type: "fact", label: label.name } });
+        for (const row of await j.query(projected, given)) {
+            delivered.add(j.hash(row));
+        }
+    }
+    return [...delivered];
+}
+
+describe("predecessor traversal inside a notExists predicate", () => {
+    describe("the minimal reproduction from issue #241", () => {
+        class Tenant {
+            static Type = "Example.Tenant" as const;
+            type = Tenant.Type;
+            constructor(public creator: User) { }
+        }
+        class Parent {
+            static Type = "Example.Parent" as const;
+            type = Parent.Type;
+            constructor(public tenant: Tenant, public id: string) { }
+        }
+        class ParentDeleted {
+            static Type = "Example.Parent.Deleted" as const;
+            type = ParentDeleted.Type;
+            constructor(public parent: Parent, public deletedAt: string) { }
+        }
+        class ParentRestored {
+            static Type = "Example.Parent.Restored" as const;
+            type = ParentRestored.Type;
+            constructor(public deletion: ParentDeleted) { }
+        }
+        class Child {
+            static Type = "Example.Child" as const;
+            type = Child.Type;
+            constructor(public parent: Parent, public id: string) { }
+        }
+        class Grandchild {
+            static Type = "Example.Grandchild" as const;
+            type = Grandchild.Type;
+            constructor(public child: Child, public id: string) { }
+        }
+
+        const model = buildModel(b => b
+            .type(User)
+            .type(Tenant, x => x.predecessor("creator", User))
+            .type(Parent, x => x.predecessor("tenant", Tenant))
+            .type(ParentDeleted, x => x.predecessor("parent", Parent))
+            .type(ParentRestored, x => x.predecessor("deletion", ParentDeleted))
+            .type(Child, x => x.predecessor("parent", Parent))
+            .type(Grandchild, x => x.predecessor("child", Child))
+        );
+
+        // The issue's "works" variant: every notExists predicate calls only
+        // successors, and the predecessor walk happens outside any notExists.
+        const viaSuccessors = model.given(Tenant).match(tenant =>
+            tenant.successors(Parent, p => p.tenant)
+                .notExists(parent => parent.successors(ParentDeleted, d => d.parent)
+                    .notExists(d => d.successors(ParentRestored, r => r.deletion)))
+                .selectMany(parent => parent.successors(Child, c => c.parent))
+                .selectMany(child => child.successors(Grandchild, g => g.child)));
+
+        // The issue's "fails" variant: the notExists predicate itself walks two
+        // predecessor hops before reaching successors.
+        const viaPredecessorNotExists = model.given(Tenant).match(tenant =>
+            tenant.successors(Parent, p => p.tenant)
+                .selectMany(parent => parent.successors(Child, c => c.parent))
+                .selectMany(child => child.successors(Grandchild, g => g.child))
+                .notExists(grandchild => grandchild.child.predecessor()
+                    .selectMany(child => child.parent.predecessor()
+                        .selectMany(parent => parent.successors(ParentDeleted, d => d.parent)
+                            .notExists(d => d.successors(ParentRestored, r => r.deletion))))));
+
+        async function populate(j: Jinaga) {
+            const tenant = await j.fact(new Tenant(new User("---CREATOR---")));
+            const state: { [name: string]: Grandchild } = {};
+            for (const name of ["live", "deleted", "restored"]) {
+                const parent = await j.fact(new Parent(tenant, name));
+                if (name !== "live") {
+                    const deletion = await j.fact(new ParentDeleted(parent, "2026-01-01T00:00:00Z"));
+                    if (name === "restored") {
+                        await j.fact(new ParentRestored(deletion));
+                    }
+                }
+                const child = await j.fact(new Child(parent, name));
+                state[name] = await j.fact(new Grandchild(child, name));
+            }
+            return { tenant, state };
+        }
+
+        it("builds a well ordered feed and a skeleton for every feed", () => {
+            expectEveryFeedToBuild(viaPredecessorNotExists.specification);
+        });
+
+        it("keeps every feed to a single level of negation", () => {
+            expectSingleLevelOfNegation(viaPredecessorNotExists.specification);
+        });
+
+        it("decomposes a rule to the same feeds by both routes", () => {
+            expectRuleToDecomposeLikeTheQuery(viaPredecessorNotExists.specification);
+        });
+
+        it("authorizes the query against a rule built from the same function", async () => {
+            const tenant = new Tenant(new User("---CREATOR---"));
+            expect(await canDistribute(viaPredecessorNotExists.specification, tenant, false))
+                .toEqual({ type: "success" });
+        });
+
+        it("authorizes it against a rule loaded from policy text", async () => {
+            const tenant = new Tenant(new User("---CREATOR---"));
+            expect(await canDistribute(viaPredecessorNotExists.specification, tenant, true))
+                .toEqual({ type: "success" });
+        });
+
+        it("selects the same grandchildren as the successors-only formulation", async () => {
+            const j = JinagaTest.create({
+                model,
+                // Both formulations are shared, because this test compares the two
+                // result sets. That the predecessor form authorizes at all is
+                // asserted against the engine above.
+                distribution: d => d
+                    .share(viaPredecessorNotExists).withEveryone()
+                    .share(viaSuccessors).withEveryone()
+            });
+            const { tenant, state } = await populate(j);
+
+            const selected = (await j.query(viaPredecessorNotExists, tenant)).map(g => j.hash(g)).sort();
+
+            expect(selected).toEqual([j.hash(state.live), j.hash(state.restored)].sort());
+            expect(selected).toEqual((await j.query(viaSuccessors, tenant)).map(g => j.hash(g)).sort());
+        });
+
+        it("carries every selected grandchild in a feed", async () => {
+            const j = JinagaTest.create({ model });
+            const { tenant, state } = await populate(j);
+
+            const delivered = await deliveredByFeeds(j, viaPredecessorNotExists.specification, Grandchild.Type, tenant);
+
+            expect(delivered).toContain(j.hash(state.live));
+            expect(delivered).toContain(j.hash(state.restored));
+        });
+    });
+
+    describe("the model the issue describes in production", () => {
+        // Closer to the reporter's real model than the generalized reproduction
+        // is, in the way that matters structurally: the notExists predicate walks
+        // up a predecessor edge the query never walked down. `Invitation` is
+        // reached through `code`, so `invitation.accessPath` binds an `AccessPath`
+        // and an `Event` that appear nowhere else in the specification.
+        class Tenant {
+            static Type = "Example.Tenant" as const;
+            type = Tenant.Type;
+            constructor(public creator: User) { }
+        }
+        class Event {
+            static Type = "Example.Event" as const;
+            type = Event.Type;
+            constructor(public tenant: Tenant, public id: string) { }
+
+            static in(tenant: LabelOf<Tenant>) {
+                return tenant.successors(Event, e => e.tenant)
+                    .notExists(e => e.successors(EventDelete, d => d.event)
+                        .notExists(d => d.successors(EventRestore, r => r.eventDelete)));
+            }
+        }
+        class EventDelete {
+            static Type = "Example.Event.Delete" as const;
+            type = EventDelete.Type;
+            constructor(public event: Event) { }
+        }
+        class EventRestore {
+            static Type = "Example.Event.Restore" as const;
+            type = EventRestore.Type;
+            constructor(public eventDelete: EventDelete) { }
+        }
+        class AccessPath {
+            static Type = "Example.AttendeeAccessPath" as const;
+            type = AccessPath.Type;
+            constructor(public event: Event, public id: string) { }
+        }
+        class InvitationCode {
+            static Type = "Example.AttendeeInvitationCode" as const;
+            type = InvitationCode.Type;
+            constructor(public tenant: Tenant, public id: string) { }
+        }
+        class Invitation {
+            static Type = "Example.AttendeeInvitation" as const;
+            type = Invitation.Type;
+            constructor(public code: InvitationCode, public accessPath: AccessPath) { }
+        }
+
+        const model = buildModel(b => b
+            .type(User)
+            .type(Tenant, x => x.predecessor("creator", User))
+            .type(Event, x => x.predecessor("tenant", Tenant))
+            .type(EventDelete, x => x.predecessor("event", Event))
+            .type(EventRestore, x => x.predecessor("eventDelete", EventDelete))
+            .type(AccessPath, x => x.predecessor("event", Event))
+            .type(InvitationCode, x => x.predecessor("tenant", Tenant))
+            .type(Invitation, x => x
+                .predecessor("code", InvitationCode)
+                .predecessor("accessPath", AccessPath))
+        );
+
+        // The reporter's original: two `.predecessor()` hops, each its own match.
+        const viaPredecessorNotExists = model.given(Tenant).match(tenant =>
+            tenant.successors(InvitationCode, c => c.tenant)
+                .selectMany(code => code.successors(Invitation, i => i.code))
+                .notExists(invitation => invitation.accessPath.predecessor()
+                    .selectMany(accessPath => accessPath.event.predecessor()
+                        .selectMany(event => event.successors(EventDelete, d => d.event)
+                            .notExists(d => d.successors(EventRestore, r => r.eventDelete))))));
+
+        // The same walk spelled compactly, as one path condition carrying two
+        // roles rather than two matches carrying one each. It reaches a different
+        // branch of `skeletonOfSpecification`, so it is pinned separately.
+        const viaCompactPredecessorNotExists = model.given(Tenant).match(tenant =>
+            tenant.successors(InvitationCode, c => c.tenant)
+                .selectMany(code => code.successors(Invitation, i => i.code))
+                .notExists(invitation => invitation.accessPath.event.predecessor()
+                    .selectMany(event => event.successors(EventDelete, d => d.event)
+                        .notExists(d => d.successors(EventRestore, r => r.eventDelete)))));
+
+        // The restructuring the reporter says fixed it: successors end to end,
+        // reusing the sibling specification that always distributed correctly.
+        const viaSuccessors = model.given(Tenant).match(tenant =>
+            Event.in(tenant)
+                .selectMany(event => event.successors(AccessPath, p => p.event))
+                .selectMany(accessPath => accessPath.successors(Invitation, i => i.accessPath)));
+
+        async function populate(j: Jinaga) {
+            const tenant = await j.fact(new Tenant(new User("---CREATOR---")));
+            const state: { [name: string]: Invitation } = {};
+            for (const name of ["live", "deleted", "restored"]) {
+                const event = await j.fact(new Event(tenant, name));
+                if (name !== "live") {
+                    const deletion = await j.fact(new EventDelete(event));
+                    if (name === "restored") {
+                        await j.fact(new EventRestore(deletion));
+                    }
+                }
+                const accessPath = await j.fact(new AccessPath(event, name));
+                const code = await j.fact(new InvitationCode(tenant, name));
+                state[name] = await j.fact(new Invitation(code, accessPath));
+            }
+            return { tenant, state };
+        }
+
+        for (const [spelling, specification] of [
+            ["two matches", viaPredecessorNotExists],
+            ["one two-role path condition", viaCompactPredecessorNotExists]
+        ] as const) {
+            describe(`spelled as ${spelling}`, () => {
+                it("builds a well ordered feed and a skeleton for every feed", () => {
+                    expectEveryFeedToBuild(specification.specification);
+                });
+
+                it("keeps every feed to a single level of negation", () => {
+                    expectSingleLevelOfNegation(specification.specification);
+                });
+
+                it("decomposes a rule to the same feeds by both routes", () => {
+                    expectRuleToDecomposeLikeTheQuery(specification.specification);
+                });
+
+                it("authorizes the query against a rule built from the same function", async () => {
+                    const tenant = new Tenant(new User("---CREATOR---"));
+                    expect(await canDistribute(specification.specification, tenant, false))
+                        .toEqual({ type: "success" });
+                });
+
+                it("authorizes it against a rule loaded from policy text", async () => {
+                    const tenant = new Tenant(new User("---CREATOR---"));
+                    expect(await canDistribute(specification.specification, tenant, true))
+                        .toEqual({ type: "success" });
+                });
+
+                it("selects the same invitations as the successors-only restructuring", async () => {
+                    const j = JinagaTest.create({
+                        model,
+                        distribution: d => d
+                            .share(specification).withEveryone()
+                            .share(viaSuccessors).withEveryone()
+                    });
+                    const { tenant, state } = await populate(j);
+
+                    const selected = (await j.query(specification, tenant)).map(i => j.hash(i)).sort();
+
+                    expect(selected).toEqual([j.hash(state.live), j.hash(state.restored)].sort());
+                    expect(selected).toEqual((await j.query(viaSuccessors, tenant)).map(i => j.hash(i)).sort());
+                });
+
+                it("carries every selected invitation in a feed", async () => {
+                    const j = JinagaTest.create({ model });
+                    const { tenant, state } = await populate(j);
+
+                    const delivered = await deliveredByFeeds(j, specification.specification, Invitation.Type, tenant);
+
+                    expect(delivered).toContain(j.hash(state.live));
+                    expect(delivered).toContain(j.hash(state.restored));
+                });
+            });
+        }
+    });
+});

--- a/test/specification/predecessorNotExistsDistributionSpec.ts
+++ b/test/specification/predecessorNotExistsDistributionSpec.ts
@@ -23,7 +23,7 @@ import { expectWellOrdered } from "./specificationTestHelpers";
 // and edges by traversal order, so this sees an ordering divergence that a diff
 // of the two texts cannot.
 function expectRuleToDecomposeLikeTheQuery(specification: Specification) {
-    const rules = new DistributionRules([]).share(new SpecificationOf(specification) as any).withEveryone();
+    const rules = new DistributionRules([]).share(new SpecificationOf(specification)).withEveryone();
     const policyText = rules.saveToDescription();
     const loaded = DistributionRules.loadFromDescription(policyText);
 
@@ -38,7 +38,10 @@ function expectRuleToDecomposeLikeTheQuery(specification: Specification) {
 // decided. `viaPolicyText` selects the replicator's route: rule objects written
 // out by `saveToDescription` and read back by the parser.
 async function canDistribute(specification: Specification, given: any, viaPolicyText: boolean) {
-    let rules: DistributionRules = new DistributionRules([]).share(new SpecificationOf(specification) as any).withEveryone();
+    // Every specification here is given a single Tenant. Say so, rather than
+    // letting `given[0]` silently pick the first of several.
+    expect(specification.given).toHaveLength(1);
+    let rules: DistributionRules = new DistributionRules([]).share(new SpecificationOf(specification)).withEveryone();
     if (viaPolicyText) {
         rules = DistributionRules.loadFromDescription(rules.saveToDescription());
     }


### PR DESCRIPTION
Third layer of the stack. Stacks on #255 (issue #242), which stacks on #253 (issue #226). Base is `claude/issue-242-compound-notexists-distribution`; GitHub retargets this to `main` as the bases land.

Issue #241 reports that a `notExists()` predicate resolving a **predecessor** chain before it reaches `successors()` is denied by the distribution engine, even against a `.share()` rule built from the literally identical exported function.

**It does not reproduce — and #244 is not the reason it doesn't.**

## Did it reproduce?

No. Not on this base, and not at `0d6c13b` (`6.11.4`), the client version the reporter was running.

That second measurement is the point. PR #255's note to this session found the shape passing on its branch and guessed that #244's restoring-feed continuation (L6c, shipped in `6.11.5`) had fixed it under the reporter's feet. I checked out `0d6c13b` — which predates #244, and whose `feed-builder.ts` has no continuation logic at all — and ran the same tests there. **All 21 pass.** The shape was never broken in this library at any version the reporter used, so whatever denied their query, it was not this.

## Was the minimal repro faithful?

Faithful enough — its infidelity is real but not load-bearing.

The generalized repro's predicate walks `grandchild → child → parent`, retracing edges the query already walked down, so every fact it binds is a duplicate of one already in the specification. The reporter's described model does something structurally different: the query reaches `AttendeeInvitation` through `code`, and the predicate walks up `invitation.accessPath`, an edge the query never traversed, binding an `AccessPath` and an `Event` that appear nowhere else. That is a genuinely different skeleton, so it was worth building — but it authorizes too.

Seven shapes were tried in total, at the level each mechanism fails at rather than only end to end:

1. the issue's own generalized reproduction;
2. the reporter's described model (predicate walks up an untraversed edge);
3. that walk spelled compactly as one two-role path condition — `invitation.accessPath.event.predecessor()` — which reaches a different branch of `addPathCondition`;
4. a walk correlated back to an outer label by `join`;
5. a single level of negation (no nested `notExists`);
6. a walk inside the **second** level of negation;
7. the walk reached through a chain that already carries its own delete/restore `notExists`.

For each: `buildFeeds` decomposes with no unordered feed and no skeleton throw; every feed keeps to one level of negation; rule feeds and query feeds are skeleton-identical by **both** routes a rule can reach the engine (TypeScript objects, and `saveToDescription` → parser, with the text round trip idempotent); `canDistributeToAll` returns `success`; the result set equals the successors-only restructuring across live / deleted / restored; and every selected fact is carried by some feed.

Skeleton equality rather than a text diff, per #255's observation: fact and edge indices are assigned by traversal order, so an ordering divergence between the two rule routes is invisible to a diff of the two policy texts.

## Root cause

None found in this repository. Everything on the client side of the wire is measured and correct. Nothing on the replicator side is — the reporter ran `jinaga-replicator` 3.7.7, whose embedded feed decomposition and rule loading no in-repo test reaches.

Worth recording: while testing, a **different** cause reproduced the reporter's log prefix exactly. A query whose projection reaches fact types no rule shares is denied with

```
Cannot distribute to (p1: Example.Tenant) {
```

which is §10.2, and has nothing to do with `notExists`. Their log was truncated at exactly that line, so it does not distinguish the two.

## The reporter's second ask

They asked that, if predecessor traversal inside a `notExists` predicate is a genuine limitation, it surface as a validation error rather than a query-time `DistributionDeniedError`. On this evidence it is **not** a limitation, so no such diagnostic is built here: rejecting the shape would refuse specifications that demonstrably work. `validateSpecification` (from #253, the bottom of this stack) accepts every variant above, correctly. The two denials that *do* produce this message are already addressed one layer down — §10.2's reason text, and §10.4's `reactive` derivation in #255.

## Tests

`test/specification/predecessorNotExistsDistributionSpec.ts` — 21 tests pinning the two variants that correspond to what the issue and its production account describe (shapes 1, 2 and 3 above).

Before/after, stated plainly: **these tests pass on `main`, on this base, and at `0d6c13b` (`6.11.4`) alike.** There is no before-and-after, because there is no defect to fix. They are pins, not a regression proof — they exist so that a future change to `feed-builder.ts` or `skeleton.ts` cannot quietly break a shape that works today, which is what §10.5 asks of them.

`npm ci && npm run build && npm test` green locally: **663 passing, 84 suites.**

`docs/analysis/specification-invariants.md` gains §10.5: the per-mechanism verdicts, the corrected attribution, and what remains unmeasured.

## Out of scope

- The replicator side. Settling #241 needs a capture against a live stack, or the runnable reproduction repo the reporter offered.
- No `Fixes #241`. The shape is clean here, but the reporter saw a real denial in production and this does not explain it. Recommending the issue stay open pending that reproduction; the `ready` label is untouched and the maintainer decides.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F79mMqGiV3Q2f11tcfuqRh)_