### PR TITLE
Recover a subscription whose feed the replicator forgot (#243)

### DIFF
--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -120,6 +120,23 @@ export class FetchConnection implements HttpConnection {
         const signal = controller.signal;
         let closed = false;
 
+        // Backoff that a disconnect can cut short. Without this the loop stays
+        // parked in a timer for up to feedRefreshIntervalSeconds after the
+        // caller has already let go, which delays teardown and keeps the
+        // process alive on a pending timer that will only ever observe `closed`.
+        let wake: (() => void) | undefined;
+        const sleep = (ms: number) => new Promise<void>(resolve => {
+            const timer = setTimeout(() => {
+                wake = undefined;
+                resolve();
+            }, ms);
+            wake = () => {
+                clearTimeout(timer);
+                wake = undefined;
+                resolve();
+            };
+        });
+
         // Start a background task to read the stream.
         // This function will read one chunk and pass it to onResponse.
         // The function will then call itself to read the next chunk.
@@ -144,7 +161,18 @@ export class FetchConnection implements HttpConnection {
                     });
 
                     if (!response.ok) {
-                        throw new Error(`Unexpected status code ${response.status}: ${response.statusText}`);
+                        // Type this the way get() types its failures (issue
+                        // #234), so a caller can tell the replicator's
+                        // documented 404 `feed_not_found` -- the signal that it
+                        // no longer holds this feed registration -- from a
+                        // server that is merely unreachable. The plain Error
+                        // thrown here before carried neither status nor body,
+                        // which left the two indistinguishable (issue #243).
+                        const body = await this.readErrorBody(response);
+                        throw new HttpError(
+                            responseReason(body, response.statusText, "Unknown error"),
+                            response.status,
+                            body);
                     }
 
                     const reader = response.body?.getReader();
@@ -196,10 +224,24 @@ export class FetchConnection implements HttpConnection {
                     if (err.name === 'AbortError') {
                         return;
                     }
+                    // Report the failure before backing off (issue #243).
+                    // onError used to be reachable only from the read loop
+                    // above, which requires a connection that already opened,
+                    // so a failure to open one was invisible outside this
+                    // closure: the loop reissued the same doomed URL forever
+                    // with no signal anywhere that it would never succeed.
+                    try {
+                        onError(err as Error);
+                    } catch (handlerError) {
+                        Trace.error(handlerError);
+                    }
+                    if (closed) {
+                        return;
+                    }
                     const exponentialDelay = baseDelayMs * Math.pow(2, attempt);
                     const jitter = Math.random() * baseDelayMs;
                     const delay = Math.min(exponentialDelay + jitter, feedRefreshIntervalSeconds * 1000);
-                    await new Promise(resolve => setTimeout(resolve, delay));
+                    await sleep(delay);
                     attempt++;
                 }
             }
@@ -209,7 +251,26 @@ export class FetchConnection implements HttpConnection {
             // If the connection is closed, exit.
             closed = true;
             controller.abort();
+            if (wake) {
+                wake();
+            }
         };
