### PR TITLE
Correct what actually triggers CI on an upper stack layer

### DIFF
--- a/.claude/skills/night-shift/SKILL.md
+++ b/.claude/skills/night-shift/SKILL.md
@@ -77,9 +77,28 @@ There is no MCP tool for the Stacks API. Use the committed script, which is pre-
 ./scripts/register-stack.sh add <stack-number> <pr>    # append above the current top
 ```
 
-Register as soon as the second pull request in a chain exists. Observed behaviour, from the first real run: registration alone was enough — `build` fired on both upper layers without any further push. Do not count on that, because `pull_request.opened` cannot carry stack information (a pull request is created before it joins a stack) and `stacked` is not among the workflow's default `pull_request` types. Treat a short gap as normal and a long one as worth reporting.
+Register as soon as the second pull request in a chain exists. **Registration does not, by itself, start a check run on a layer whose pull request already exists.** It changes how *future* `pull_request` events on that layer are evaluated; it does not reach back and trigger a run for an event that already fired. A pull request is created before it joins a stack, so its `opened` event carried no stack information, and `stacked` is not among the workflow's default `pull_request` types.
 
-Until checks appear, absent checks are expected. **Never push an empty commit, and never close and reopen a pull request, to provoke a run.** `main.yml` declares `workflow_dispatch` if a run genuinely needs forcing.
+Measured on the first real stack (`main` ← #253 ← #255 ← #257), by reading the `event` field of each workflow run rather than only its conclusion:
+
+| head | layer | how CI actually ran |
+|---|---|---|
+| `f3af791` | #253, base `main` | `pull_request` |
+| `699c705` | #255, base = #253's branch | `workflow_dispatch` |
+| `aadee42` | #257, base = #255's branch | `workflow_dispatch` |
+
+Only the bottom layer ran from its own pull request event. Both upper layers were green because a session dispatched the workflow by hand. An earlier revision of this section claimed registration alone had been enough, because whoever wrote it saw green checks and never looked at what triggered them. Check the `event`, not just the conclusion.
+
+Scope that lookup by commit. Listing a workflow's recent runs returns tens of kilobytes and will overflow a tool result; ask for the one head you care about instead:
+
+```
+gh api "repos/jinaga/jinaga.js/actions/runs?head_sha=<sha>" \
+  --jq '.workflow_runs[] | select(.name=="CI") | "\(.event)/\(.conclusion)"'
+```
+
+So an upper layer's first run arrives on its **next push**, or you trigger it yourself. `main.yml` declares `workflow_dispatch` for exactly that, and using it is the sanctioned move here rather than a workaround — say in your report that you dispatched it.
+
+Until then, absent checks are expected. **Never push an empty commit, and never close and reopen a pull request, to provoke a run.**
 
 ## 6. When to stop and ask instead
 

--- a/.claude/skills/night-shift/SKILL.md
+++ b/.claude/skills/night-shift/SKILL.md
@@ -89,12 +89,14 @@ Measured on the first real stack (`main` ← #253 ← #255 ← #257), by reading
 
 Only the bottom layer ran from its own pull request event. Both upper layers were green because a session dispatched the workflow by hand. An earlier revision of this section claimed registration alone had been enough, because whoever wrote it saw green checks and never looked at what triggered them. Check the `event`, not just the conclusion.
 
-Scope that lookup by commit. Listing a workflow's recent runs returns tens of kilobytes and will overflow a tool result; ask for the one head you care about instead:
+Scope that lookup to one commit and one workflow. Listing a workflow's recent runs returns tens of kilobytes and will overflow a tool result; ask for the one head you care about instead:
 
 ```
-gh api "repos/jinaga/jinaga.js/actions/runs?head_sha=<sha>" \
-  --jq '.workflow_runs[] | select(.name=="CI") | "\(.event)/\(.conclusion)"'
+gh api "repos/jinaga/jinaga.js/actions/workflows/main.yml/runs?head_sha=<sha>" \
+  --jq '.workflow_runs[] | "\(.event)/\(.conclusion)"'
 ```
+
+Address the workflow by its **file**, not by matching a display name. This repository runs ten workflows, so an unscoped `actions/runs?head_sha=` returns several rows per commit — and a run's `name` is the *run* name, which a workflow can override with `run-name:`. A name filter that stops matching returns nothing, which reads exactly like "CI never ran." Getting that backwards is the failure this whole section exists to prevent.
 
 So an upper layer's first run arrives on its **next push**, or you trigger it yourself. `main.yml` declares `workflow_dispatch` for exactly that, and using it is the sanctioned move here rather than a workaround — say in your report that you dispatched it.
 


### PR DESCRIPTION
Section 5 of the night-shift skill told the agent something false, and the first scheduled run caught it.

## What it said, and why it was wrong

[#258](https://github.com/jinaga/jinaga.js/pull/258) rewrote §5 to claim that registering a chain as a GitHub stack was by itself enough to start check runs on the upper layers — citing the first real stack as evidence. That evidence was misread. I saw green checks on #255 and #257 and inferred registration had caused them. I never looked at what triggered the runs.

Reading the `event` field tells a different story:

| head | layer | how CI actually ran |
|---|---|---|
| `f3af791` | #253, base `main` | `pull_request` |
| `699c705` | #255, base = #253's branch | `workflow_dispatch` |
| `aadee42` | #257, base = #255's branch | `workflow_dispatch` |

Only the bottom layer — the one already based on `main` — ran from its own pull request event. Both upper layers were green because a session had dispatched the workflow by hand.

## What is actually true

Registration changes how *future* `pull_request` events on a layer are evaluated. It does not reach back and trigger a run for an event that already fired, and a pull request is created before it joins a stack, so its `opened` event carried no stack information. An upper layer's first run therefore arrives on its **next push**, or someone triggers it.

`main.yml` declares `workflow_dispatch` for exactly this, so using it is the sanctioned move rather than a workaround. The skill now says so, and asks the agent to report when it dispatched.

That restores the caution the pre-#258 text had, but with a measurement behind it instead of an inference in either direction.

## How it was caught

The first run of the scheduled night-shift routine, sweeping a queue where all three `ready` issues were already claimed. Rather than trusting the labels or the green ticks, it verified stack registration, CI on each current head, and every Copilot round — and reported that §5 did not hold, naming `workflow_dispatch` as the reason. I confirmed it independently against the API before writing this.

The lesson generalises past this one paragraph, so §5 now says it outright: **check the `event`, not just the `conclusion`.**

## Also

The same run hit a 62KB tool result listing a workflow's recent runs, and recovered by parsing the spilled file. §5 now shows the scoped query instead:

```
gh api "repos/jinaga/jinaga.js/actions/runs?head_sha=<sha>" \
  --jq '.workflow_runs[] | select(.name=="CI") | "\(.event)/\(.conclusion)"'
```

## Testing

Documentation only. No source or test changes; CI runs on this pull request as usual.

---
_Generated by [Claude Code](https://claude.ai/code)_