### PR TITLE
Refuse initial state in JinagaTest.create when a store is supplied

### DIFF
--- a/src/jinaga-test.ts
+++ b/src/jinaga-test.ts
@@ -15,6 +15,7 @@ import { PurgeConditions } from "./purge/purgeConditions";
 import { Model } from './specification/model';
 import { Specification } from "./specification/specification";
 import { FactEnvelope, Storage } from './storage';
+import { Trace } from './util/trace';
 
 export type JinagaTestConfig = {
   model?: Model,
@@ -37,9 +38,11 @@ export type JinagaTestConfig = {
    * another implementation of `Storage`, the way the storage conformance kit
    * runs one suite against several stores (issue #252).
    *
-   * A store whose writes complete asynchronously — `IndexedDBStore`, or a
-   * SQL-backed one — must be paired with `createAsync`, because `create`
-   * cannot await the initial state.
+   * Supplying this together with a non-empty `initialState` requires
+   * `createAsync`, because `create` cannot await the save; `create` refuses
+   * the combination rather than dropping the result (issue #274). `create`
+   * still accepts the factory on its own, for a suite that seeds its facts
+   * through the instance.
    *
    * The factory itself is synchronous, unlike the conformance kit's
    * `StorageFactory`, because `create` is synchronous and both entry points
@@ -52,11 +55,28 @@ export type JinagaTestConfig = {
 
 export class JinagaTest {
   static create(config: JinagaTestConfig) {
+    // `create` cannot await the save, so a supplied store carrying initial
+    // state is a misuse (issue #274): a store whose writes complete
+    // asynchronously returns an instance that does not hold the state yet, and
+    // a save that fails is detached from this call site — an unhandled
+    // rejection, or a failure Jest attributes to whichever test the microtask
+    // lands in. Refuse it here, where the caller can see it. The factory is
+    // opt-in as of issue #252, so no caller predating it is affected.
+    if (config.store && config.initialState && config.initialState.length > 0) {
+      throw new Error("JinagaTest.create cannot save initial state into a store from the `store` factory, because it does not await the save. Use JinagaTest.createAsync instead.");
+    }
     const store = this.createStore(config);
     // The initial state is saved without awaiting, so it is readable on return
     // only for a store that applies writes synchronously, as `MemoryStore`
     // does. `createAsync` is the entry point for any store that does not.
-    this.saveInitialState(config, store);
+    //
+    // What reaches the save from here is the default `MemoryStore`, or a
+    // supplied store with an empty `initialState`. A rejection from either
+    // should not happen, but must not escape as an unhandled rejection, so
+    // report it. A *synchronous* throw is untouched: `saveInitialState` is not
+    // `async`, so it propagates out of `create` before there is a promise to
+    // attach this handler to.
+    this.saveInitialState(config, store).catch(error => Trace.error(error));
     return this.assemble(config, store);
   }
 

--- a/test/jinaga-test/storeFactorySpec.ts
+++ b/test/jinaga-test/storeFactorySpec.ts
@@ -77,9 +77,9 @@ class RejectingSaveStore extends MemoryStore {
 }
 
 /**
- * Captures what `Trace.error` is handed. Restores the default tracer on
- * `stop`, so a failing assertion cannot leave tracing configured for the rest
- * of the suite.
+ * Captures what `Trace.error` is handed. Restores whatever tracer was
+ * configured before, rather than forcing the default, so a failing assertion
+ * cannot leave tracing altered for the rest of the suite.
  */
 function captureTraceErrors() {
     const errors: any[] = [];
@@ -91,10 +91,11 @@ function captureTraceErrors() {
         metric: () => { },
         counter: () => { }
     };
+    const originalTracer = Trace.getTracer();
     Trace.configure(tracer);
     return {
         errors,
-        stop: () => Trace.off()
+        stop: () => Trace.configure(originalTracer)
     };
 }
 

--- a/test/jinaga-test/storeFactorySpec.ts
+++ b/test/jinaga-test/storeFactorySpec.ts
@@ -1,4 +1,4 @@
-import { FactEnvelope, Jinaga, JinagaTest, MemoryStore, Storage, User } from "@src";
+import { FactEnvelope, Jinaga, JinagaTest, MemoryStore, Storage, Trace, Tracer, User } from "@src";
 import { IndexedDBStore } from "../../src/indexeddb/indexeddb-store";
 import { Company, Office, OfficeClosed, OfficeReopened, model } from "../companyModel";
 
@@ -65,6 +65,39 @@ class ThrowingSaveStore extends MemoryStore {
     }
 }
 
+/**
+ * A store whose `save` rejects, standing in for one that cannot reach its
+ * backing medium — an aborted IndexedDB transaction, a SQL connection that
+ * cannot be opened.
+ */
+class RejectingSaveStore extends MemoryStore {
+    save(): Promise<FactEnvelope[]> {
+        return Promise.reject(new Error("save failed asynchronously"));
+    }
+}
+
+/**
+ * Captures what `Trace.error` is handed. Restores the default tracer on
+ * `stop`, so a failing assertion cannot leave tracing configured for the rest
+ * of the suite.
+ */
+function captureTraceErrors() {
+    const errors: any[] = [];
+    const tracer: Tracer = {
+        info: () => { },
+        warn: () => { },
+        error: error => { errors.push(error); },
+        dependency: (name, data, operation) => operation(),
+        metric: () => { },
+        counter: () => { }
+    };
+    Trace.configure(tracer);
+    return {
+        errors,
+        stop: () => Trace.off()
+    };
+}
+
 // Yields to the macrotask queue. Everything already resolvable has resolved by
 // the time this returns, so a `createAsync` that failed to await its save would
 // have settled. This is a scheduling boundary rather than an arbitrary delay:
@@ -87,7 +120,9 @@ describe("JinagaTest store factory", () => {
     it("should back the instance with the store the factory returns", async () => {
         const { company, initialState } = buildInitialState();
         const stores: MemoryStore[] = [];
-        const j = JinagaTest.create({
+        // `createAsync`, not `create`: a supplied store carrying initial state
+        // goes through the entry point that awaits the save (issue #274).
+        const j = await JinagaTest.createAsync({
             initialState,
             store: () => {
                 const store = new MemoryStore();
@@ -131,19 +166,67 @@ describe("JinagaTest store factory", () => {
         expect(result.length).toBe(2);
     });
 
-    it("should propagate a synchronous save failure out of create", () => {
-        const { initialState } = buildInitialState();
-
+    it("should propagate a synchronous throw out of create", () => {
         // `create` does not await `saveInitialState`, so making that method
         // `async` would convert this throw into a rejected promise that
         // `create` drops — an unhandled rejection in place of a failure the
-        // caller can see. The same conversion would swallow a throw from
-        // `dehydrate` on malformed initial state, which is the default
-        // MemoryStore path rather than an edge of the new factory.
+        // caller can see. This is the default MemoryStore path, not an edge of
+        // the store factory: `dehydrate` rejects the malformed fact before any
+        // store is touched.
+        expect(() => JinagaTest.create({
+            initialState: [{ identifier: "no type here" }]
+        })).toThrow("Specify the type of the fact and all of its predecessors.");
+    });
+
+    it("should refuse initial state through create when a store is supplied", () => {
+        const { initialState } = buildInitialState();
+
+        // `create` cannot await the save, so a supplied store carrying initial
+        // state is a misuse: an asynchronous writer returns an instance that
+        // does not hold the state yet, and a failed save is detached from this
+        // call site (issue #274). Refuse it here rather than downstream.
         expect(() => JinagaTest.create({
             initialState,
-            store: () => new ThrowingSaveStore()
-        })).toThrow("save failed synchronously");
+            store: () => new MemoryStore()
+        })).toThrow(/createAsync/);
+    });
+
+    it("should still honour the factory in create when there is no initial state", () => {
+        const stores: MemoryStore[] = [];
+        const j = JinagaTest.create({
+            store: () => {
+                const store = new MemoryStore();
+                stores.push(store);
+                return store;
+            }
+        });
+
+        // Nothing to save, so nothing to await: `create` remains available for
+        // a suite that seeds its facts through the instance.
+        expect(stores.length).toBe(1);
+        expect(j).toBeInstanceOf(Jinaga);
+    });
+
+    it("should trace an asynchronous save failure in create rather than dropping it", async () => {
+        // An empty `initialState` still reaches `store.save`, and it is the one
+        // combination the refusal above lets through with a supplied store. The
+        // rejection has nowhere to be reported to — `create` has already
+        // returned — so it must at least reach `Trace` instead of surfacing as
+        // an unhandled rejection in an unrelated test (issue #274).
+        const trace = captureTraceErrors();
+        try {
+            JinagaTest.create({
+                initialState: [],
+                store: () => new RejectingSaveStore()
+            });
+
+            await flushPending();
+            expect(trace.errors.length).toBe(1);
+            expect(trace.errors[0].message).toBe("save failed asynchronously");
+        }
+        finally {
+            trace.stop();
+        }
     });
 
     it("should reject createAsync when the save fails synchronously", async () => {


### PR DESCRIPTION
Fixes #274.

## The defect

`JinagaTest.create` called `saveInitialState` without awaiting it and without attaching a handler. A rejected save was therefore detached from its call site: Node reports an `UnhandledPromiseRejection`, or Jest attributes the failure to whichever test happens to be running when the microtask lands. #272 made this reachable by adding the `store` factory, since a supplied store can fail in ways `MemoryStore` cannot.

## The fix

Option 2 from the issue, as decided in [the maintainer's comment](https://github.com/jinaga/jinaga.js/issues/274#issuecomment-5535237972), with option 1 as the backstop.

**Refuse the combination that has something to drop.** A supplied `store` together with a non-empty `initialState` now throws from `create`, directing the caller to `createAsync`. The factory is opt-in as of #272, so no caller predating it is affected, and `create` still accepts the factory on its own — a suite that seeds its facts through the instance has nothing to await.

**Handle the rejection on what remains.** Two paths still reach `store.save` from `create`: the default `MemoryStore`, and a supplied store with an *empty* `initialState` — `saveInitialState` branches on `config.initialState` being truthy, so `[]` still calls `save`. A rejection from either is reported through `Trace.error` instead of escaping.

`saveInitialState` stays non-`async`, and that is load-bearing exactly as the issue and its existing comment describe: a synchronous throw — a malformed fact out of `dehydrate`, or a store whose `save` throws before returning — propagates out of `create` before there is a promise for the `.catch` to attach to.

The `store` field's doc comment is updated to state the new contract.

## Regression tests

In `test/jinaga-test/storeFactorySpec.ts`. Before the change, on `7b42f20`:

```
✘ should refuse initial state through create when a store is supplied
    Expected pattern: /createAsync/ — Received function did not throw
✘ should trace an asynchronous save failure in create rather than dropping it
    save failed asynchronously        <- the detached rejection itself, surfacing
                                         via src/jinaga-test.ts:59 (create)
    expect(trace.errors.length).toBe(1) — Received: 0
Ran 9 tests: 7 passing, 2 failing
```

After the change, `npm ci && npm run build && npm test` is green: **759 passing, 0 failing** across 91 suites.

New cases:

- `should refuse initial state through create when a store is supplied` — the refusal.
- `should trace an asynchronous save failure in create rather than dropping it` — a `RejectingSaveStore` with `initialState: []`, the one combination the refusal lets through with a supplied store. Asserts the rejection reaches a captured `Tracer` rather than the process.
- `should still honour the factory in create when there is no initial state` — pins that the refusal did not close the factory off from `create` entirely.

Changed cases:

- `should propagate a synchronous save failure out of create` → `should propagate a synchronous throw out of create`. The issue asks to keep a case that fails if `saveInitialState` is made `async`, *on the `MemoryStore` path*. The old case injected a synchronously-throwing store through the factory, which the refusal now rejects earlier. It is replaced by malformed initial state on the default path, where `dehydrate` throws before any store is touched — the same pin, and the more representative one. The `createAsync` half of that pair (`should reject createAsync when the save fails synchronously`) is unchanged and still covers `ThrowingSaveStore`.
- `should back the instance with the store the factory returns` — switched to `createAsync`, since it supplies both a store and initial state.

## Notes beyond scope

`saveInitialState` calls `store.save([])` when `initialState` is an empty array, which is a pointless round trip to the store. Skipping the save when there are no fact records would close the last path by which `create` can drop a rejection, making the backstop unreachable. Left alone here: it changes `createAsync`'s behaviour too, and it is not what the issue asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnMMQiraRUBpg4b5mBPeV5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnMMQiraRUBpg4b5mBPeV5)_