+    }
+
+    /**
+     * Read a failed stream response's body for its diagnostic text, best
+     * effort. The body only enriches the error being reported; a body that
+     * cannot be read must not displace the status code that is the point of
+     * reporting it at all.
+     */
+    private async readErrorBody(response: Response): Promise<unknown> {
+        try {
+            const contentType = response.headers?.get('content-type') || '';
+            return contentType.includes(ContentTypeJson) ? await response.json() : await response.text();
+        } catch (err) {
+            Trace.warn(`Could not read the body of a failed feed stream response: ${err}`);
+            return null;
+        }
     }
 
     post(path: string, contentType: PostContentType, accept: PostAccept, body: string, timeoutSeconds: number): Promise<HttpResponse> {

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -256,6 +256,12 @@ export interface CachedFeeds {
 
 export class NetworkManager {
     private readonly feedsCache = new Map<string, CachedFeeds>();
+    // What each cache entry was registered from, so a feed the replicator has
+    // forgotten can be registered again (issue #243). `feedsCache` holds only
+    // the response, and the key is a hash, so neither can reproduce the
+    // `POST /feeds` that produced it.
+    private readonly feedRegistrations = new Map<string, { start: FactReference[], specification: Specification }>();
+    private readonly feedReregistrations = new Map<string, Promise<void>>();
     private readonly activeFeeds = new Map<string, Promise<void>>();
     private fetchCount = 0;
     private currentBatch: LoadBatch | null = null;
@@ -378,7 +384,8 @@ export class NetworkManager {
                         this.handleFeedData(feed);
                     }
                 };
-                subscriber = new Subscriber(feed, this.network, this.store, notify, this.feedRefreshIntervalSeconds);
+                subscriber = new Subscriber(feed, this.network, this.store, notify, this.feedRefreshIntervalSeconds,
+                    () => this.reregisterFeed(feed));
                 this.subscribers.set(feed, subscriber);
             }
             return subscriber;
@@ -431,12 +438,57 @@ export class NetworkManager {
             decisions: response.decisions ?? []
         };
         this.feedsCache.set(hash, cachedFeeds);
+        this.feedRegistrations.set(hash, { start, specification });
         return cachedFeeds;
     }
 
     private removeFeedsFromCache(start: FactReference[], specification: Specification) {
         const hash = getSpecificationHash(start, specification);
         this.feedsCache.delete(hash);
+    }
+
+    /**
+     * Register a feed with the replicator again after it reported the feed
+     * gone (issue #243).
+     *
+     * The feed hash is derived from the feed definition, so re-registering the
+     * same specification restores the very hash the running subscriber is
+     * already streaming, and the bookmark the store holds against that hash
+     * still applies: the subscription resumes where it left off rather than
+     * replaying its history.
+     *
+     * At most one re-registration per feed is in flight, because every attempt
+     * in the stream's backoff loop reports the same failure.
+     */
+    private reregisterFeed(feed: string): Promise<void> {
+        const inFlight = this.feedReregistrations.get(feed);
+        if (inFlight) {
+            return inFlight;
+        }
+        const promise = this.registerFeedAgain(feed)
+            .finally(() => {
+                this.feedReregistrations.delete(feed);
+            });
+        this.feedReregistrations.set(feed, promise);
+        return promise;
+    }
+
+    private async registerFeedAgain(feed: string): Promise<void> {
+        // One feed hash can belong to several cached specifications, so
+        // re-register every one that produced it.
+        const affected = Array.from(this.feedsCache.entries())
+            .filter(([, cached]) => cached.feeds.includes(feed))
+            .map(([hash]) => hash);
+        for (const hash of affected) {
+            const registration = this.feedRegistrations.get(hash);
+            if (!registration) {
+                continue;
+            }
+            // Drop the cached response first so getFeedsFromCache actually
+            // reaches the replicator instead of returning the stale entry.
+            this.feedsCache.delete(hash);
+            await this.getFeedsFromCache(registration.start, registration.specification);
+        }
     }
 
     private async processFeed(feed: string) {

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -254,13 +254,25 @@ export interface CachedFeeds {
     decisions: FeedDecision[];
 }
 
+/**
+ * One entry in the feed cache: the replicator's response, plus the arguments
+ * that produced it. The arguments are kept so a feed the replicator has
+ * forgotten can be registered again (issue #243) -- the response cannot
+ * reproduce the `POST /feeds` that returned it, and the cache key is a hash.
+ */
+interface CachedFeedRegistration {
+    cached: CachedFeeds;
+    start: FactReference[];
+    specification: Specification;
+}
+
 export class NetworkManager {
-    private readonly feedsCache = new Map<string, CachedFeeds>();
-    // What each cache entry was registered from, so a feed the replicator has
-    // forgotten can be registered again (issue #243). `feedsCache` holds only
-    // the response, and the key is a hash, so neither can reproduce the
-    // `POST /feeds` that produced it.
-    private readonly feedRegistrations = new Map<string, { start: FactReference[], specification: Specification }>();
+    // Each entry carries the response *and* what it was registered from, so a
+    // feed the replicator has forgotten can be registered again (issue #243).
+    // The response alone cannot reproduce the `POST /feeds` that produced it,
+    // and the key is a hash. Keeping the two in one entry rather than in
+    // parallel maps means they cannot fall out of step as entries are evicted.
+    private readonly feedsCache = new Map<string, CachedFeedRegistration>();
     private readonly feedReregistrations = new Map<string, Promise<void>>();
     private readonly activeFeeds = new Map<string, Promise<void>>();
     private fetchCount = 0;
@@ -426,9 +438,9 @@ export class NetworkManager {
 
     private async getFeedsFromCache(start: FactReference[], specification: Specification): Promise<CachedFeeds> {
         const hash = getSpecificationHash(start, specification);
-        const cached = this.feedsCache.get(hash);
-        if (cached) {
-            return cached;
+        const entry = this.feedsCache.get(hash);
+        if (entry) {
+            return entry.cached;
         }
         const response = await this.network.feeds(start, specification);
         // Old replicators omit `decisions`; normalize to an empty array so every
@@ -437,8 +449,7 @@ export class NetworkManager {
             feeds: response.feeds,
             decisions: response.decisions ?? []
         };
-        this.feedsCache.set(hash, cachedFeeds);
-        this.feedRegistrations.set(hash, { start, specification });
+        this.feedsCache.set(hash, { cached: cachedFeeds, start, specification });
         return cachedFeeds;
     }
 
@@ -477,17 +488,12 @@ export class NetworkManager {
         // One feed hash can belong to several cached specifications, so
         // re-register every one that produced it.
         const affected = Array.from(this.feedsCache.entries())
-            .filter(([, cached]) => cached.feeds.includes(feed))
-            .map(([hash]) => hash);
-        for (const hash of affected) {
-            const registration = this.feedRegistrations.get(hash);
-            if (!registration) {
-                continue;
-            }
+            .filter(([, entry]) => entry.cached.feeds.includes(feed));
+        for (const [hash, entry] of affected) {
             // Drop the cached response first so getFeedsFromCache actually
             // reaches the replicator instead of returning the stale entry.
             this.feedsCache.delete(hash);
-            await this.getFeedsFromCache(registration.start, registration.specification);
+            await this.getFeedsFromCache(entry.start, entry.specification);
         }
     }
 

--- a/src/observer/subscriber.ts
+++ b/src/observer/subscriber.ts
@@ -1,3 +1,4 @@
+import { HttpError } from "../http/errors";
 import { Network } from "../managers/NetworkManager";
 import { Storage, FactEnvelope, FactReference } from "../storage";
 import { Trace } from "../util/trace";
@@ -9,13 +10,21 @@ export class Subscriber {
   private disconnect: (() => void) | undefined;
   private timer: NodeJS.Timer | undefined;
   private reject: ((reason?: any) => void) | undefined;
+  private reregistering: boolean = false;
 
   constructor(
     private readonly feed: string,
     private readonly network: Network,
     private readonly store: Storage,
     private readonly notifyFactsAdded: (envelopes: FactEnvelope[]) => Promise<void>,
-    private readonly refreshIntervalSeconds: number
+    private readonly refreshIntervalSeconds: number,
+    /**
+     * Ask the owner to register this feed with the replicator again, because
+     * the replicator says it no longer holds it (issue #243). Optional so a
+     * Subscriber can still be constructed without one; a subscription that has
+     * no way to re-register simply keeps its old retry behavior.
+     */
+    private readonly reregisterFeed?: () => Promise<void>
   ) {}
 
   addRef() {
@@ -97,6 +106,36 @@ export class Subscriber {
       if (err.name !== 'AbortError') {
         Trace.warn(`Subscriber connection error: ${err}`);
       }
+      // A 404 on GET /feeds/:hash is the replicator's documented way of saying
+      // the route is known but the registration is gone -- it restarted, or a
+      // policy reload rebuilt its feed cache. Retrying the same URL can never
+      // fix that, so ask the owner to register the feed again (issue #243).
+      // Before this the subscription just retried forever and went quiet: the
+      // one path that re-registered was start()'s promise rejecting, which
+      // only happens before the first delivery ever arrives, so a subscription
+      // that had been running a while could never take it.
+      if (err instanceof HttpError && err.statusCode === 404) {
+        this.reregister();
+      }
     }, this.refreshIntervalSeconds);
+  }
+
+  /**
+   * Re-register this feed, at most once at a time. Every attempt in the
+   * stream's backoff loop reports the same 404, so an unguarded call here
+   * would turn one lost registration into a POST storm.
+   */
+  private reregister() {
+    if (this.reregistering || !this.reregisterFeed) {
+      return;
+    }
+    this.reregistering = true;
+    this.reregisterFeed()
+      .catch(err => {
+        Trace.warn(`Could not re-register feed ${this.feed}: ${err}`);
+      })
+      .then(() => {
+        this.reregistering = false;
+      });
   }
 }

--- a/test/http/fetchStreamReconnectSpec.ts
+++ b/test/http/fetchStreamReconnectSpec.ts
@@ -1,0 +1,130 @@
+import { FetchConnection, HttpError } from "@src";
+import { waitForCondition } from "../utils/async-test-utils";
+
+// A stand-in for the streaming Response that FetchConnection.getStream reads.
+// The success shape hands back a reader that immediately reports `done`, which
+// is enough to exercise the connect path without a real body.
+function fakeStreamResponse(ok: boolean, status: number, statusText: string, contentType = "text/plain", body: unknown = "") {
+  return {
+    ok,
+    status,
+    statusText,
+    headers: { get: (h: string) => (h.toLowerCase() === "content-type" ? contentType : null) },
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    body: { getReader: () => ({ read: async () => ({ done: true, value: undefined }) }) }
+  };
+}
+
+describe("FetchConnection.getStream when the replicator has forgotten a feed (issue #243)", () => {
+  const realFetch = global.fetch;
+  afterEach(() => { global.fetch = realFetch; });
+
+  function connection() {
+    return new FetchConnection(
+      "http://localhost",
+      () => Promise.resolve({}),
+      () => Promise.resolve(false)
+    );
+  }
+
+  it("reports a connect failure through onError instead of swallowing it", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      fakeStreamResponse(false, 404, "Not Found", "text/plain", "feed_not_found")
+    ) as any;
+
+    const errors: Error[] = [];
+    const disconnect = connection().getStream(
+      "/feeds/deadbeef?b=482.117.9",
+      async () => { },
+      err => { errors.push(err); },
+      90);
+
+    try {
+      // The first connect attempt fails immediately; no backoff has elapsed
+      // yet, so this settles as soon as the rejection propagates.
+      await waitForCondition(() => errors.length > 0);
+    } finally {
+      disconnect();
+    }
+
+    expect(errors).toHaveLength(1);
+  });
+
+  it("preserves the status code and diagnostic body on the reported error", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      fakeStreamResponse(false, 404, "Not Found", "text/plain", "feed_not_found")
+    ) as any;
+
+    const errors: Error[] = [];
+    const disconnect = connection().getStream(
+      "/feeds/deadbeef?b=482.117.9",
+      async () => { },
+      err => { errors.push(err); },
+      90);
+
+    try {
+      await waitForCondition(() => errors.length > 0);
+    } finally {
+      disconnect();
+    }
+
+    // The polling GET path already does this (issue #234). Without the same
+    // typing here a caller cannot tell "the server forgot this feed" from
+    // "the server is unreachable", and so cannot recover from the first.
+    const error = errors[0] as HttpError;
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error.statusCode).toBe(404);
+    expect(error.body).toBe("feed_not_found");
+  });
+
+  it("does not report an aborted connection as an error", async () => {
+    global.fetch = jest.fn().mockImplementation(async () => {
+      const abort: any = new Error("The operation was aborted.");
+      abort.name = "AbortError";
+      throw abort;
+    }) as any;
+
+    const errors: Error[] = [];
+    const disconnect = connection().getStream(
+      "/feeds/deadbeef?b=482.117.9",
+      async () => { },
+      err => { errors.push(err); },
+      90);
+
+    // Give the connect attempt a turn of the event loop to reject and be
+    // classified, then confirm nothing was reported. There is no positive
+    // event to wait for here -- the assertion is that none occurs.
+    await waitForCondition(() => (global.fetch as jest.Mock).mock.calls.length > 0);
+    disconnect();
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("still reports errors raised once the stream is open", async () => {
+    // A body whose reader rejects: the pre-existing read-loop path to onError,
+    // which must keep working alongside the new connect-failure path.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { get: () => null },
+      body: { getReader: () => ({ read: async () => { throw new Error("stream broke"); } }) }
+    }) as any;
+
+    const errors: Error[] = [];
+    const disconnect = connection().getStream(
+      "/feeds/deadbeef?b=482.117.9",
+      async () => { },
+      err => { errors.push(err); },
+      90);
+
+    try {
+      await waitForCondition(() => errors.length > 0);
+    } finally {
+      disconnect();
+    }
+
+    expect(errors[0].message).toBe("stream broke");
+  });
+});

