### PR TITLE
Let JinagaTest run against any Storage implementation (#252, step 2)

### DIFF
--- a/src/jinaga-test.ts
+++ b/src/jinaga-test.ts
@@ -30,13 +30,52 @@ export type JinagaTestConfig = {
    * settle before continuing without it (issue #246). Set to 0 to wait
    * indefinitely. Defaults to `DEFAULT_LISTENER_TIMEOUT_MS`.
    */
-  listenerTimeoutMs?: number
+  listenerTimeoutMs?: number,
+  /**
+   * Produces the store that backs the test instance. Defaults to a new
+   * `MemoryStore`. Supply a factory to run a `JinagaTest`-based suite against
+   * another implementation of `Storage`, the way the storage conformance kit
+   * runs one suite against several stores (issue #252).
+   *
+   * A store whose writes complete asynchronously — `IndexedDBStore`, or a
+   * SQL-backed one — must be paired with `createAsync`, because `create`
+   * cannot await the initial state.
+   *
+   * The factory itself is synchronous, unlike the conformance kit's
+   * `StorageFactory`, because `create` is synchronous and both entry points
+   * read this one field. Asynchronous *construction* is not the same thing as
+   * asynchronous writes: `MemoryStore` and `IndexedDBStore` are both built
+   * synchronously and defer their work to their methods.
+   */
+  store?: () => Storage
 }
 
 export class JinagaTest {
   static create(config: JinagaTestConfig) {
-    const store = new MemoryStore();
+    const store = this.createStore(config);
+    // The initial state is saved without awaiting, so it is readable on return
+    // only for a store that applies writes synchronously, as `MemoryStore`
+    // does. `createAsync` is the entry point for any store that does not.
     this.saveInitialState(config, store);
+    return this.assemble(config, store);
+  }
+
+  /**
+   * Creates a test instance, awaiting the initial state before returning.
+   * Use this whenever `config.store` produces a store whose `save` completes
+   * asynchronously.
+   */
+  static async createAsync(config: JinagaTestConfig): Promise<Jinaga> {
+    const store = this.createStore(config);
+    await this.saveInitialState(config, store);
+    return this.assemble(config, store);
+  }
+
+  private static createStore(config: JinagaTestConfig): Storage {
+    return config.store ? config.store() : new MemoryStore();
+  }
+
+  private static assemble(config: JinagaTestConfig, store: Storage) {
     const observableSource = new ObservableSource(store, {
       listenerTimeoutMs: config.listenerTimeoutMs
     });
@@ -49,11 +88,14 @@ export class JinagaTest {
     return new Jinaga(authentication, factManager, syncStatusNotifier);
   }
 
-  static saveInitialState(config: JinagaTestConfig, store: MemoryStore) {
+  static async saveInitialState(config: JinagaTestConfig, store: Storage): Promise<void> {
     if (config.initialState) {
       const dehydrate = new Dehydration();
       config.initialState.forEach(obj => dehydrate.dehydrate(obj));
-      store.save(dehydrate.factRecords().map(f => <FactEnvelope>{
+      // `save` is still invoked synchronously — an async function body runs up
+      // to its first await — so `create` is unchanged for a store that applies
+      // writes synchronously.
+      await store.save(dehydrate.factRecords().map(f => <FactEnvelope>{
         fact: f,
         signatures: []
       }));
@@ -69,7 +111,7 @@ export class JinagaTest {
     return new AuthenticationTest(store, authorizationRules, userFact, deviceFact);
   }
 
-  static createNetwork(config: JinagaTestConfig, store: MemoryStore): Network {
+  static createNetwork(config: JinagaTestConfig, store: Storage): Network {
     if (config.distribution) {
       const distributionRules = config.distribution(new DistributionRules([]));
       const distributionEngine = new DistributionEngine(distributionRules, store, true);

--- a/src/jinaga-test.ts
+++ b/src/jinaga-test.ts
@@ -88,18 +88,23 @@ export class JinagaTest {
     return new Jinaga(authentication, factManager, syncStatusNotifier);
   }
 
-  static async saveInitialState(config: JinagaTestConfig, store: Storage): Promise<void> {
+  // Deliberately not `async`. `create` calls this without awaiting, so an
+  // async body would convert every synchronous throw in it — a malformed fact
+  // out of `dehydrate`, or a store whose `save` throws before returning —
+  // into a rejected promise that `create` drops. That would turn a clear
+  // synchronous failure into an unhandled rejection, on the default
+  // `MemoryStore` path as much as any other. Returning the promise instead
+  // keeps those throws propagating out of `create` as they always have.
+  static saveInitialState(config: JinagaTestConfig, store: Storage): Promise<void> {
     if (config.initialState) {
       const dehydrate = new Dehydration();
       config.initialState.forEach(obj => dehydrate.dehydrate(obj));
-      // `save` is still invoked synchronously — an async function body runs up
-      // to its first await — so `create` is unchanged for a store that applies
-      // writes synchronously.
-      await store.save(dehydrate.factRecords().map(f => <FactEnvelope>{
+      return store.save(dehydrate.factRecords().map(f => <FactEnvelope>{
         fact: f,
         signatures: []
-      }));
+      })).then(() => { });
     }
+    return Promise.resolve();
   }
 
   static createAuthentication(config: JinagaTestConfig, store: Storage): Authentication {

--- a/test/jinaga-test/storeFactorySpec.ts
+++ b/test/jinaga-test/storeFactorySpec.ts
@@ -1,0 +1,161 @@
+import { FactEnvelope, Jinaga, JinagaTest, MemoryStore, Storage, User } from "@src";
+import { IndexedDBStore } from "../../src/indexeddb/indexeddb-store";
+import { Company, Office, OfficeClosed, OfficeReopened, model } from "../companyModel";
+
+// `JinagaTest.create` used to construct `new MemoryStore()` itself, so the
+// specification suites that go through it could only ever exercise one store
+// (issue #252, step 2). These cases pin the factory that lifts that
+// restriction, and the async entry point a store with asynchronous writes
+// needs in order to use it.
+
+function buildInitialState() {
+    const creator = new User("--- PUBLIC KEY GOES HERE ---");
+    const company = new Company(creator, "TestCo");
+    const office = new Office(company, "TestOffice");
+    const closedOffice = new Office(company, "ClosedOffice");
+    const closed = new OfficeClosed(closedOffice, new Date("2026-01-01T00:00:00.000Z"));
+    const reopenedOffice = new Office(company, "ReopenedOffice");
+    const reopened = new OfficeReopened(new OfficeClosed(reopenedOffice, new Date("2026-01-01T00:00:00.000Z")));
+
+    return {
+        company,
+        office,
+        reopenedOffice,
+        initialState: [
+            creator, company, office, closedOffice, closed, reopenedOffice, reopened
+        ]
+    };
+}
+
+// A specification with a nested negative existential, so the comparison below
+// exercises more of the read surface than a bare successor join would.
+const openOffices = model.given(Company).match((company, facts) =>
+    Office.inCompany(facts, company)
+);
+
+/**
+ * A store whose `save` completes only when the test releases it. Stands in for
+ * any implementation that does not apply writes synchronously, without needing
+ * one to be present.
+ */
+class DeferredSaveStore extends MemoryStore {
+    private release: (() => void) | undefined;
+
+    save(envelopes: FactEnvelope[]): Promise<FactEnvelope[]> {
+        return new Promise<void>(resolve => {
+            this.release = resolve;
+        }).then(() => super.save(envelopes));
+    }
+
+    completeSave(): void {
+        if (!this.release) {
+            throw new Error("`save` has not been called yet.");
+        }
+        this.release();
+    }
+}
+
+// Yields to the macrotask queue. Everything already resolvable has resolved by
+// the time this returns, so a `createAsync` that failed to await its save would
+// have settled. This is a scheduling boundary rather than an arbitrary delay:
+// no duration is being guessed at, and lengthening it would not change the
+// outcome.
+function flushPending(): Promise<void> {
+    return new Promise(resolve => setImmediate(resolve));
+}
+
+describe("JinagaTest store factory", () => {
+    it("should default to a MemoryStore when no factory is given", async () => {
+        const { company, office, reopenedOffice, initialState } = buildInitialState();
+        const j = JinagaTest.create({ initialState });
+
+        const result = await j.query(openOffices, company);
+        expect(result.map(o => o.identifier).sort()).toEqual(
+            [office, reopenedOffice].map(o => o.identifier).sort());
+    });
+
+    it("should back the instance with the store the factory returns", async () => {
+        const { company, initialState } = buildInitialState();
+        const stores: MemoryStore[] = [];
+        const j = JinagaTest.create({
+            initialState,
+            store: () => {
+                const store = new MemoryStore();
+                stores.push(store);
+                return store;
+            }
+        });
+
+        // Called once, and the instance reads through that store rather than
+        // through one it constructed for itself: the initial state landed in
+        // the store the factory handed back.
+        expect(stores.length).toBe(1);
+        const envelopes = await stores[0].load([
+            { type: Company.Type, hash: j.hash(company) }
+        ]);
+        expect(envelopes.length).toBeGreaterThan(0);
+
+        const viaJinaga = await j.query(openOffices, company);
+        expect(viaJinaga.length).toBe(2);
+    });
+
+    it("should not resolve createAsync until the initial state is saved", async () => {
+        const { company, initialState } = buildInitialState();
+        const store = new DeferredSaveStore();
+
+        let settled = false;
+        const pending = JinagaTest.createAsync({ initialState, store: () => store })
+            .then(j => { settled = true; return j; });
+
+        // The save is still outstanding, so `createAsync` must not have
+        // settled. Without the await it would have, and the caller would hold
+        // an instance whose store has none of the initial state.
+        await flushPending();
+        expect(settled).toBe(false);
+
+        store.completeSave();
+        const j: Jinaga = await pending;
+        expect(settled).toBe(true);
+
+        const result = await j.query(openOffices, company);
+        expect(result.length).toBe(2);
+    });
+
+    it("should agree with MemoryStore when backed by IndexedDBStore", async () => {
+        const { company, initialState } = buildInitialState();
+
+        const memoryResult = await JinagaTest.create({ initialState })
+            .query(openOffices, company);
+
+        const dbName = `test-jinaga-test-store-factory-${Date.now()}-${Math.random()}`;
+        let store: Storage | undefined;
+        try {
+            // `createAsync`, not `create`: IndexedDBStore's writes complete
+            // asynchronously, so the initial state is not readable until the
+            // save has been awaited.
+            const j = await JinagaTest.createAsync({
+                initialState,
+                store: () => {
+                    store = new IndexedDBStore(dbName);
+                    return store;
+                }
+            });
+
+            const indexedDbResult = await j.query(openOffices, company);
+            expect(indexedDbResult.map(o => o.identifier).sort())
+                .toEqual(memoryResult.map(o => o.identifier).sort());
+            expect(indexedDbResult.length).toBe(2);
+        }
+        finally {
+            if (store) {
+                await store.close();
+            }
+            const deleteRequest = indexedDB.deleteDatabase(dbName);
+            await new Promise((resolve, reject) => {
+                deleteRequest.onsuccess = () => resolve(undefined);
+                deleteRequest.onerror = () => reject(deleteRequest.error);
+                deleteRequest.onblocked = () => reject(new Error("Database deletion blocked"));
+            });
+        }
+    });
+});

--- a/test/jinaga-test/storeFactorySpec.ts
+++ b/test/jinaga-test/storeFactorySpec.ts
@@ -55,6 +55,16 @@ class DeferredSaveStore extends MemoryStore {
     }
 }
 
+/**
+ * A store whose `save` throws before returning a promise, standing in for any
+ * failure that reaches `saveInitialState` synchronously.
+ */
+class ThrowingSaveStore extends MemoryStore {
+    save(): Promise<FactEnvelope[]> {
+        throw new Error("save failed synchronously");
+    }
+}
+
 // Yields to the macrotask queue. Everything already resolvable has resolved by
 // the time this returns, so a `createAsync` that failed to await its save would
 // have settled. This is a scheduling boundary rather than an arbitrary delay:
@@ -119,6 +129,32 @@ describe("JinagaTest store factory", () => {
 
         const result = await j.query(openOffices, company);
         expect(result.length).toBe(2);
+    });
+
+    it("should propagate a synchronous save failure out of create", () => {
+        const { initialState } = buildInitialState();
+
+        // `create` does not await `saveInitialState`, so making that method
+        // `async` would convert this throw into a rejected promise that
+        // `create` drops — an unhandled rejection in place of a failure the
+        // caller can see. The same conversion would swallow a throw from
+        // `dehydrate` on malformed initial state, which is the default
+        // MemoryStore path rather than an edge of the new factory.
+        expect(() => JinagaTest.create({
+            initialState,
+            store: () => new ThrowingSaveStore()
+        })).toThrow("save failed synchronously");
+    });
+
+    it("should reject createAsync when the save fails synchronously", async () => {
+        const { initialState } = buildInitialState();
+
+        // The same failure through the async entry point is a rejection, not a
+        // synchronous throw: `createAsync` awaits the save.
+        await expect(JinagaTest.createAsync({
+            initialState,
+            store: () => new ThrowingSaveStore()
+        })).rejects.toThrow("save failed synchronously");
     });
 
     it("should agree with MemoryStore when backed by IndexedDBStore", async () => {


### PR DESCRIPTION
Addresses **step 2** of #252. PR #269 landed steps 1 and 4 and said explicitly that the issue should stay open for steps 2, 3 and 5; this is the next one, and #269 named it as worth its own PR.

## Which symptoms #269 handled, and which this one addresses

The issue describes one problem in two halves, and they had different fixes.

| Issue step | Status on `main` at `c3f60a2` | Where |
|---|---|---|
| 1. Collapse the duplicated `queryGivenConditions` pair | **Resolved** | #269 |
| 4. Publish as a subpath export | **Resolved** | #269 |
| 2. `JinagaTest` accepts a store factory | **Survives** | this PR |
| 3. Migrate the read-semantics suites into the kit | Survives, was blocked on step 2 | not this PR |
| 5. Differential test against `SpecificationRunner` | Survives | not this PR |
| Extended coverage list (`save`/`whichExist`/`feed`/`purge`/ordering) | Survives | not this PR |

Verified rather than assumed: `src/jinaga-test.ts:38` on `main` still read `const store = new MemoryStore()`, and `JinagaTest.create` appears 118 times across 33 test files. Every one of those suites was locked to `MemoryStore`, which is the coverage the issue points at — the coverage that "defines what `read` is *supposed* to return."

## What this does

`JinagaTestConfig` gains an optional factory:

```ts
store?: () => Storage
```

defaulting to a new `MemoryStore`, so every existing call site is untouched. `saveInitialState` and `createNetwork` are widened from `MemoryStore` to `Storage`; neither used a `MemoryStore`-specific member, so the narrow types were incidental.

**The async half is not optional.** #269 deferred this step because `JinagaTest.create` is synchronous and fires its initial-state `save` without awaiting. That is a real obstacle, not a stylistic one: it works today only because `MemoryStore.save` mutates its array synchronously and returns an already-resolved promise (`src/memory/memory-store.ts:67-91`). Hand `create` an `IndexedDBStore` and the instance races its own initial state. So `createAsync` is added alongside:

```ts
static async createAsync(config: JinagaTestConfig): Promise<Jinaga>
```

`create` keeps its shape and its behaviour. `saveInitialState` now returns `Promise<void>`, but it is deliberately **not** an `async` function — see the review round below, where a first attempt at that was wrong and is now pinned by tests.

One deliberate asymmetry, called out in the doc comment because it invites a question: this factory is `() => Storage`, while the conformance kit's `StorageFactory` is `() => Storage | Promise<Storage>`. `create` is synchronous and both entry points read the one config field, so the factory has to be too. Asynchronous *construction* is a different thing from asynchronous writes — `MemoryStore` and `IndexedDBStore` are both built synchronously and defer their work to their methods, which is why the narrower type costs nothing here.

## Test results, before and after

**Before**, on `main` at `c3f60a2`, the new suite does not compile — the capability is simply absent:

```
test/jinaga-test/storeFactorySpec.ts(50,13): error TS2345: ... 'store' does not exist in type 'JinagaTestConfig'.
test/jinaga-test/storeFactorySpec.ts(82,48): error TS2339: Property 'createAsync' does not exist on type 'typeof JinagaTest'.
```

**After**, the six cases pass. `npm ci && npm run build && npm test` on the head of this branch:

```
Ran 756 tests in 21.7 s
✔ 756 passing
```

750 on `main`, so the six added cases are the whole of the difference and nothing was lost.

### The await is pinned, not assumed

A "does IndexedDB work through JinagaTest" test alone would have been close to vacuous about the `await`. IndexedDB serialises overlapping transactions on the same scope, so with `fake-indexeddb` the read after an un-awaited save still tends to see the data; removing the `await` first surfaced only as `Database deletion blocked` in teardown, which is a failure that names the wrong thing.

So the promise is pinned directly. `DeferredSaveStore` extends `MemoryStore` and completes its `save` only when the test releases it, standing in for any store with asynchronous writes without needing one present. Removing the `await` from `createAsync` turns that case red on the assertion that states the invariant:

```
● JinagaTest store factory › should not resolve createAsync until the initial state is saved
    Expected: false
    Received: true
```

Restoring it returns to green. The check yields through `setImmediate` rather than sleeping — a macrotask boundary, so no duration is being guessed at and lengthening it would not change the outcome, which keeps it inside the contributing guide's rule against arbitrary timeouts.

A fourth case is the end-to-end one and the restriction actually being lifted: the same nested-negative-existential specification (`Office.inCompany`) run through a `MemoryStore`-backed and an `IndexedDBStore`-backed `JinagaTest`, asserting the results agree.

## Review round

One Copilot round, one finding, real and fixed in 65c77a4.

**`saveInitialState` must not be `async`.** The first commit marked it `async`. Since `create` calls it without awaiting, that converted every synchronous throw in its body into a rejected promise which `create` then dropped — an unhandled rejection in place of a failure the caller can see.

The finding is broader than the review states, and broader than the factory it arrived with. `async` converts *every* synchronous throw, so it also swallows a throw from `dehydrate.dehydrate(obj)` on malformed initial state. That is the default `MemoryStore` path taken by all 118 existing call sites, so it was a regression for callers who never supply a store at all.

It also falsified a claim this description previously made, which is why the paragraph above now reads differently. The original argued `create` was behaviourally unchanged because an async body runs to its first `await`, so `save` is still *invoked* synchronously. True, and irrelevant: invoking `save` synchronously is not what preserves the error behaviour. Returning the promise rather than awaiting it is.

Fixed with the shape the reviewer proposed — a non-`async` method returning the `store.save` promise — plus two regression cases, because a property this easy to break by tidying the method back up should not rest on a comment:

- `should propagate a synchronous save failure out of create`. Restoring `async` turns it red with `Expected substring: "save failed synchronously" / Received function did not throw`.
- `should reject createAsync when the save fails synchronously`, pinning the other half of the contract.

The method now carries a comment saying why it is not `async`.

## Deliberately not done

- **Step 3, migrating the read-semantics suites into the conformance kit.** Unblocked by this change, and large: 118 `JinagaTest.create` call sites across 33 files. Worth its own PR so the migration is reviewable as a migration.
- **Step 5, the differential test** against `SpecificationRunner` as an oracle. The IndexedDB case here is a hand-written instance of that shape, not the general mechanism.
- **The extended coverage list.** Unchanged from #269's reasoning: each addition may surface a genuine divergence between the two stores, and fixing a store is a different change from widening a suite.

## One note beyond the issue's scope

`create` still drops the promise from `saveInitialState`, so an *asynchronous* rejection from a store passed to `create` instead of `createAsync` is still unhandled. The review round above fixed the synchronous half of this, which was a live regression; the asynchronous half is pre-existing in shape and only newly reachable, since the store was previously always a `MemoryStore` whose save cannot reject. The doc comment on `store` says which entry point to use. Recording it rather than widening the diff — routing it somewhere useful means deciding where, which is a design question of its own.

The issue should stay open for steps 3 and 5. The maintainer's question from #269, whether the kit should also cover the `Queue` interface, is still unanswered and is not advanced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNYVaiQsn5q3xnA6Ya3Fh2