### PR TITLE
Flush the save queue in bounded batches, and report when it stalls (#245)

### DIFF
--- a/src/fork/persistent-fork.ts
+++ b/src/fork/persistent-fork.ts
@@ -5,7 +5,7 @@ import { FactEnvelope, factEnvelopeEquals, FactRecord, FactReference, Queue, Sto
 import { Trace } from "../util/trace";
 import { Fork } from "./fork";
 import { serializeLoad } from './serialize';
-import { WebClientSaver } from './web-client-saver';
+import { WebClientSaver, WebClientSaverOptions } from './web-client-saver';
 
 export class PersistentFork implements Fork {
     private queueProcessor: QueueProcessor;
@@ -14,9 +14,10 @@ export class PersistentFork implements Fork {
         private storage: Storage,
         private queue: Queue,
         private client: WebClient,
-        private delayMilliseconds: number
+        private delayMilliseconds: number,
+        saverOptions: WebClientSaverOptions = {}
     ) {
-        const saver = new WebClientSaver(client, queue);
+        const saver = new WebClientSaver(client, queue, saverOptions);
         this.queueProcessor = new QueueProcessor(saver, delayMilliseconds);
     }
 

--- a/src/fork/web-client-saver.ts
+++ b/src/fork/web-client-saver.ts
@@ -26,13 +26,55 @@ export interface WebClientSaverOptions {
 }
 
 /**
+ * UTF-8 byte length of a string, which is what a request-size limit actually
+ * counts. `String.length` counts UTF-16 code units, so it under-reports every
+ * non-ASCII character -- by a factor of three for CJK text, which is exactly
+ * the data most likely to push a payload over a limit.
+ *
+ * Scanned rather than measured with `TextEncoder`, to avoid allocating a copy
+ * of every fact in the queue on each flush. A lone surrogate is counted as 4
+ * bytes where an encoder would emit a 3-byte replacement character; the budget
+ * is a bound, so erring high is the safe direction.
+ */
+function utf8ByteLength(text: string): number {
+    let bytes = 0;
+    for (let i = 0; i < text.length; i++) {
+        const code = text.charCodeAt(i);
+        if (code < 0x80) {
+            bytes += 1;
+        }
+        else if (code < 0x800) {
+            bytes += 2;
+        }
+        else if (code >= 0xd800 && code <= 0xdbff) {
+            // High surrogate: the pair encodes to four bytes.
+            bytes += 4;
+            i++;
+        }
+        else {
+            bytes += 3;
+        }
+    }
+    return bytes;
+}
+
+/**
  * Estimate the serialized size of one envelope. This is deliberately an
  * estimate: the caller picks between the graph and JSON encodings inside
  * `saveWithRetry`, so the exact wire size is not knowable here. The batch
  * budget is a bound with headroom, not an accounting.
  */
 function estimateSize(envelope: FactEnvelope): number {
-    return JSON.stringify(envelope).length;
+    return utf8ByteLength(JSON.stringify(envelope));
+}
+
+/**
+ * Take a caller-supplied bound only when it is a positive number. Zero or a
+ * negative value would put one fact in every request, or none at all, rather
+ * than doing what the name promises.
+ */
+function positiveOr(value: number | undefined, fallback: number): number {
+    return typeof value === 'number' && value > 0 ? value : fallback;
 }
 
 /**
@@ -82,8 +124,8 @@ export class WebClientSaver implements Saver {
         private readonly queue: Queue,
         options: WebClientSaverOptions = {}
     ) {
-        this.maxBatchBytes = options.maxBatchBytes ?? DEFAULT_MAX_SAVE_BATCH_BYTES;
-        this.maxBatchCount = options.maxBatchCount ?? DEFAULT_MAX_SAVE_BATCH_COUNT;
+        this.maxBatchBytes = positiveOr(options.maxBatchBytes, DEFAULT_MAX_SAVE_BATCH_BYTES);
+        this.maxBatchCount = positiveOr(options.maxBatchCount, DEFAULT_MAX_SAVE_BATCH_COUNT);
     }
 
     /**

--- a/src/fork/web-client-saver.ts
+++ b/src/fork/web-client-saver.ts
@@ -1,30 +1,153 @@
 import { WebClient } from "../http/web-client";
 import { Saver } from "../managers/QueueProcessor";
-import { Queue } from "../storage";
+import { FactEnvelope, Queue } from "../storage";
 import { Trace } from "../util/trace";
+
+/**
+ * Approximate upper bound on the serialized size of one `POST /save` request
+ * (issue #245). A proxy in front of the replicator commonly caps request
+ * bodies -- nginx's default `client_max_body_size` is 1 MB -- and a queue
+ * flushed as one request will eventually exceed any such cap. This default
+ * leaves generous headroom under the common 1 MB limit, because the budget is
+ * measured against an estimate rather than the exact wire form.
+ */
+export const DEFAULT_MAX_SAVE_BATCH_BYTES = 256 * 1024;
+
+/**
+ * Upper bound on the number of facts in one `POST /save`, so a queue of many
+ * tiny facts is still split into requests the replicator can process
+ * comfortably.
+ */
+export const DEFAULT_MAX_SAVE_BATCH_COUNT = 200;
+
+export interface WebClientSaverOptions {
+    maxBatchBytes?: number;
+    maxBatchCount?: number;
+}
+
+/**
+ * Estimate the serialized size of one envelope. This is deliberately an
+ * estimate: the caller picks between the graph and JSON encodings inside
+ * `saveWithRetry`, so the exact wire size is not knowable here. The batch
+ * budget is a bound with headroom, not an accounting.
+ */
+function estimateSize(envelope: FactEnvelope): number {
+    return JSON.stringify(envelope).length;
+}
+
+/**
+ * Split the queue into batches that respect both bounds, preserving order.
+ *
+ * Order is not incidental. Facts form a DAG, and a fact later in the queue may
+ * name an earlier one as a predecessor, so batches must be sent in the order
+ * they were queued.
+ *
+ * An envelope larger than the byte budget gets a batch to itself. It cannot be
+ * made to fit by batching, but dropping it would silently lose a write, and
+ * merging it with neighbours would only take them down with it.
+ */
+export function batchEnvelopes(envelopes: FactEnvelope[], maxBatchBytes: number, maxBatchCount: number): FactEnvelope[][] {
+    const batches: FactEnvelope[][] = [];
+    let current: FactEnvelope[] = [];
+    let currentBytes = 0;
+
+    for (const envelope of envelopes) {
+        const size = estimateSize(envelope);
+        const wouldExceed = current.length > 0 &&
+            (currentBytes + size > maxBatchBytes || current.length >= maxBatchCount);
+        if (wouldExceed) {
+            batches.push(current);
+            current = [];
+            currentBytes = 0;
+        }
+        current.push(envelope);
+        currentBytes += size;
+    }
+
+    if (current.length > 0) {
+        batches.push(current);
+    }
+    return batches;
+}
 
 /**
  * A Saver implementation that uses a WebClient to save facts.
  */
 export class WebClientSaver implements Saver {
+    private readonly maxBatchBytes: number;
+    private readonly maxBatchCount: number;
+
     constructor(
         private readonly client: WebClient,
-        private readonly queue: Queue
-    ) { }
+        private readonly queue: Queue,
+        options: WebClientSaverOptions = {}
+    ) {
+        this.maxBatchBytes = options.maxBatchBytes ?? DEFAULT_MAX_SAVE_BATCH_BYTES;
+        this.maxBatchCount = options.maxBatchCount ?? DEFAULT_MAX_SAVE_BATCH_COUNT;
+    }
 
     /**
      * Saves facts to the server and removes them from the queue.
+     *
+     * The queue is flushed in size-bounded batches, and each batch that
+     * succeeds is dequeued before the next is attempted (issue #245). Flushing
+     * the whole queue as one request made the failure permanent: once the
+     * accumulated payload passed a request-size limit anywhere between the
+     * client and the replicator, every later write made the next attempt larger
+     * and more certain to fail, so the queue could only grow.
+     *
+     * The flush stops at the first batch that fails rather than skipping past
+     * it. A fact behind the failed batch may name one of its facts as a
+     * predecessor, and sending it first would leave a dangling reference.
+     * Stopping still makes progress -- everything ahead of the blocking batch
+     * has drained -- so the queue shrinks instead of growing without bound.
      */
     async save(): Promise<void> {
         const envelopes = await this.queue.peek();
-        if (envelopes.length > 0) {
+        if (envelopes.length === 0) {
+            return;
+        }
+
+        const batches = batchEnvelopes(envelopes, this.maxBatchBytes, this.maxBatchCount);
+        let sent = 0;
+
+        this.client.notifySyncStatus({
+            sending: true,
+            retrying: false,
+            retryInSeconds: 0,
+            warning: ""
+        });
+
+        for (const batch of batches) {
             try {
-                await this.client.saveWithRetry(envelopes);
-                await this.queue.dequeue(envelopes);
+                await this.client.saveWithRetry(batch);
+                await this.queue.dequeue(batch);
+                sent += batch.length;
             }
             catch (error) {
                 Trace.error(error);
+                // Report the stall rather than only logging it. Without this an
+                // application sees every write resolve normally while its local
+                // store diverges from the replicator, with nothing anywhere to
+                // tell it -- the failure that made the reported incident
+                // invisible for as long as it was.
+                const remaining = envelopes.length - sent;
+                const reason = error instanceof Error ? error.message : `${error}`;
+                this.client.notifySyncStatus({
+                    sending: false,
+                    retrying: false,
+                    retryInSeconds: 0,
+                    warning: `${remaining} fact(s) could not be sent to the replicator: ${reason}`
+                });
+                return;
             }
         }
+
+        this.client.notifySyncStatus({
+            sending: false,
+            retrying: false,
+            retryInSeconds: 0,
+            warning: ""
+        });
     }
 }

--- a/src/http/web-client.ts
+++ b/src/http/web-client.ts
@@ -95,6 +95,16 @@ export class WebClient {
         return <LoginResponse> await this.httpConnection.get('/login');
     }
 
+    /**
+     * Publish a sync status to whoever registered through `j.onSyncStatus`.
+     * The notifier has been held here since the client was written but never
+     * fired, so the public handler could never observe anything. The save
+     * queue uses it to report that it is not draining (issue #245).
+     */
+    notifySyncStatus(status: SyncStatus) {
+        this.syncStatusNotifier.notify(status);
+    }
+
     async save(envelopes: FactEnvelope[]) {
         if (this.saveContentTypes === null) {
             this.saveContentTypes = await this.httpConnection.getAcceptedContentTypes('/save');

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export { AuthenticationProvider, HttpHeaders } from "./http/authenticationProvid
 export { GraphDeserializer, GraphSource } from "./http/deserializer";
 export { ForbiddenError, HttpError } from "./http/errors";
 export { FetchConnection } from "./http/fetch";
+export { DEFAULT_MAX_SAVE_BATCH_BYTES, DEFAULT_MAX_SAVE_BATCH_COUNT, WebClientSaverOptions } from "./fork/web-client-saver";
 export { HttpNetwork } from "./http/httpNetwork";
 export { parseFeedsResponse, parseLoadMessage, parseSaveMessage } from './http/messageParsers';
 export {

--- a/src/jinaga-browser.ts
+++ b/src/jinaga-browser.ts
@@ -62,7 +62,22 @@ export type JinagaBrowserConfig = {
      * deliberate trade: a bounded, logged loss of the delivery guarantee in
      * place of an unbounded wedge.
      */
-    listenerTimeoutMs?: number
+    listenerTimeoutMs?: number,
+    /**
+     * Approximate maximum serialized size, in bytes, of one `POST /save`
+     * request (issue #245). The outgoing queue is flushed in batches under this
+     * bound instead of as one request, so a queue that grows past a
+     * request-size limit somewhere between the client and the replicator still
+     * drains. Set it below the smallest limit in that path -- a proxy's
+     * `client_max_body_size`, an API gateway's payload cap. Defaults to
+     * `DEFAULT_MAX_SAVE_BATCH_BYTES`.
+     */
+    saveBatchBytes?: number,
+    /**
+     * Maximum number of facts in one `POST /save` request. Defaults to
+     * `DEFAULT_MAX_SAVE_BATCH_COUNT`.
+     */
+    saveBatchCount?: number
 }
 
 export class JinagaBrowser {
@@ -140,7 +155,10 @@ function createFork(
         if (config.indexedDb) {
             const queue = new IndexedDBQueue(config.indexedDb);
             const queueProcessingDelay = config.queueProcessingDelayMs || 100;
-            const fork = new PersistentFork(store, queue, webClient, queueProcessingDelay);
+            const fork = new PersistentFork(store, queue, webClient, queueProcessingDelay, {
+                maxBatchBytes: config.saveBatchBytes,
+                maxBatchCount: config.saveBatchCount
+            });
             fork.initialize();
             return fork;
         }

--- a/test/fork/webClientSaverSpec.ts
+++ b/test/fork/webClientSaverSpec.ts
@@ -1,0 +1,220 @@
+import { SyncStatus, SyncStatusNotifier, WebClient } from "@src";
+import { ContentTypeJson, PostAccept, PostContentType } from "../../src/http/ContentType";
+import { HttpConnection, HttpResponse } from "../../src/http/web-client";
+import { WebClientSaver } from "../../src/fork/web-client-saver";
+import { FactEnvelope, Queue } from "../../src/storage";
+
+/**
+ * A connection that enforces a request-size limit, the way a proxy in front of
+ * the replicator does. nginx's default `client_max_body_size` is 1m; anything
+ * over it comes back 413 before the replicator ever sees the request.
+ */
+class SizeLimitedConnection implements HttpConnection {
+    public readonly bodySizes: number[] = [];
+
+    constructor(private readonly maxBodyBytes: number) { }
+
+    get(path: string): Promise<{}> {
+        throw new Error("not used");
+    }
+
+    getStream(): () => void {
+        throw new Error("not used");
+    }
+
+    async post(path: string, contentType: PostContentType, accept: PostAccept, body: string, timeoutSeconds: number): Promise<HttpResponse> {
+        this.bodySizes.push(body.length);
+        if (body.length > this.maxBodyBytes) {
+            // 413 is not retryable, so this surfaces immediately rather than
+            // spending the limited-retry budget on a request that can never fit.
+            return {
+                result: "failure",
+                error: "Payload Too Large",
+                statusCode: 413,
+                body: ""
+            };
+        }
+        return { result: "success", response: {} };
+    }
+
+    async getAcceptedContentTypes(path: string): Promise<string[]> {
+        return [ContentTypeJson];
+    }
+}
+
+class FakeQueue implements Queue {
+    constructor(public envelopes: FactEnvelope[]) { }
+
+    async peek(): Promise<FactEnvelope[]> {
+        return this.envelopes;
+    }
+
+    async enqueue(envelopes: FactEnvelope[]): Promise<void> {
+        this.envelopes = [...this.envelopes, ...envelopes];
+    }
+
+    async dequeue(envelopes: FactEnvelope[]): Promise<void> {
+        const removed = new Set(envelopes.map(e => e.fact.hash));
+        this.envelopes = this.envelopes.filter(e => !removed.has(e.fact.hash));
+    }
+}
+
+// A fact whose serialized size is driven by one padded field, so a test can
+// say "this one is too big to send" without depending on real domain shapes.
+function envelope(hash: string, payloadBytes: number): FactEnvelope {
+    return {
+        fact: {
+            type: "Test.Fact",
+            hash,
+            predecessors: {},
+            fields: { payload: "x".repeat(payloadBytes) }
+        },
+        signatures: []
+    };
+}
+
+describe("Save queue flush (issue #245)", () => {
+    const maxBodyBytes = 4000;
+    // Well under the connection's limit, so several envelopes ride in one
+    // request but the whole queue cannot.
+    const maxBatchBytes = 1500;
+
+    let connection: SizeLimitedConnection;
+    let notifier: SyncStatusNotifier;
+    let statuses: SyncStatus[];
+    let client: WebClient;
+
+    beforeEach(() => {
+        connection = new SizeLimitedConnection(maxBodyBytes);
+        notifier = new SyncStatusNotifier();
+        statuses = [];
+        notifier.onSyncStatus(status => statuses.push(status));
+        client = new WebClient(connection, notifier, { timeoutSeconds: 30 });
+    });
+
+    function saver(queue: Queue) {
+        return new WebClientSaver(client, queue, { maxBatchBytes });
+    }
+
+    it("drains a queue whose whole payload exceeds the request limit", async () => {
+        // Twelve facts of ~400 bytes each: about 4.8 KB in one request, past
+        // the limit, but comfortable in batches.
+        const queue = new FakeQueue(
+            Array.from({ length: 12 }, (_, i) => envelope(`fact${i}`, 400)));
+
+        await saver(queue).save();
+
+        expect(queue.envelopes).toHaveLength(0);
+        expect(connection.bodySizes.length).toBeGreaterThan(1);
+        expect(Math.max(...connection.bodySizes)).toBeLessThanOrEqual(maxBodyBytes);
+    });
+
+    it("does not grow monotonically once a flush has failed", async () => {
+        // The failure mode from the report: the queue only ever got larger, so
+        // every attempt was more certain to fail than the last.
+        const queue = new FakeQueue([
+            ...Array.from({ length: 6 }, (_, i) => envelope(`small${i}`, 400)),
+            envelope("enormous", maxBodyBytes * 2),
+            ...Array.from({ length: 6 }, (_, i) => envelope(`later${i}`, 400))
+        ]);
+
+        await saver(queue).save();
+        const afterFirst = queue.envelopes.length;
+
+        await queue.enqueue([envelope("newWrite", 400)]);
+        await saver(queue).save();
+
+        expect(afterFirst).toBeLessThan(13);
+        expect(queue.envelopes.length).toBeLessThanOrEqual(afterFirst + 1);
+    });
+
+    it("stops at the first batch that fails, keeping facts that may depend on it", async () => {
+        const queue = new FakeQueue([
+            ...Array.from({ length: 6 }, (_, i) => envelope(`small${i}`, 400)),
+            envelope("enormous", maxBodyBytes * 2),
+            ...Array.from({ length: 6 }, (_, i) => envelope(`later${i}`, 400))
+        ]);
+
+        await saver(queue).save();
+
+        const remaining = queue.envelopes.map(e => e.fact.hash);
+        // Everything ahead of the blocking fact is gone.
+        expect(remaining).not.toContain("small0");
+        expect(remaining).not.toContain("small5");
+        // The blocking fact stays, and so does everything behind it: a later
+        // fact may name an earlier one as a predecessor, and sending it while
+        // its predecessor is still queued would leave a dangling reference.
+        expect(remaining).toContain("enormous");
+        expect(remaining).toContain("later0");
+        expect(remaining).toContain("later5");
+    });
+
+    it("reports a queue that is not draining through sync status", async () => {
+        const queue = new FakeQueue([
+            envelope("enormous", maxBodyBytes * 2),
+            envelope("behind", 400)
+        ]);
+
+        await saver(queue).save();
+
+        // Today the transport error is logged and discarded, so an application
+        // has no way to learn its local store has diverged from the replicator.
+        const warning = statuses.find(s => s.warning.length > 0);
+        expect(warning).toBeDefined();
+        expect(warning!.warning).toContain("2");
+        expect(warning!.sending).toBe(false);
+    });
+
+    it("reports no warning once the queue drains", async () => {
+        const queue = new FakeQueue(
+            Array.from({ length: 4 }, (_, i) => envelope(`fact${i}`, 400)));
+
+        await saver(queue).save();
+
+        expect(queue.envelopes).toHaveLength(0);
+        expect(statuses.length).toBeGreaterThan(0);
+        expect(statuses[statuses.length - 1].warning).toBe("");
+        expect(statuses[statuses.length - 1].sending).toBe(false);
+    });
+
+    it("gives a fact over the batch budget a request to itself, without dropping it", async () => {
+        // A fact larger than the batch budget cannot be made to fit by
+        // batching. It must still be attempted -- silently skipping it would
+        // lose a write -- and it must not drag its neighbours into a request
+        // that is oversized because of it.
+        const queue = new FakeQueue([
+            envelope("small", 200),
+            envelope("oversized", maxBatchBytes * 2),
+            envelope("alsoSmall", 200)
+        ]);
+
+        await saver(queue).save();
+
+        // Three requests: the small one, the oversized one alone, the last one.
+        expect(connection.bodySizes).toHaveLength(3);
+        expect(queue.envelopes).toHaveLength(0);
+    });
+
+    it("keeps a fact that no request can carry, and everything behind it", async () => {
+        // Over the connection's limit too, so it can never be sent. It stays
+        // queued rather than being discarded, and it blocks what follows.
+        const queue = new FakeQueue([
+            envelope("sendable", 200),
+            envelope("unsendable", maxBodyBytes * 2),
+            envelope("behind", 200)
+        ]);
+
+        await saver(queue).save();
+
+        expect(queue.envelopes.map(e => e.fact.hash)).toEqual(["unsendable", "behind"]);
+    });
+
+    it("makes no request for an empty queue", async () => {
+        const queue = new FakeQueue([]);
+
+        await saver(queue).save();
+
+        expect(connection.bodySizes).toHaveLength(0);
+        expect(statuses).toHaveLength(0);
+    });
+});

--- a/test/fork/webClientSaverSpec.ts
+++ b/test/fork/webClientSaverSpec.ts
@@ -23,8 +23,11 @@ class SizeLimitedConnection implements HttpConnection {
     }
 
     async post(path: string, contentType: PostContentType, accept: PostAccept, body: string, timeoutSeconds: number): Promise<HttpResponse> {
-        this.bodySizes.push(body.length);
-        if (body.length > this.maxBodyBytes) {
+        // Bytes on the wire, which is what a proxy limit counts -- not
+        // `String.length`, which is UTF-16 code units.
+        const bytes = Buffer.byteLength(body, "utf8");
+        this.bodySizes.push(bytes);
+        if (bytes > this.maxBodyBytes) {
             // 413 is not retryable, so this surfaces immediately rather than
             // spending the limited-retry budget on a request that can never fit.
             return {
@@ -207,6 +210,47 @@ describe("Save queue flush (issue #245)", () => {
         await saver(queue).save();
 
         expect(queue.envelopes.map(e => e.fact.hash)).toEqual(["unsendable", "behind"]);
+    });
+
+    it("measures the budget in UTF-8 bytes, not UTF-16 code units", async () => {
+        // A limit set just above the batch budget, the way an operator would
+        // set the budget under a known proxy limit.
+        const tightLimit = maxBatchBytes + 500;
+        const tightConnection = new SizeLimitedConnection(tightLimit);
+        const tightClient = new WebClient(tightConnection, notifier, { timeoutSeconds: 30 });
+
+        // Each of these characters is one UTF-16 code unit but three UTF-8
+        // bytes. Counting `String.length` under-reports the payload threefold
+        // and packs batches well past the limit -- and non-ASCII text is
+        // exactly the data most likely to push a payload over a limit.
+        const queue = new FakeQueue(
+            Array.from({ length: 6 }, (_, i) => ({
+                fact: {
+                    type: "Test.Fact",
+                    hash: `wide${i}`,
+                    predecessors: {},
+                    fields: { payload: "漢".repeat(400) }
+                },
+                signatures: []
+            })));
+
+        await new WebClientSaver(tightClient, queue, { maxBatchBytes }).save();
+
+        expect(queue.envelopes).toHaveLength(0);
+        expect(Math.max(...tightConnection.bodySizes)).toBeLessThanOrEqual(tightLimit);
+    });
+
+    it("falls back to the defaults for a non-positive bound", async () => {
+        // Zero would put one fact in every request, and a negative value none
+        // at all. Neither is what the option name promises, so neither is
+        // honoured.
+        const queue = new FakeQueue(
+            Array.from({ length: 4 }, (_, i) => envelope(`fact${i}`, 100)));
+
+        await new WebClientSaver(client, queue, { maxBatchBytes: 0, maxBatchCount: -1 }).save();
+
+        expect(queue.envelopes).toHaveLength(0);
+        expect(connection.bodySizes).toHaveLength(1);
     });
 
     it("makes no request for an empty queue", async () => {


### PR DESCRIPTION
Fixes #245.

Independent of #260 (issue #243) — different path, no stack. Both branch from `main`.

## What was wrong

`WebClientSaver.save()` peeked the whole queue and sent it as one `POST /save`. Once the accumulated payload passed a request-size limit anywhere between the client and the replicator — nginx's default `client_max_body_size` is 1m — that request failed permanently. The error was caught and passed to `Trace.error`, and nothing else. Every later write grew the payload, so each attempt was more certain to fail than the last.

The reported incident had 3362 unsent facts, including 20 `Event.Delete` facts the UI had reported as successful and the replicator had never seen.

Three properties compounded: **all-or-nothing flush**, **no size bound**, and **silent failure**. This PR addresses all three, though the first two are what make the condition permanent.

## The changes

**Batched flush — `src/fork/web-client-saver.ts`.**

The queue is now split into batches bounded by serialized size *and* fact count, and each batch that succeeds is dequeued before the next is attempted.

Size is measured in **UTF-8 bytes**, which is what a request-size limit counts — `String.length` would under-report non-ASCII text threefold, and that is exactly the data most likely to push a payload over a limit. The bound is still approximate in one respect: `saveWithRetry` chooses between the graph and JSON encodings internally, so the exact wire form is not knowable at this layer. `DEFAULT_MAX_SAVE_BATCH_BYTES` is 256 KB, leaving headroom under the common 1 MB proxy limit. `DEFAULT_MAX_SAVE_BATCH_COUNT` is 200.

**The flush stops at the first batch that fails**, rather than skipping past it. This is the one place the issue's suggested fix needed adjusting: facts form a DAG, and a fact behind the failed batch may name one of its facts as a predecessor, so sending it first would leave a dangling reference. Stopping still delivers what the issue is after — everything ahead of the blocking batch has drained, so the queue *shrinks* instead of growing without bound, and a single oversized fact no longer blocks the unrelated writes queued before it.

A fact larger than the batch budget gets a request to itself. Batching cannot make it fit, but dropping it would silently lose a write, and merging it with neighbours would only take them down with it.

**Configurable — `src/jinaga-browser.ts`.** `saveBatchBytes` and `saveBatchCount` join `queueProcessingDelayMs` and `listenerTimeoutMs`, for a deployment whose limit is lower than the default assumes. A non-positive value falls back to the default rather than being honoured.

**Surfaced failure — `src/http/web-client.ts`.**

`WebClient` has held a `SyncStatusNotifier` since it was written and **never once called `notify`**, so `j.onSyncStatus` — a public, documented handler — could never observe anything. That is now a `notifySyncStatus` passthrough, and the saver reports through it: `sending: true` while a flush is in progress, and on a stall a warning naming how many facts are left unsent and why. An application can finally learn that its local store has diverged from the replicator.

This reuses the existing public channel rather than inventing a new one. The issue floated "an error callback, or an observable queue depth"; `SyncStatus.warning` is already the shape for exactly this and is already reachable from `j`.

## Regression tests

`test/fork/webClientSaverSpec.ts` (10 tests) drives a stub `HttpConnection` that enforces a request-size limit the way a proxy does — measured in UTF-8 bytes, returning 413 over it — through a real `WebClient`, so the real serialization is exercised:

- a queue whose whole payload exceeds the limit drains, in more than one request, none over the limit
- the queue does not grow monotonically once a flush has failed
- the flush stops at the first failing batch, keeping facts that may depend on it
- the stall is reported through sync status, naming the remaining count
- a clean drain reports no warning
- a fact over the batch budget gets a request to itself and is not dropped
- a fact no request can carry stays queued, and so does everything behind it
- the budget is measured in UTF-8 bytes, not UTF-16 code units
- a non-positive bound falls back to the default
- an empty queue makes no request

**Before this change: 7 of the original 8 fail** (verified by reverting only the `save()` body to the single-request form and re-running). The eighth — the empty queue — pins behaviour that already held. The two tests added in the review round likewise fail without their fixes.

**After: all 10 pass.**

## Verification

`npm ci && npm run build && npm test` run locally on Node 22: **673 tests passing**, no failures.

## Deliberately not done

The issue also suggests a **queue-depth ceiling** with a loud error, "so the failure mode is writes start failing visibly rather than writes silently stop reaching the server." That is a policy call, not a defect fix: it changes what `j.fact()` does on a client that is merely offline for a while, and the right ceiling depends on the application. Left for you to decide. With this PR the queue no longer grows without bound in the reported scenario, which was the mechanism that made a ceiling feel necessary.

Also unchanged: `save()` still resolves rather than throwing when a batch fails, so `j.fact()` behaves as before. Changing that is the same policy question.