### PR TITLE
Move the workflow actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -5,10 +5,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '20.x'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,8 +10,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,11 +23,11 @@ jobs:
     steps:
     # Step 1: Checkout the repository
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     # Step 2: Set up Node.js environment
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
         node-version: '20'
 


### PR DESCRIPTION
The 6.12.0 publish run raised a deprecation annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4.

Every workflow in this repository hit it. This bumps `actions/checkout` and `actions/setup-node` to `v7`, whose `action.yml` declares `using: node24` for both.

| Workflow | Was | Now |
|---|---|---|
| `main.yml` | checkout@v4, setup-node@v4 | v7, v7 |
| `publish.yaml` | checkout@v4, setup-node@v4 | v7, v7 |
| `publish-github.yml` | checkout@v4, setup-node@v4 | v7, v7 |
| `release.yaml` | checkout@v3, setup-node@v3 | v7, v7 |

## Why this is behaviour-preserving

Two changes between v4 and v7 could have bitten, and neither applies:

- **setup-node v5 enabled automatic caching**, v6 narrowed it to npm. It engages only when `package.json` names npm in the top-level `packageManager` field or in `devEngines.packageManager`. This package declares neither, so no cache step is introduced — including on the two workflows that publish, where the setup-node README specifically recommends against implicit caching.
- **setup-node v7 removed the dummy `NODE_AUTH_TOKEN` export** ([actions/setup-node#1558](https://github.com/actions/setup-node/pull/1558)), which is what `publish.yaml`'s `NODE_AUTH_TOKEN: ''` guard works around. The guard is left in place: it still pins the OIDC fall-through explicitly rather than depending on the action's default, and the publish path is the wrong place to remove a belt while adding a brace.

Both v7 majors require runner `v2.327.1` or newer, which GitHub-hosted runners are well past.

## Testing

No source or test changes, so the local gate is unchanged from the 6.12.0 release run (`npm ci && npm run build && npm test` — 750 passing across 90 suites). The real verification is CI on this PR: `main.yml` exercises the bumped `checkout` and `setup-node` on the same Node 22 setup it always has, and a green run with no deprecation annotation is the evidence. All five workflow files were parsed with `js-yaml` after the edit.

The two publish workflows and `release.yaml` are `workflow_dispatch`/`release`-triggered, so they cannot be exercised by this PR; they take the identical two-line change that `main.yml` proves out.

## Noticed but not changed

- `release.yaml` runs its tests on `node-version: '20'` and `publish-github.yml` on `'20.x'`, while CI uses 22 and the npm publish uses 24. That is the runtime the job requests, not the action runtime this PR is about, but Node 20 went end-of-life and the three workflows disagreeing is worth settling separately.
- There is no `.github/dependabot.yml`. Dependabot is clearly enabled for npm on this repository, but without a config the `github-actions` ecosystem is not watched, which is why these went four majors stale. Adding it would keep this from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7sg3LD9U5X2xx9yv18y7