### PR TITLE
Record each night-shift run so the reasoning outlives the container

### DIFF
--- a/.claude/skills/night-shift/SKILL.md
+++ b/.claude/skills/night-shift/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: night-shift
-description: Work the queue of GitHub issues labelled `ready` in jinaga/jinaga.js, unattended. Use when sweeping for ready issues, deciding which are actually available to work, ordering them, opening a fix as a stacked pull request, or recording a blocking question instead of guessing. Covers the claim rule, the stacked-PR registration step, and the stop condition for PR monitoring.
+description: Work the queue of GitHub issues labelled `ready` in jinaga/jinaga.js, unattended. Use when sweeping for ready issues, deciding which are actually available to work, ordering them, opening a fix as a stacked pull request, or recording a blocking question instead of guessing. Covers the claim rule, the stacked-PR registration step, the stop condition for PR monitoring, and how each run is recorded in the Night Shift Log so the reasoning outlives the container.
 ---
 
 # Night shift: working `ready` issues
@@ -77,10 +77,9 @@ There is no MCP tool for the Stacks API. Use the committed script, which is pre-
 ./scripts/register-stack.sh add <stack-number> <pr>    # append above the current top
 ```
 
-Register as soon as the second pull request in a chain exists. Two timing notes:
+Register as soon as the second pull request in a chain exists. Observed behaviour, from the first real run: registration alone was enough — `build` fired on both upper layers without any further push. Do not count on that, because `pull_request.opened` cannot carry stack information (a pull request is created before it joins a stack) and `stacked` is not among the workflow's default `pull_request` types. Treat a short gap as normal and a long one as worth reporting.
 
-- `pull_request.opened` never carries stack information, because a pull request is created before it joins a stack, and the `stacked` action is not among the workflow's default `pull_request` types. So an upper layer's first check run normally arrives on its **next push** after registration.
-- Until then, absent checks are expected. **Never push an empty commit, and never close and reopen a pull request, to provoke a run.** `main.yml` declares `workflow_dispatch` if a run genuinely needs forcing.
+Until checks appear, absent checks are expected. **Never push an empty commit, and never close and reopen a pull request, to provoke a run.** `main.yml` declares `workflow_dispatch` if a run genuinely needs forcing.
 
 ## 6. When to stop and ask instead
 
@@ -107,12 +106,37 @@ After opening a pull request:
 
 Until both conditions hold, schedule a check-in roughly an hour out before ending a turn, and re-arm it each time.
 
-## 8. Hard limits
+**Check-run events name a stale head.** In the first real run, two `check_suite.completed` events arrived naming commits the pull request had already moved past, and a third arrived for a head that a co-author's push had superseded seconds earlier. Acting on the SHA in the event would have declared green on a commit that was no longer current. Always re-read the pull request's own head before concluding anything about its state, and treat the event as a nudge to look rather than as a report of what is true.
+
+## 8. Record the run in the Night Shift Log
+
+A run that leaves no trace teaches nothing. GitHub keeps the artifacts — a pull request, a comment, a label — but not the judgments: what you considered and passed over, why you ordered the work as you did, what a verdict rested on. Those die with the container unless you record them.
+
+They go in the **Night Shift Log**, a Jinaga application reached through the Factual MCP server. Open a console, run `applications`, and open the one whose routing matches; its manifest carries the full action catalog with argument guidance, so read `describe` there rather than relying on this list.
+
+The shape of a run:
+
+1. `practicesForAdministrator($me)` — the entry point. Find the repository whose current name matches the one you are sweeping and take its `repositoryRef`. If no practice or no matching repository exists, **stop and say so**. `createPractice` and `registerGitHubRepository` are one-time setup, and calling them speculatively mints duplicates that split the history.
+2. `startSweep($repository, $headCommit)` once, before examining anything.
+3. Per issue: `considerIssue`, then exactly one finding action — `findOpenPullRequest`, `findMergedPullRequest`, `findClosedPullRequest`, `findBranch`, or `findNoPriorWork` — matching what section 2's claim check turned up.
+4. Then `dispatchWork` (with the ordering argument in `rationale`) or `skipIssue`. Creating the fact *is* the decision; there is no decision value to set.
+5. Per dispatch, when it finishes: `openPullRequest`, `raiseQuestion`, or `findNoChange`.
+6. Later, when a question is answered or a verdict turns out wrong: `answerQuestion`, or `correctVerdictFromWork` naming the consideration whose work produced the disproof.
+
+Two rules about what goes in:
+
+- **Record what you skipped, not just what you worked.** A skip with its reason is the evidence the claim rule is working, and it is the only record that an issue was looked at at all.
+- **Never record availability.** GitHub is the queue and the only authority on what is currently ready. The log holds what was observed and decided, and when. Storing "issue 242 is available" would create a second source of truth that can go stale, which is the exact failure the claim rule exists to catch.
+
+If the Factual server is unreachable, do the GitHub work anyway and say in your final report that the run went unrecorded. A missing log entry is a gap; a blocked run is a worse one.
+
+## 9. Hard limits
 
 - Never push to `main`, and never push to another session's branch.
 - Never merge a pull request.
 - Never close an issue, and never remove `ready` except as part of the question swap.
 - Never skip, disable, or quarantine a test to get a green build.
 - Never push an empty commit to re-trigger CI.
+- Never put a mutating call in a retry or fallback position. A shell `cmd-a || cmd-b` runs `cmd-b` when `cmd-a` merely prints something unexpected, and a "test" invocation of a create endpoint is a real write. Both happened in the first run; the API's own validation caught them, which is luck, not method.
 - End every GitHub comment with the Claude Code attribution footer.
 - Do not put model identifiers in commit messages, pull request text, or code comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Every bug fix needs a regression test that fails before the change and passes af
 
 ## Working from issues
 
-Issues labelled `ready` are queued for automated work. `.claude/skills/night-shift/SKILL.md` documents that protocol: how to tell whether an issue is already claimed or already fixed, how ordering is decided, when to stop and ask a question instead of guessing, and how stacked pull requests are opened and registered.
+Issues labelled `ready` are queued for automated work. `.claude/skills/night-shift/SKILL.md` documents that protocol: how to tell whether an issue is already claimed or already fixed, how ordering is decided, when to stop and ask a question instead of guessing, how stacked pull requests are opened and registered, and how each run is recorded so the reasoning survives the container.
 
 Read it before picking up a `ready` issue, whether you are a scheduled agent or a person driving one.
 


### PR DESCRIPTION
Prerequisite for scheduling the night-shift agent. The protocol landed in #254 produces pull requests and comments, but nothing that survives about *why*: which issues were considered and passed over, how the ordering was chosen, what a verdict rested on. GitHub keeps artifacts, not reasoning, and a session's context dies with its container.

A file committed to a branch would not have solved it either — an unmerged pull request takes its run log with it.

## What this adds

**Section 8, recording the run.** Each sweep is recorded in the Night Shift Log, a Jinaga application reached through the Factual MCP server. Its fact model makes findings, decisions and outcomes *types* rather than field values, so "what did we skip and why" is a join rather than a string comparison. The step lists the call sequence, but points at the application's own manifest for argument guidance rather than duplicating it here, where it would drift.

Two rules matter more than the sequence:

- **Record skips as well as work.** A skip with its reason is the evidence the claim rule is doing its job, and the only record that an issue was examined at all.
- **Never record availability.** GitHub is the queue and the sole authority on what is currently ready. Storing a judgment about availability would create a second source of truth that can go stale, which is precisely the failure the claim rule exists to catch.

If the Factual server is unreachable, the GitHub work proceeds and the final report says the run went unrecorded. A missing log entry is a gap; a blocked run is worse.

## Two corrections the first real run produced

**The stack timing note was too pessimistic.** #254 said an upper layer's first check run "normally arrives on its next push after registration." In the run that followed, registering stack #256 was enough on its own — `build` fired on both upper layers with no further push. The reasoning behind the caution still holds (`pull_request.opened` cannot carry stack information, and `stacked` is not among the workflow's default types), so the guidance now says to treat a short gap as normal and a long one as worth reporting, rather than to expect a gap.

**Check-run events name stale heads.** Three arrived during that run for commits the pull request had already moved past, including one superseded seconds earlier by a co-author's push. Acting on the SHA in the event would have declared green on a commit that was no longer current. The monitoring step now says to re-read the pull request's own head and treat the event as a nudge to look rather than a report of what is true.

## One new hard limit

Never put a mutating call in a retry or fallback position. During that run a shell `cmd-a || cmd-b` re-ran a stack append because the first invocation printed something unexpected, and a live `create` endpoint was invoked as a "test". The API's own validation caught both — chain validation rejected one, duplicate-detection the other. That is luck, not method, and it is the kind of mistake an unattended agent will repeat.

## Testing

Documentation only; no source or test changes. `npm ci && npm run build && npm test` is unaffected, and CI runs it on this pull request as usual.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGQmdqnP9r3ViAFgW7UJUL)_