### PR TITLE
Memoize invertSpecification behind a bounded LRU cache (#266)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export { Declaration } from './specification/declaration';
 export { describeDeclaration, describeSpecification } from './specification/description';
 export { buildFeeds } from './specification/feed-builder';
 export { FeedCache, FeedObject } from "./specification/feed-cache";
-export { invertSpecification, SpecificationInverse } from "./specification/inverse";
+export { clearInverseCache, DEFAULT_INVERSE_CACHE_CAPACITY, inverseCacheStatistics, InverseCacheStatistics, invertSpecification, setInverseCacheCapacity, SpecificationInverse } from "./specification/inverse";
 export { alphaTransform, DISTRIBUTION_USER_LABEL, intersectSpecificationWithDistributionRule, specificationHasIntersection } from "./specification/specification-intersection";
 export { buildModel, FactRepository, LabelOf, Model, ModelBuilder, ProjectionOf, SpecificationOf } from './specification/model';
 export { EdgeDescription, emptySkeleton, FactDescription, InputDescription, NotExistsConditionDescription, OutputDescription, Skeleton, skeletonOfSpecification } from './specification/skeleton';

--- a/src/specification/inverse.ts
+++ b/src/specification/inverse.ts
@@ -23,7 +23,133 @@ interface InverterContext {
     projection: Projection;
 }
 
+/**
+ * How many distinct specifications the inversion cache retains by default.
+ *
+ * Inversion is a pure function of the specification, but every caller
+ * recomputed it: a production session logged 32,528 inversions for roughly 33
+ * distinct specifications, because the server inverts once per streaming
+ * subscription (issue #266). Server workloads see a small, stable set of
+ * specifications, which is the shape that caches well.
+ *
+ * The bound is what makes that safe for the other shape. A caller that
+ * generates specifications dynamically would otherwise grow the cache without
+ * limit, so entries are evicted least-recently-used once the capacity is
+ * reached.
+ */
+export const DEFAULT_INVERSE_CACHE_CAPACITY = 500;
+
+export interface InverseCacheStatistics {
+    /** Distinct specifications currently retained. */
+    size: number;
+    /** The configured bound. Zero means caching is disabled. */
+    capacity: number;
+    /** Calls served from the cache since the last `clearInverseCache`. */
+    hits: number;
+    /** Calls that had to compute an inversion since the last `clearInverseCache`. */
+    misses: number;
+}
+
+/**
+ * Insertion-ordered, so the first key is the least recently used. A hit
+ * re-inserts its key to move it to the end.
+ */
+const inverseCache = new Map<string, SpecificationInverse[]>();
+let inverseCacheCapacity = DEFAULT_INVERSE_CACHE_CAPACITY;
+let inverseCacheHits = 0;
+let inverseCacheMisses = 0;
+
+/**
+ * Bound how many distinct specifications are retained. Pass 0 to disable
+ * caching entirely, which restores the previous compute-every-time behavior.
+ * Lowering the capacity evicts the least recently used entries immediately.
+ */
+export function setInverseCacheCapacity(capacity: number): void {
+    if (!Number.isInteger(capacity) || capacity < 0) {
+        throw new Error(`Inverse cache capacity must be a non-negative integer, but received ${capacity}.`);
+    }
+    inverseCacheCapacity = capacity;
+    trimInverseCache();
+}
+
+/**
+ * Drop every retained inversion and reset the hit and miss counters. Inversion
+ * is pure, so this is never required for correctness; it exists for tests and
+ * for a host that wants to reclaim the memory.
+ */
+export function clearInverseCache(): void {
+    inverseCache.clear();
+    inverseCacheHits = 0;
+    inverseCacheMisses = 0;
+}
+
+/**
+ * Report cache occupancy and the hit and miss counts. Issue #266 could measure
+ * the redundancy but not the compute it costs; this is how a host quantifies
+ * what the cache actually saves in its own workload.
+ */
+export function inverseCacheStatistics(): InverseCacheStatistics {
+    return {
+        size: inverseCache.size,
+        capacity: inverseCacheCapacity,
+        hits: inverseCacheHits,
+        misses: inverseCacheMisses
+    };
+}
+
+function trimInverseCache(): void {
+    while (inverseCache.size > inverseCacheCapacity) {
+        const oldest = inverseCache.keys().next();
+        if (oldest.done) {
+            return;
+        }
+        inverseCache.delete(oldest.value);
+    }
+}
+
+/**
+ * Invert a specification, memoized on the specification itself.
+ *
+ * The key is the hash of the specification's description, which is already
+ * this codebase's identity for a specification: `deduplicateInverses` below
+ * dedupes on it, and `ObservableSource.addSpecificationListener` groups
+ * listeners by it. Computing the key is also strictly cheaper than the
+ * deduplication step alone, which describes every inverse it produced.
+ *
+ * A thrown inversion is not cached. `detectDisconnectedSpecification` and the
+ * infinite-loop guard in `shakeTree` reject a specification outright, so a
+ * caller that retries gets the same rejection rather than a stale success, and
+ * no failure occupies a cache slot.
+ *
+ * The returned array is a copy. The inverses inside it are shared, and callers
+ * have always treated them as read-only, but handing out the stored array
+ * would let one caller's in-place sort reorder what every later caller sees.
+ */
 export function invertSpecification(specification: Specification): SpecificationInverse[] {
+    if (inverseCacheCapacity === 0) {
+        return computeInverses(specification);
+    }
+
+    const key = computeStringHash(describeSpecification(specification, 0));
+    const cached = inverseCache.get(key);
+    if (cached !== undefined) {
+        // Re-insert to mark the entry most recently used.
+        inverseCache.delete(key);
+        inverseCache.set(key, cached);
+        inverseCacheHits++;
+        Trace.counter("invert_specification_cache_hit", 1);
+        return [...cached];
+    }
+
+    inverseCacheMisses++;
+    Trace.counter("invert_specification_cache_miss", 1);
+    const inverses = computeInverses(specification);
+    inverseCache.set(key, inverses);
+    trimInverseCache();
+    return [...inverses];
+}
+
+function computeInverses(specification: Specification): SpecificationInverse[] {
     const givenTypes = specification.given.map(g => g.label.type).join(', ');
     const givenNames = specification.given.map(g => g.label.name).join(', ');
     const matchCount = specification.matches.length;

--- a/src/specification/inverse.ts
+++ b/src/specification/inverse.ts
@@ -108,7 +108,13 @@ function trimInverseCache(): void {
 }
 
 /**
- * Invert a specification, memoized on the specification itself.
+ * Invert a specification, memoized on its STRUCTURE rather than its identity.
+ *
+ * Two distinct `Specification` objects that describe the same thing share one
+ * cache entry, and that is the point rather than a side effect: the server
+ * inverts once per subscription, and the specifications arriving are separate
+ * object graphs of a handful of shapes. Object-identity memoization would miss
+ * every one of those.
  *
  * The key is the hash of the specification's description, which is already
  * this codebase's identity for a specification: `deduplicateInverses` below
@@ -141,9 +147,13 @@ export function invertSpecification(specification: Specification): Specification
         return [...cached];
     }
 
+    // Count the miss only once the inversion has actually succeeded. A
+    // rejected specification caches nothing, so counting it here would inflate
+    // the miss total against a cache that was never given anything to hold,
+    // and understate the hit rate for a host repeatedly inverting a bad spec.
+    const inverses = computeInverses(specification);
     inverseCacheMisses++;
     Trace.counter("invert_specification_cache_miss", 1);
-    const inverses = computeInverses(specification);
     inverseCache.set(key, inverses);
     trimInverseCache();
     return [...inverses];

--- a/test/specification/inverseCacheSpec.ts
+++ b/test/specification/inverseCacheSpec.ts
@@ -1,0 +1,220 @@
+import {
+    DEFAULT_INVERSE_CACHE_CAPACITY,
+    Specification,
+    SpecificationParser,
+    User,
+    buildModel,
+    clearInverseCache,
+    describeSpecification,
+    inverseCacheStatistics,
+    invertSpecification,
+    setInverseCacheCapacity
+} from "@src";
+
+// Issue #266: invertSpecification is pure but was recomputed by every caller.
+// A production session logged 32,528 inversions for ~33 distinct specifications
+// because the server inverts once per streaming subscription.
+//
+// These tests pin the two things a cache must not break — the same answer, and
+// a different answer for a different specification — and the bound that keeps a
+// caller generating many distinct specifications from growing it forever.
+
+class Project {
+    static Type = "Cache.Project" as const;
+    type = Project.Type;
+    constructor(public creator: User, public identifier: string) { }
+}
+
+class Task {
+    static Type = "Cache.Task" as const;
+    type = Task.Type;
+    constructor(public project: Project, public description: string) { }
+}
+
+class TaskCompleted {
+    static Type = "Cache.TaskCompleted" as const;
+    type = TaskCompleted.Type;
+    constructor(public task: Task) { }
+}
+
+const model = buildModel(b => b
+    .type(User)
+    .type(Project, x => x.predecessor("creator", User))
+    .type(Task, x => x.predecessor("project", Project))
+    .type(TaskCompleted, x => x.predecessor("task", Task))
+);
+
+const allTasks = model.given(Project).match(project =>
+    project.successors(Task, task => task.project)
+);
+
+const outstandingTasks = model.given(Project).match(project =>
+    project.successors(Task, task => task.project)
+        .notExists(task => task.successors(TaskCompleted, completed => completed.task))
+);
+
+const projectsForUser = model.given(User).match(user =>
+    user.successors(Project, project => project.creator)
+);
+
+/**
+ * Re-parse a specification's own description into a structurally identical but
+ * distinct object graph. This is the situation the issue describes: each
+ * subscription arrives with its own specification instance, and only about 33
+ * of them are actually distinct.
+ */
+function reparse(specification: Specification): Specification {
+    const parser = new SpecificationParser(describeSpecification(specification, 0));
+    parser.skipWhitespace();
+    return parser.parseSpecification();
+}
+
+describe("invertSpecification memoization", () => {
+    beforeEach(() => {
+        setInverseCacheCapacity(DEFAULT_INVERSE_CACHE_CAPACITY);
+        clearInverseCache();
+    });
+
+    afterAll(() => {
+        setInverseCacheCapacity(DEFAULT_INVERSE_CACHE_CAPACITY);
+        clearInverseCache();
+    });
+
+    it("serves a repeated call from the cache", () => {
+        invertSpecification(allTasks.specification);
+        expect(inverseCacheStatistics()).toMatchObject({ hits: 0, misses: 1, size: 1 });
+
+        invertSpecification(allTasks.specification);
+        expect(inverseCacheStatistics()).toMatchObject({ hits: 1, misses: 1, size: 1 });
+    });
+
+    it("shares one entry across structurally identical, distinct instances", () => {
+        // The whole point of the issue: 33 distinct specifications, 32,528 calls.
+        const instances = [
+            allTasks.specification,
+            reparse(allTasks.specification),
+            reparse(allTasks.specification)
+        ];
+        expect(instances[0]).not.toBe(instances[1]);
+
+        const results = instances.map(invertSpecification);
+
+        expect(inverseCacheStatistics()).toMatchObject({ hits: 2, misses: 1, size: 1 });
+        expect(results[1]).toEqual(results[0]);
+        expect(results[2]).toEqual(results[0]);
+    });
+
+    it("returns what an uncached inversion returns", () => {
+        for (const specification of [allTasks, outstandingTasks, projectsForUser]) {
+            setInverseCacheCapacity(0);
+            const uncached = invertSpecification(specification.specification);
+
+            setInverseCacheCapacity(DEFAULT_INVERSE_CACHE_CAPACITY);
+            clearInverseCache();
+            const firstCall = invertSpecification(specification.specification);
+            const secondCall = invertSpecification(specification.specification);
+
+            expect(firstCall).toEqual(uncached);
+            expect(secondCall).toEqual(uncached);
+        }
+    });
+
+    it("does not confuse two different specifications", () => {
+        const tasks = invertSpecification(allTasks.specification);
+        const outstanding = invertSpecification(outstandingTasks.specification);
+
+        expect(inverseCacheStatistics()).toMatchObject({ hits: 0, misses: 2, size: 2 });
+        // The notExists shape produces a remove inverse; the plain one does not.
+        expect(tasks.some(i => i.operation === "remove")).toBe(false);
+        expect(outstanding.some(i => i.operation === "remove")).toBe(true);
+        expect(outstanding).not.toEqual(tasks);
+    });
+
+    it("evicts the least recently used entry at capacity", () => {
+        setInverseCacheCapacity(2);
+
+        invertSpecification(allTasks.specification);
+        invertSpecification(outstandingTasks.specification);
+        expect(inverseCacheStatistics().size).toBe(2);
+
+        // Touch the first so the second becomes least recently used.
+        invertSpecification(allTasks.specification);
+        invertSpecification(projectsForUser.specification);
+
+        expect(inverseCacheStatistics().size).toBe(2);
+
+        // allTasks survived, so it is still a hit.
+        const hitsBefore = inverseCacheStatistics().hits;
+        invertSpecification(allTasks.specification);
+        expect(inverseCacheStatistics().hits).toBe(hitsBefore + 1);
+
+        // outstandingTasks was evicted, so it must be recomputed.
+        const missesBefore = inverseCacheStatistics().misses;
+        invertSpecification(outstandingTasks.specification);
+        expect(inverseCacheStatistics().misses).toBe(missesBefore + 1);
+    });
+
+    it("evicts immediately when the capacity is lowered", () => {
+        invertSpecification(allTasks.specification);
+        invertSpecification(outstandingTasks.specification);
+        invertSpecification(projectsForUser.specification);
+        expect(inverseCacheStatistics().size).toBe(3);
+
+        setInverseCacheCapacity(1);
+        expect(inverseCacheStatistics().size).toBe(1);
+    });
+
+    it("computes every time when caching is disabled", () => {
+        setInverseCacheCapacity(0);
+
+        const first = invertSpecification(allTasks.specification);
+        const second = invertSpecification(allTasks.specification);
+
+        expect(inverseCacheStatistics()).toMatchObject({ hits: 0, misses: 0, size: 0 });
+        expect(second).toEqual(first);
+        expect(second).not.toBe(first);
+    });
+
+    it("rejects a negative or fractional capacity", () => {
+        expect(() => setInverseCacheCapacity(-1)).toThrow(/non-negative integer/);
+        expect(() => setInverseCacheCapacity(1.5)).toThrow(/non-negative integer/);
+    });
+
+    it("hands each caller its own array", () => {
+        const first = invertSpecification(allTasks.specification);
+        const length = first.length;
+        expect(length).toBeGreaterThan(0);
+
+        // A caller that mutates its result must not reorder or truncate what
+        // the next caller sees.
+        first.length = 0;
+
+        const second = invertSpecification(allTasks.specification);
+        expect(second).toHaveLength(length);
+        expect(second).not.toBe(first);
+    });
+
+    it("does not cache a rejected specification", () => {
+        // Two isolated clusters: u1 connects to p1, t1 connects to p2, and
+        // nothing joins them. Rejected before any inversion runs.
+        const disconnected = new SpecificationParser(`
+            (u1: Jinaga.User, p2: Cache.Project) {
+                p1: Cache.Project [
+                    p1->creator: Jinaga.User = u1
+                ]
+                t1: Cache.Task [
+                    t1->project: Cache.Project = p2
+                ]
+            }
+        `);
+        disconnected.skipWhitespace();
+        const specification = disconnected.parseSpecification();
+
+        expect(() => invertSpecification(specification)).toThrow();
+        expect(inverseCacheStatistics().size).toBe(0);
+
+        // The rejection is stable rather than turning into a stale success.
+        expect(() => invertSpecification(specification)).toThrow();
+        expect(inverseCacheStatistics().size).toBe(0);
+    });
+});

--- a/test/specification/inverseCacheSpec.ts
+++ b/test/specification/inverseCacheSpec.ts
@@ -216,5 +216,11 @@ describe("invertSpecification memoization", () => {
         // The rejection is stable rather than turning into a stale success.
         expect(() => invertSpecification(specification)).toThrow();
         expect(inverseCacheStatistics().size).toBe(0);
+
+        // And it is not counted as a miss. A miss means the cache had to
+        // compute AND retained the result; a rejection retains nothing, so
+        // counting it would inflate misses against a cache that was never
+        // given anything to hold.
+        expect(inverseCacheStatistics()).toMatchObject({ hits: 0, misses: 0 });
     });
 });