--- a/test/managers/feedReregistrationSpec.ts
+++ b/test/managers/feedReregistrationSpec.ts
@@ -1,0 +1,137 @@
+import { HttpError, User } from "@src";
+import { DistributionIntersectionBranch } from "../../src/distribution/distribution-engine";
+import { FeedResponse, FeedsResponse } from "../../src/http/messages";
+import { Network, NetworkManager } from "../../src/managers/NetworkManager";
+import { MemoryStore } from "../../src/memory/memory-store";
+import { Specification } from "../../src/specification/specification";
+import { FactEnvelope, FactReference } from "../../src/storage";
+import { Company, model, Office } from "../companyModel";
+import { waitForCondition } from "../utils/async-test-utils";
+
+/**
+ * A replicator stand-in that records every `POST /feeds` registration and hands
+ * back the `onError` callback of the live stream, so a test can deliver the
+ * failure a real replicator would send after it restarts and lost the feed.
+ */
+class RestartableNetwork implements Network {
+    public readonly registrations: { start: FactReference[], specification: Specification }[] = [];
+    public streamErrors: ((err: Error) => void)[] = [];
+
+    feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse> {
+        this.registrations.push({ start, specification });
+        return Promise.resolve({ feeds: ["feed1"] });
+    }
+
+    fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
+        return Promise.resolve({ references: [], bookmark });
+    }
+
+    streamFeed(feed: string, bookmark: string, onResponse: (factReferences: FactReference[], nextBookmark: string) => Promise<void>, onError: (err: Error) => void): () => void {
+        this.streamErrors.push(onError);
+        // Deliver once so Subscriber.start() resolves, putting the subscription
+        // in the steady state where this defect lives: past its first delivery.
+        onResponse([], bookmark);
+        return () => { };
+    }
+
+    load(factReferences: FactReference[]): Promise<FactEnvelope[]> {
+        return Promise.resolve([]);
+    }
+
+    intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {
+        return Promise.resolve([{ start, specification }]);
+    }
+
+    // The error callback of the most recently opened stream.
+    get lastStreamError(): (err: Error) => void {
+        return this.streamErrors[this.streamErrors.length - 1];
+    }
+}
+
+describe("Feed re-registration after a replicator restart (issue #243)", () => {
+    let network: RestartableNetwork;
+    let store: MemoryStore;
+    let manager: NetworkManager;
+    let spec: Specification;
+    let subscribedFeeds: string[] | undefined;
+
+    beforeEach(() => {
+        network = new RestartableNetwork();
+        store = new MemoryStore();
+        manager = new NetworkManager(network, store, async () => { });
+        new User("--- PUBLIC KEY GOES HERE ---");
+        spec = model.given(Company).match((company, facts) =>
+            facts.ofType(Office).join(office => office.company, company)
+        ).specification;
+        subscribedFeeds = undefined;
+    });
+
+    afterEach(() => {
+        // Release the subscription so its refresh interval does not outlive
+        // the test.
+        if (subscribedFeeds) {
+            manager.unsubscribe(subscribedFeeds);
+            subscribedFeeds = undefined;
+        }
+    });
+
+    async function subscribe() {
+        const { feeds } = await manager.subscribe([], spec);
+        subscribedFeeds = feeds;
+    }
+
+    it("re-registers the specification when a live stream reports feed_not_found", async () => {
+        await subscribe();
+        expect(network.registrations).toHaveLength(1);
+
+        // The replicator restarted: it still routes /feeds/:hash but no longer
+        // holds this registration, so it answers 404 feed_not_found.
+        network.lastStreamError(new HttpError("feed_not_found", 404, "feed_not_found"));
+
+        await waitForCondition(() => network.registrations.length > 1);
+        expect(network.registrations).toHaveLength(2);
+    });
+
+    it("re-registers the same start and specification, so the feed hash and its bookmark still apply", async () => {
+        await subscribe();
+        network.lastStreamError(new HttpError("feed_not_found", 404, "feed_not_found"));
+        await waitForCondition(() => network.registrations.length > 1);
+
+        // The feed hash is derived from the feed definition, so re-registering
+        // the same specification restores the hash the subscriber is already
+        // streaming -- and the bookmark stored against that hash still applies.
+        // Recovery resumes where the subscription left off; it does not replay.
+        expect(network.registrations[1].specification).toEqual(network.registrations[0].specification);
+        expect(network.registrations[1].start).toEqual(network.registrations[0].start);
+    });
+
+    it("does not re-register for failures that are not the server forgetting the feed", async () => {
+        await subscribe();
+
+        // Neither a server-side fault nor an untyped transport error means the
+        // registration is gone; re-registering on those would turn every blip
+        // into a POST storm. Only the documented 404 warrants it.
+        network.lastStreamError(new HttpError("Internal Server Error", 500, ""));
+        network.lastStreamError(new Error("network request failed"));
+
+        // Then a 404, whose re-registration is the deterministic signal that
+        // the two errors above have already been processed and ignored.
+        network.lastStreamError(new HttpError("feed_not_found", 404, "feed_not_found"));
+
+        await waitForCondition(() => network.registrations.length > 1);
+        expect(network.registrations).toHaveLength(2);
+    });
+
+    it("collapses a burst of feed_not_found errors into one re-registration", async () => {
+        await subscribe();
+
+        // Every retry in the stream's backoff loop reports the same 404. Each
+        // must not mint its own POST /feeds.
+        network.lastStreamError(new HttpError("feed_not_found", 404, "feed_not_found"));
+        network.lastStreamError(new HttpError("feed_not_found", 404, "feed_not_found"));
+        network.lastStreamError(new HttpError("feed_not_found", 404, "feed_not_found"));
+
+        await waitForCondition(() => network.registrations.length > 1);
+        expect(network.registrations).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
Fixes #243.

Independent of #261 (issue #245) — different path, no stack. Both branch from `main`.

## What was wrong

Once a `j.subscribe()` observer had delivered its first result, it could never recover from the replicator losing its feed registration — a process restart, or a policy reload that rebuilt the server's `FeedCache`. It retried the same doomed URL forever and went permanently, silently quiet. Not "redelivers everything from scratch": it never delivered anything again, with no error event and no log line.

The replicator already has a contract for exactly this. `GET /feeds/:hash` answers 404 `feed_not_found` when the route is known but the registration is gone, so the client can re-register via `POST /feeds`. `NetworkManager` implements the client half — but the only path that reached it was `Subscriber.start()`'s promise rejecting, which per `stop()` happens only *before the first delivery ever arrives*. Once `resolved` flipped to `true`, that path was dead for the rest of the subscriber's life, including across its own periodic `setInterval` reconnects.

Two things kept it dead, and both are fixed here.

## The changes

**`src/http/fetch.ts` — stop discarding the status, and report connect failures.**

A non-ok connect threw a plain `Error` carrying neither status code nor body, so "the server forgot this feed" and "the server is unreachable" were indistinguishable to any caller. It now throws the same `HttpError` that `get()` has thrown since #234, with the status and the diagnostic body.

Separately, `onError` was reachable only from the nested `read()` function, which requires a connection that *already opened*. The outer catch swallowed every failure to open one, so not even the existing `Trace.warn` in `Subscriber` fired. It now reports the error before backing off.

**`src/observer/subscriber.ts` — escalate the 404.**

The error handler now recognizes `HttpError` with status 404 and asks its owner to register the feed again. Guarded so at most one re-registration is in flight per subscriber: every attempt in the stream's backoff loop reports the same failure, and an unguarded call would turn one lost registration into a POST storm.

**`src/managers/NetworkManager.ts` — implement re-registration.**

The cached `POST /feeds` response cannot reproduce the call that produced it, and the cache key is a hash, so each cache entry now carries the response *and* the `(start, specification)` it came from:

```ts
interface CachedFeedRegistration {
    cached: CachedFeeds;
    start: FactReference[];
    specification: Specification;
}
```

One entry, one lifetime — there is no second map that can fall out of step as entries are evicted. (This started as a parallel map; review caught that `removeFeedsFromCache` would have leaked its entries, and merging them removes the hazard rather than patching one instance of it.)

On a 404, every cached specification whose feeds include that hash is dropped and re-registered, with one in-flight re-registration per feed.

The feed hash is derived from the feed definition, so re-registering the same specification restores the very hash the subscriber is already streaming, and the bookmark the store holds against that hash still applies. **Recovery resumes where the subscription left off rather than replaying history** — which is what the issue notes the durable `fact_id` bookmarks were designed for.

Only a 404 triggers this. A 5xx or an untyped transport error does not mean the registration is gone.

**One adjacent change:** the backoff is now cut short by `disconnect()`. It previously stayed parked in a timer for up to `feedRefreshIntervalSeconds` after the caller had let go, which both delayed teardown and left a pending timer whose only remaining job was to observe that the stream had closed. This surfaced as a Jest open handle while writing the tests.

## Regression tests

`test/http/fetchStreamReconnectSpec.ts` (4 tests) pins the reporting and typing of a connect failure, that an `AbortError` is still not reported as one, and that the pre-existing read-loop path to `onError` keeps working.

`test/managers/feedReregistrationSpec.ts` (4 tests) pins the recovery at the `Subscriber`/`NetworkManager` seam: a 404 on a live stream re-registers; it re-registers the *same* start and specification, so the hash and bookmark still apply; a 500 and an untyped error do not; and a burst of 404s collapses to one `POST /feeds`.

**Before this change:** the two tests asserting the new behaviour in `fetchStreamReconnectSpec` fail (`onError` never fires), and all four in `feedReregistrationSpec` fail (no re-registration). The other two in `fetchStreamReconnectSpec` pass, as they pin behaviour that already held.

**After:** all 8 pass.

Per CLAUDE.md, these test the failing mechanism rather than only end-to-end, since `JinagaTest` green is not sufficient evidence here.

## Verification

`npm ci && npm run build && npm test` run locally on Node 22: **671 tests passing**, no failures.

## Notes beyond this diff

- The WebSocket path (`src/ws/wsGraphNetwork.ts`) reports plain `Error`s, so the `instanceof HttpError` check does not fire there. That path has its own reconnect handling and is untouched by this change; whether it needs an equivalent recovery signal is a separate question.
- `attempt` in `getStream`'s retry loop is never reset after a successful connect, so a stream that reconnects repeatedly over a long life keeps its backoff pinned at the `feedRefreshIntervalSeconds` cap. Left alone to keep this diff minimal.