### PR DESCRIPTION
Closes #266.

`invertSpecification` is a pure function of its `Specification`, but every caller recomputed it. This memoizes it on the specification, taking the issue's first option — cache inside the function, bounded — because it benefits every consumer with no API change.

## The key

The hash of `describeSpecification(specification, 0)`. That is already this codebase's identity for a specification, not a new claim being made here:

- `deduplicateInverses`, in this same file, dedupes on exactly that hash.
- `ObservableSource.addSpecificationListener` groups listeners by exactly that hash.

Computing the key is also strictly cheaper than the deduplication step alone, which describes *every inverse it just produced*.

## The bound

Least-recently-used eviction at `DEFAULT_INVERSE_CACHE_CAPACITY` (500). `setInverseCacheCapacity(n)` changes it and evicts immediately; `0` disables caching and restores the previous compute-every-time behaviour. This is the condition the issue attaches to its preferred option — server workloads see a small, stable set of specifications, and the bound is what keeps a caller that generates them dynamically from growing the cache forever.

`clearInverseCache()` drops everything and resets the counters. Inversion is pure, so it is never needed for correctness; it is there for tests and for a host reclaiming memory.

## Measuring what the issue could not

The issue says plainly that it did not measure the CPU cost of a single inversion, so the compute saving was unquantified. `inverseCacheStatistics()` now reports `{ size, capacity, hits, misses }` so a host can quantify it in its own workload.

And here it is for this repository, driven at the issue's own call count, over one representative shape (two `notExists`, three matches), with tracing set to `NoOpTracer` so this is compute rather than logging:

| | 32,528 calls | per call |
|---|---|---|
| uncached | 4,056–4,237 ms | ~127 µs |
| cached | 1,009–1,059 ms | ~32 µs |

**4.0x, stable across three runs.** Roughly 3.1 seconds of CPU returned at the volume the issue reports.

Two honest caveats on that number:

- The residual ~32 µs per call is the **key computation itself** — describing the specification and hashing it. Memoizing cannot go below that while the key is derived from the specification's text. A second tier keyed on the specification *instance* (a `WeakMap`) would make a repeated inversion of the same object nearly free, but it only helps if a consumer reuses instances, and it is bounded by caller retention rather than by a capacity. Left out deliberately as a follow-up to be driven by a real profile, since the issue asked for a bounded cache.
- A cache hit also skips the 8 `Trace` lines the issue measures at 260,258 lines and 9.3% of a 282 MB log. That is a side benefit here, not a fix for #264, which is left alone.

## Correctness

- **A rejected specification is not cached.** `detectDisconnectedSpecification` and the `shakeTree` loop guard reject outright, so a retry gets the same rejection rather than a stale success, and no failure occupies a slot.
- **The returned array is a copy.** The inverses inside are shared, and callers have always treated them as read-only, but handing out the stored array would let one caller's in-place `sort` reorder what every later caller sees. A test pins this.

## Testing

`npm ci && npm run build && npm test` green on Node 22: **691 tests passing**, 10 of them new in `test/specification/inverseCacheSpec.ts`.

Because this is an optimization rather than a defect fix, "fails before the change" means the cache API did not exist. The behavioural claim that matters — that memoizing does not change the answer — is pinned instead by `returns what an uncached inversion returns`, which inverts three specifications with the cache disabled and again with it enabled and asserts deep equality both times. `shares one entry across structurally identical, distinct instances` reproduces the issue's actual scenario, re-parsing a specification into separate object graphs and asserting one miss and two hits. The 680 pre-existing tests exercise `invertSpecification` heavily through the observer and subscribe paths and are unchanged.

## Note, not widened into the diff

`describeProjection` sorts `projection.components` in place. That is pre-existing and unchanged in behaviour here — `deduplicateInverses` describes inverse specifications that share the input's projection object, so the input's components were already being sorted on every inversion. Worth knowing, not worth fixing in this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_012fcoLzMb1pLwKDDE92tLEa)_