### PR TITLE
Run the read-semantics suites against every store (#252, step 3)

### DIFF
--- a/src/indexeddb/driver.ts
+++ b/src/indexeddb/driver.ts
@@ -34,9 +34,16 @@ function openDatabase(indexName: string): Promise<IDBDatabase> {
 
 export async function withDatabase<T>(indexName: string, action: (db: IDBDatabase) => Promise<T>) {
   const db = await openDatabase(indexName);
-  const result = await action(db);
-  db.close();
-  return result;
+  // Closed even when the action fails. A connection left open outlives the
+  // operation that opened it, and the next attempt to delete or upgrade the
+  // database blocks on it — so a read that merely failed took the whole
+  // database down with it (issue #252).
+  try {
+    return await action(db);
+  }
+  finally {
+    db.close();
+  }
 }
 
 export async function withTransaction<T>(db: IDBDatabase, storeNames: string[], mode: IDBTransactionMode, action: (transaction: IDBTransaction) => Promise<T>) {

--- a/src/indexeddb/indexeddb-store.ts
+++ b/src/indexeddb/indexeddb-store.ts
@@ -126,11 +126,27 @@ export class IndexedDBStore implements Storage {
               .map(edge => keyToReference(edge.successor))
               .filter(reference => reference.type === successorType);
           },
-          findFact(reference) {
-            return execRequest<FactRecord>(factObjectStore.get(factKey(reference)));
+          async findFact(reference) {
+            // `FactSource.findFact` reports a fact the store does not hold as
+            // `null`, and the runner tests for exactly that before reading
+            // through a given. `get` yields `undefined` for a missing key, and
+            // `execRequest<FactRecord>` asserted the difference away, so the
+            // runner's short circuit never fired for this store: a read whose
+            // given was never saved carried on into `hydrate` instead of
+            // returning no results (issue #252).
+            const fact = await execRequest<FactRecord | undefined>(factObjectStore.get(factKey(reference)));
+            return fact ?? null;
           },
           async hydrate(reference) {
-            const allAncestors = await execRequest<string[]>(ancestorObjectStore.get(factKey(reference)));
+            // A reference the store has never seen has no ancestor entry, and
+            // `get` answers that with `undefined`. The reference semantics
+            // return no fact for it, as `MemoryStore.hydrate` does; reading
+            // through it produced a TypeError instead, which surfaced as a
+            // failed read for a given that was never saved (issue #252).
+            const allAncestors = await execRequest<string[] | undefined>(ancestorObjectStore.get(factKey(reference)));
+            if (!allAncestors) {
+              return undefined;
+            }
             const distinctAncestors = allAncestors.filter(distinct);
             const factRecords = await Promise.all(distinctAncestors.map(key =>
               execRequest<FactRecord>(factObjectStore.get(key))));

--- a/test/fact/factReferenceAcceptanceSpec.ts
+++ b/test/fact/factReferenceAcceptanceSpec.ts
@@ -1,11 +1,14 @@
-import { Jinaga, JinagaTest, User } from '@src';
+import { Jinaga, User } from '@src';
 import { Company, model } from '../companyModel';
+import { describeAcrossStores } from '../utils/store-factories';
 
-describe('factReference acceptance criteria', () => {
+// The acceptance criteria describe what a read returns for a reference, which
+// is a semantic no one store owns (issue #252, step 3).
+describeAcrossStores('factReference acceptance criteria', (createInstance) => {
     let j: Jinaga;
 
     beforeEach(async () => {
-        j = JinagaTest.create({});
+        j = await createInstance({});
     });
 
     it('✅ Developers can call the helper with a fact class and a hash, and receive a strongly-typed reference object', () => {

--- a/test/fact/factReferenceAcceptanceSpec.ts
+++ b/test/fact/factReferenceAcceptanceSpec.ts
@@ -58,9 +58,13 @@ describeAcrossStores('factReference acceptance criteria', (createInstance) => {
             company => { /* callback */ }
         );
         expect(observer).toBeDefined();
+        // Awaited before stopping, so the initial read has finished rather than
+        // being abandoned mid-flight, which against a store that reads from a
+        // database would hold a connection open past the end of this test.
+        await observer.loaded();
         observer.stop();
-        
-        // Test subscribe API (setup only)  
+
+        // Test subscribe API (setup only)
         const subscription = j.subscribe(
             model.given(User).match((u, facts) =>
                 facts.ofType(Company).join(c => c.creator, u)
@@ -69,6 +73,7 @@ describeAcrossStores('factReference acceptance criteria', (createInstance) => {
             company => { /* callback */ }
         );
         expect(subscription).toBeDefined();
+        await subscription.loaded();
         subscription.stop();
     });
 

--- a/test/fact/factReferenceCompanySpec.ts
+++ b/test/fact/factReferenceCompanySpec.ts
@@ -1,11 +1,14 @@
-import { Jinaga, JinagaTest, User } from '@src';
+import { Jinaga, User } from '@src';
 import { Company, model } from '../companyModel';
+import { describeAcrossStores } from '../utils/store-factories';
 
-describe('factReference with company model', () => {
+// A fact reference stands for a fact the store holds, so what a read makes of
+// one is a semantic every store has to share (issue #252, step 3).
+describeAcrossStores('factReference with company model', (createInstance) => {
     let j: Jinaga;
 
     beforeEach(async () => {
-        j = JinagaTest.create({});
+        j = await createInstance({});
     });
 
     it('should work with real company model facts', async () => {

--- a/test/fact/factReferenceIntegrationSpec.ts
+++ b/test/fact/factReferenceIntegrationSpec.ts
@@ -1,4 +1,5 @@
-import { buildModel, Jinaga, JinagaTest, User } from '@src';
+import { buildModel, Jinaga, User } from '@src';
+import { describeAcrossStores } from '../utils/store-factories';
 
 class Task {
     static Type = "IntegrationTest.Task" as const;
@@ -31,11 +32,13 @@ const model = buildModel(b => b
     )
 );
 
-describe('factReference integration', () => {
+// Reads that start from a fact reference rather than a fact object exercise
+// the same read surface, so they run against every store (issue #252, step 3).
+describeAcrossStores('factReference integration', (createInstance) => {
     let j: Jinaga;
 
     beforeEach(async () => {
-        j = JinagaTest.create({});
+        j = await createInstance({});
     });
 
     it('should work with query API using fact reference', async () => {

--- a/test/fact/factReferenceIntegrationSpec.ts
+++ b/test/fact/factReferenceIntegrationSpec.ts
@@ -136,7 +136,12 @@ describeAcrossStores('factReference integration', (createInstance) => {
         // The main test is that watch doesn't crash with a factReference
         expect(observer).toBeDefined();
         expect(typeof observer.stop).toBe('function');
-        
+
+        // Awaited before stopping, so the observer's initial read has finished
+        // rather than being abandoned mid-flight. Against a store that reads
+        // from a database, an abandoned read holds a connection open past the
+        // end of the test that started it.
+        await observer.loaded();
         observer.stop();
     });
 

--- a/test/indexeddb/indexeddbStoreReadSpec.ts
+++ b/test/indexeddb/indexeddbStoreReadSpec.ts
@@ -1,0 +1,134 @@
+import { Dehydration, dehydrateReference, HashMap } from "../../src/fact/hydrate";
+import { IndexedDBStore } from "../../src/indexeddb/indexeddb-store";
+import { MemoryStore } from "../../src/memory/memory-store";
+import { Specification } from "../../src/specification/specification";
+import { SpecificationParser } from "../../src/specification/specification-parser";
+import { FactEnvelope, Storage } from "../../src/storage";
+
+// Reading a fact the store does not hold, at the level of `Storage` rather than
+// through `Jinaga`. Both divergences fixed here were found by running one
+// read-semantics suite against both stores (issue #252), and both are invisible
+// to a suite that only ever runs against `MemoryStore`.
+
+const isIndexedDBAvailable = typeof indexedDB !== "undefined";
+const describeFunc = isIndexedDBAvailable ? describe : describe.skip;
+
+function parse(specificationText: string): Specification {
+    const parser = new SpecificationParser(specificationText);
+    parser.skipWhitespace();
+    return parser.parseSpecification();
+}
+
+function buildFixture() {
+    const creator: HashMap = {
+        type: "Jinaga.User",
+        publicKey: "--- PUBLIC KEY GOES HERE ---"
+    };
+    const company: HashMap = {
+        type: "Company",
+        creator,
+        identifier: "TestCo"
+    };
+    const office: HashMap = {
+        type: "Office",
+        company,
+        identifier: "TestOffice"
+    };
+    const unsavedCompany: HashMap = {
+        type: "Company",
+        creator,
+        identifier: "UnsavedCo"
+    };
+
+    const dehydration = new Dehydration();
+    for (const fact of [creator, company, office]) {
+        dehydration.dehydrate(fact);
+    }
+    const envelopes = dehydration.factRecords().map(fact => <FactEnvelope>({
+        fact,
+        signatures: []
+    }));
+
+    return { company, unsavedCompany, envelopes };
+}
+
+const officesOfCompany = parse(`
+    (company: Company) {
+        office: Office [
+            office->company: Company = company
+        ]
+    } => office
+`);
+
+const companyItself = parse(`
+    (company: Company) {
+    } => company
+`);
+
+describeFunc("IndexedDBStore read", () => {
+    let store: IndexedDBStore;
+    let databaseName: string;
+    let fixture: ReturnType<typeof buildFixture>;
+
+    beforeEach(async () => {
+        databaseName = `test-indexeddb-read-${Date.now()}-${Math.random()}`;
+        store = new IndexedDBStore(databaseName);
+        fixture = buildFixture();
+        await store.save(fixture.envelopes);
+    });
+
+    afterEach(async () => {
+        await store.close();
+        const request = indexedDB.deleteDatabase(databaseName);
+        await new Promise<void>((resolve, reject) => {
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+            request.onblocked = () => reject(new Error("Database deletion blocked"));
+        });
+    });
+
+    it("returns no results for a given it does not hold", async () => {
+        // `findFact` used to answer `undefined` here rather than `null`, so the
+        // runner's short circuit for an absent given never fired. The read then
+        // carried on to project the given itself, and `hydrate` failed with a
+        // TypeError on the ancestor entry that a fact it does not hold has not
+        // got. The successor query does not reach that far, so it takes both
+        // specifications to show the difference.
+        const start = [dehydrateReference(fixture.unsavedCompany)];
+
+        expect(await store.read(start, officesOfCompany)).toEqual([]);
+        expect(await store.read(start, companyItself)).toEqual([]);
+    });
+
+    it("agrees with MemoryStore on a given it does not hold", async () => {
+        const memoryStore: Storage = new MemoryStore();
+        await memoryStore.save(fixture.envelopes);
+        const start = [dehydrateReference(fixture.unsavedCompany)];
+
+        // The interpreter is the reference semantics, so agreement with it is
+        // the assertion — not merely that the read did not throw.
+        for (const specification of [officesOfCompany, companyItself]) {
+            expect(await store.read(start, specification))
+                .toEqual(await memoryStore.read(start, specification));
+        }
+    });
+
+    it("closes the database when a read fails", async () => {
+        // A read that fails used to leave the connection open, because the
+        // close came after the awaited action rather than in a `finally`. The
+        // next attempt to delete or upgrade the database then blocked on it, so
+        // one failing read took the database down for everything after it.
+        await expect(store.read([], officesOfCompany)).rejects.toThrow();
+
+        const request = indexedDB.deleteDatabase(databaseName);
+        const outcome = await new Promise<string>((resolve, reject) => {
+            request.onsuccess = () => resolve("deleted");
+            request.onerror = () => reject(request.error);
+            // Reported rather than awaited: a blocked deletion never completes
+            // while the connection is open, so waiting for it would hang.
+            request.onblocked = () => resolve("blocked");
+        });
+
+        expect(outcome).toBe("deleted");
+    });
+});

--- a/test/jinaga-test/acrossStoresSpec.ts
+++ b/test/jinaga-test/acrossStoresSpec.ts
@@ -1,6 +1,6 @@
 import { Jinaga, User } from "@src";
 import { Company, Office, model } from "../companyModel";
-import { describeAcrossStores } from "../utils/store-factories";
+import { databaseDeletionsSettled, databasesAllocatedHere, describeAcrossStores } from "../utils/store-factories";
 
 // `describeAcrossStores` is what lifts a read-semantics suite off the
 // `MemoryStore` that `JinagaTest.create` used to construct for itself (issue
@@ -68,6 +68,27 @@ describeAcrossStores("describeAcrossStores", (createInstance) => {
         const result = await j.query(officesInCompany, company);
         expect(result.map(o => o.identifier)).toEqual(["TestOffice"]);
     });
+
+    it("releases the store of a test that ends with an observer's tail in flight", async () => {
+        recordRun("observer tail");
+        const { company, initialState } = buildInitialState();
+
+        const j = await createInstance({ initialState });
+        const observed: string[] = [];
+        const observer = j.watch(officesInCompany, company, office => {
+            observed.push(office.identifier);
+        });
+
+        await observer.loaded();
+        observer.stop();
+        expect(observed).toEqual(["TestOffice"]);
+
+        // `Observer.start` issues `setMruDate` after resolving `loaded()`, so
+        // this test ends with a write still in flight and nothing to await it
+        // by. The store is released anyway, and the `afterAll` below is where
+        // that release is checked: the deletion its teardown could not
+        // complete is still queued, and completes when the write does.
+    });
 });
 
 afterAll(async () => {
@@ -80,10 +101,25 @@ afterAll(async () => {
         expect(runs.filter(name => name.includes("IndexedDBStore")).length).toBe(1);
         expect(caseName).toBeTruthy();
     }
-    expect(runsByCase.size).toBe(3);
+    expect(runsByCase.size).toBe(4);
 
-    // The databases the IndexedDB runs allocated were deleted by teardown. A
-    // helper that dropped its stores on the floor would leave one per case.
+    // Every database this file's runs allocated is gone: the ones teardown
+    // deleted outright, and the one whose deletion was blocked by the observer
+    // tail above and completed when that write closed its connection. A helper
+    // that dropped its stores on the floor would leave one per case.
+    //
+    // Checked against the names this file allocated rather than against every
+    // database present, because Jest can run several test files in one worker
+    // process and `indexedDB` is shared across them.
+    const allocated = new Set(databasesAllocatedHere());
+    expect(allocated.size).toBeGreaterThan(0);
+
+    // Awaited rather than assumed: a deletion blocked at teardown finishes when
+    // the connection blocking it closes, and that is later than the test that
+    // held it. A deletion that never finishes leaves this pending until the
+    // hook times out, which is the report a real leak should produce.
+    await databaseDeletionsSettled();
+
     const databases = await indexedDB.databases();
-    expect(databases.filter(database => database.name?.startsWith("test-across-stores-"))).toEqual([]);
+    expect(databases.filter(database => database.name && allocated.has(database.name))).toEqual([]);
 });

--- a/test/jinaga-test/acrossStoresSpec.ts
+++ b/test/jinaga-test/acrossStoresSpec.ts
@@ -1,0 +1,89 @@
+import { Jinaga, User } from "@src";
+import { Company, Office, model } from "../companyModel";
+import { describeAcrossStores } from "../utils/store-factories";
+
+// `describeAcrossStores` is what lifts a read-semantics suite off the
+// `MemoryStore` that `JinagaTest.create` used to construct for itself (issue
+// #252, step 3). These cases pin what it promises the suites that use it: the
+// cases run once per store, each one gets a store of its own, and the databases
+// those stores allocate are released.
+
+const officesInCompany = model.given(Company).match((company, facts) =>
+    facts.ofType(Office)
+        .join(office => office.company, company)
+);
+
+function buildInitialState() {
+    const creator = new User("--- PUBLIC KEY GOES HERE ---");
+    const company = new Company(creator, "TestCo");
+    const office = new Office(company, "TestOffice");
+    return { creator, company, office, initialState: [creator, company, office] };
+}
+
+// Collected from `expect.getState().currentTestName`, which carries the
+// enclosing `describe` name and so names the store each run was registered for.
+const runsByCase = new Map<string, string[]>();
+
+function recordRun(caseName: string) {
+    const suiteName = expect.getState().currentTestName ?? "";
+    const runs = runsByCase.get(caseName) ?? [];
+    runs.push(suiteName);
+    runsByCase.set(caseName, runs);
+}
+
+describeAcrossStores("describeAcrossStores", (createInstance) => {
+    it("backs the instance with a store that holds the initial state", async () => {
+        recordRun("holds the initial state");
+        const { company, office, initialState } = buildInitialState();
+
+        const j: Jinaga = await createInstance({ initialState });
+
+        // Read back rather than merely constructed: for a store whose writes
+        // complete asynchronously this passes only because the helper routes
+        // through `createAsync` and awaits the save.
+        const result = await j.query(officesInCompany, company);
+        expect(result.map(o => o.identifier)).toEqual([office.identifier]);
+    });
+
+    it("leaves a fact written by one case invisible to the next", async () => {
+        recordRun("first of the isolation pair");
+        const { company, initialState } = buildInitialState();
+
+        const j = await createInstance({ initialState });
+        await j.fact(new Office(company, "LeakedOffice"));
+
+        const result = await j.query(officesInCompany, company);
+        expect(result.map(o => o.identifier).sort()).toEqual(["LeakedOffice", "TestOffice"]);
+    });
+
+    it("starts from a store that holds only its own initial state", async () => {
+        recordRun("second of the isolation pair");
+        const { company, initialState } = buildInitialState();
+
+        // Same fixture as the case above, which wrote one more office into the
+        // store it was given. A helper that shared one store between cases
+        // would show that office here.
+        const j = await createInstance({ initialState });
+
+        const result = await j.query(officesInCompany, company);
+        expect(result.map(o => o.identifier)).toEqual(["TestOffice"]);
+    });
+});
+
+afterAll(async () => {
+    // Every case ran once per store, and the store is named in the suite it ran
+    // under. A helper that registered only the default store would leave one
+    // run per case.
+    for (const [caseName, runs] of runsByCase) {
+        expect(runs.length).toBeGreaterThan(1);
+        expect(runs.filter(name => name.includes("MemoryStore")).length).toBe(1);
+        expect(runs.filter(name => name.includes("IndexedDBStore")).length).toBe(1);
+        expect(caseName).toBeTruthy();
+    }
+    expect(runsByCase.size).toBe(3);
+
+    // The databases the IndexedDB runs allocated were deleted by teardown. A
+    // helper that dropped its stores on the floor would leave one per case.
+    const databases = await indexedDB.databases();
+    expect(databases.filter(database => database.name?.startsWith("test-across-stores-"))).toEqual([]);
+});

--- a/test/specification/missingFactSpec.ts
+++ b/test/specification/missingFactSpec.ts
@@ -1,17 +1,22 @@
-import { Jinaga, JinagaTest, User } from "@src";
+import { Jinaga, User } from "@src";
 import { Company, Office, model } from "../companyModel";
+import { describeAcrossStores } from "../utils/store-factories";
 
-describe("missing fact handling", () => {
+// What a read returns for a given that the store has never seen is a semantic
+// every implementation has to agree on, so these cases run against each one
+// rather than against the `MemoryStore` that `JinagaTest.create` used to
+// construct for itself (issue #252, step 3).
+describeAcrossStores("missing fact handling", (createInstance) => {
     let creator: User;
     let company: Company;
     let office: Office;
     let j: Jinaga;
-    
-    beforeEach(() => {
+
+    beforeEach(async () => {
         creator = new User("--- PUBLIC KEY GOES HERE ---");
         company = new Company(creator, "TestCo");
         office = new Office(company, "TestOffice");
-        j = JinagaTest.create({
+        j = await createInstance({
             initialState: [
                 creator,
                 company,

--- a/test/specification/versioningSpec.ts
+++ b/test/specification/versioningSpec.ts
@@ -1,4 +1,5 @@
-import { JinagaTest, buildModel } from "@src";
+import { buildModel } from "@src";
+import { describeAcrossStores } from "../utils/store-factories";
 
 class Parent {
   static Type = "Parent";
@@ -56,9 +57,12 @@ const childrenOfParentWithFields = model.given(Parent).match((parent, facts) =>
     }))
 );
 
-describe("versioning", () => {
+// Reading a fact written under an earlier version of its type is a read
+// semantic, so it runs against every store rather than only the `MemoryStore`
+// that `JinagaTest.create` used to construct for itself (issue #252, step 3).
+describeAcrossStores("versioning", (createInstance) => {
   it("should read version 1 into version 2", async () => {
-    const j = JinagaTest.create({
+    const j = await createInstance({
       model,
       initialState: [
         new Parent("parent"),
@@ -75,7 +79,7 @@ describe("versioning", () => {
   });
 
   it("should have the same hash", async () => {
-    const j = JinagaTest.create({
+    const j = await createInstance({
       model,
       initialState: [
         new Parent("parent"),

--- a/test/utils/store-factories.ts
+++ b/test/utils/store-factories.ts
@@ -19,20 +19,76 @@ interface StoreUnderTest {
     teardown: (store: Storage) => Promise<void>;
 }
 
-let databaseCount = 0;
+// Names every IndexedDB database this file's suites have allocated. Jest gives
+// each test file its own module registry but can run several files in one
+// worker process, and `indexedDB` is per process — so the names are drawn with
+// a random component to keep two files apart, and a check on what survives has
+// to be made against this list rather than against every database in sight.
+const allocatedDatabaseNames: string[] = [];
+
+/**
+ * The IndexedDB databases the suites in this file have allocated, in the order
+ * they were created. Exposed so `acrossStoresSpec` can check that none of them
+ * outlives the file.
+ */
+export function databasesAllocatedHere(): readonly string[] {
+    return allocatedDatabaseNames;
+}
+
+function allocateDatabaseName(): string {
+    const name = `test-across-stores-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    allocatedDatabaseNames.push(name);
+    return name;
+}
+
+// One entry per deletion this file has started, each settling when that
+// deletion actually finishes — which is later than teardown for a deletion that
+// was blocked. `databaseDeletionsSettled` is how a suite waits for all of them.
+const deletionsFinished: Promise<void>[] = [];
+
+/**
+ * Resolves when every database deletion started by this file's suites has
+ * finished, including one that was blocked at teardown and completed later.
+ * Rejects if any of them failed.
+ *
+ * A deletion whose connection never closes leaves this pending, so a suite that
+ * awaits it fails on the hook timeout rather than passing over a leak.
+ */
+export function databaseDeletionsSettled(): Promise<void> {
+    return Promise.all(deletionsFinished).then(() => { });
+}
 
 function deleteDatabase(name: string): Promise<void> {
     const request = indexedDB.deleteDatabase(name);
+    let finish: () => void;
+    let fail: (error: unknown) => void;
+    const finished = new Promise<void>((resolveFinished, rejectFinished) => {
+        finish = resolveFinished;
+        fail = rejectFinished;
+    });
+    // Held so a failure that nothing awaits before `databaseDeletionsSettled`
+    // does not surface as an unhandled rejection. The rejection is still there
+    // for whoever does await it.
+    finished.catch(() => { });
+    deletionsFinished.push(finished);
+
     return new Promise<void>((resolve, reject) => {
-        request.onsuccess = () => resolve();
-        request.onerror = () => reject(request.error);
-        // A test that leaves an observer running — `watch` without awaiting
-        // `loaded()` — still has a connection open when its store is released,
-        // and the deletion blocks on it. Waiting for that connection would hang
-        // the run, and failing would report a teardown detail as a test
-        // failure. Each store here is given a database name of its own, so one
-        // left undeleted is unreachable by any later test either way; the
-        // deletion stays queued and completes when the connection closes.
+        request.onsuccess = () => { finish(); resolve(); };
+        request.onerror = () => { fail(request.error); reject(request.error); };
+        // Blocked means a connection is still open, and for an observer that
+        // is not something the test can wait out: `Observer.start` issues
+        // `setMruDate` *after* resolving `loaded()`, so a test that awaits
+        // `loaded()` and stops the observer still leaves that write in flight,
+        // with no public signal to await. Measured against a store that counts
+        // its operations: `["read start", "read end", "setMruDate start"]`,
+        // one outstanding, at the moment `stop()` returns.
+        //
+        // So failing here would report the observer's own tail as a failure of
+        // whichever test used `watch`. Resolving does not lose the deletion:
+        // the request stays queued and completes when that write closes its
+        // connection, which `acrossStoresSpec` asserts at the end of its file.
+        // Each store is given a database name of its own, so a deletion still
+        // outstanding is unreachable by any later test in the meantime.
         request.onblocked = () => resolve();
     });
 }
@@ -57,7 +113,7 @@ function storesUnderTest(): StoreUnderTest[] {
         {
             name: "IndexedDBStore",
             createStore: () => {
-                const databaseName = `test-across-stores-${process.pid}-${databaseCount++}`;
+                const databaseName = allocateDatabaseName();
                 const store = new IndexedDBStore(databaseName);
                 databaseNames.set(store, databaseName);
                 return store;

--- a/test/utils/store-factories.ts
+++ b/test/utils/store-factories.ts
@@ -1,0 +1,126 @@
+import { Jinaga, JinagaTest, JinagaTestConfig, MemoryStore, Storage } from "@src";
+import { IndexedDBStore } from "../../src/indexeddb/indexeddb-store";
+
+/**
+ * Creates a test instance backed by the store the surrounding
+ * `describeAcrossStores` block is running against.
+ *
+ * Always asynchronous, and always routed through `JinagaTest.createAsync`, even
+ * for a store whose writes complete synchronously: a suite that reads the
+ * initial state cannot know which store it is running against, and `create`
+ * refuses the combination of a store factory and initial state precisely
+ * because it cannot await the save (issue #274).
+ */
+export type CreateTestInstance = (config: Omit<JinagaTestConfig, "store">) => Promise<Jinaga>;
+
+interface StoreUnderTest {
+    name: string;
+    createStore: () => Storage;
+    teardown: (store: Storage) => Promise<void>;
+}
+
+let databaseCount = 0;
+
+function deleteDatabase(name: string): Promise<void> {
+    const request = indexedDB.deleteDatabase(name);
+    return new Promise<void>((resolve, reject) => {
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+        // A test that leaves an observer running — `watch` without awaiting
+        // `loaded()` — still has a connection open when its store is released,
+        // and the deletion blocks on it. Waiting for that connection would hang
+        // the run, and failing would report a teardown detail as a test
+        // failure. Each store here is given a database name of its own, so one
+        // left undeleted is unreachable by any later test either way; the
+        // deletion stays queued and completes when the connection closes.
+        request.onblocked = () => resolve();
+    });
+}
+
+/**
+ * The store implementations a read-semantics suite runs against.
+ *
+ * `MemoryStore.read` delegates to `SpecificationRunner`, the interpreter that
+ * defines the reference semantics; `IndexedDBStore` answers the same reads from
+ * its own indexes. Running one suite against both is what turns agreement
+ * between them into an assertion rather than an assumption (issue #252).
+ */
+function storesUnderTest(): StoreUnderTest[] {
+    const databaseNames = new Map<Storage, string>();
+
+    return [
+        {
+            name: "MemoryStore",
+            createStore: () => new MemoryStore(),
+            teardown: async () => { }
+        },
+        {
+            name: "IndexedDBStore",
+            createStore: () => {
+                const databaseName = `test-across-stores-${process.pid}-${databaseCount++}`;
+                const store = new IndexedDBStore(databaseName);
+                databaseNames.set(store, databaseName);
+                return store;
+            },
+            teardown: async store => {
+                await store.close();
+                const databaseName = databaseNames.get(store);
+                if (databaseName) {
+                    databaseNames.delete(store);
+                    await deleteDatabase(databaseName);
+                }
+            }
+        }
+    ];
+}
+
+/**
+ * Registers a suite once per store implementation, so the same cases assert the
+ * same semantics against each one.
+ *
+ * The suite body receives a `createInstance` function in place of a direct
+ * `JinagaTest.create` call. Every instance it creates is backed by a store this
+ * block owns, and every such store is released after the test that created it,
+ * so no case observes another's writes.
+ *
+ * ```ts
+ * describeAcrossStores("specification query", createInstance => {
+ *     let j: Jinaga;
+ *     beforeEach(async () => {
+ *         j = await createInstance({ initialState: [ ... ] });
+ *     });
+ *     it("should query for successors", async () => { ... });
+ * });
+ * ```
+ *
+ * @param name Names the suite; the store's name is appended to it.
+ * @param defineSuite Registers the cases, in a `describe` block of its own.
+ */
+export function describeAcrossStores(
+    name: string,
+    defineSuite: (createInstance: CreateTestInstance) => void
+): void {
+    for (const storeUnderTest of storesUnderTest()) {
+        describe(`${name} (${storeUnderTest.name})`, () => {
+            const created: Storage[] = [];
+
+            afterEach(async () => {
+                // Drained rather than iterated, so a teardown that throws still
+                // leaves the list empty for the next test instead of releasing
+                // the same store twice.
+                while (created.length > 0) {
+                    await storeUnderTest.teardown(created.pop()!);
+                }
+            });
+
+            defineSuite(config => JinagaTest.createAsync({
+                ...config,
+                store: () => {
+                    const store = storeUnderTest.createStore();
+                    created.push(store);
+                    return store;
+                }
+            }));
+        });
+    }
+}


### PR DESCRIPTION
Step 3 of #252: lift the read-semantics suites off the `MemoryStore` that `JinagaTest.create` used to construct for itself, and run them against every implementation of `Storage` in this repository.

Stacked on #275 (issue #274). That is a hard dependency, not tidiness: #275 makes `create` refuse initial state alongside a supplied store, so every migrated call site has to route through `createAsync`, and both changes touch `src/jinaga-test.ts`'s contract.

## What this adds

`test/utils/store-factories.ts` — `describeAcrossStores(name, defineSuite)` registers a suite once per store implementation and hands its body a `createInstance` in place of the direct `JinagaTest.create` call. Every instance is backed by a store the block owns and releases after the test that created it, so no case observes another's writes. It routes through `createAsync` unconditionally, because a suite cannot know which store it is running against.

Migrated, each now running against `MemoryStore` and `IndexedDBStore`:

- `test/specification/missingFactSpec.ts`
- `test/specification/versioningSpec.ts`
- `test/fact/factReferenceCompanySpec.ts`
- `test/fact/factReferenceIntegrationSpec.ts`
- `test/fact/factReferenceAcceptanceSpec.ts`

`test/jinaga-test/acrossStoresSpec.ts` pins what the helper promises: each case runs once per store, each run gets a store holding only its own initial state, and the databases the IndexedDB runs allocate are deleted.

## Two divergences it found on the first run, fixed here

Both are in `IndexedDBStore`, and neither is visible to a suite pinned to `MemoryStore`.

**A read whose given the store does not hold failed instead of returning nothing.** `FactSource.findFact` reports an absent fact as `null`, and `SpecificationRunner.read` tests for exactly that before reading through a given. IndexedDB returned the `undefined` that `get` yields for a missing key, and `execRequest<FactRecord>` asserted the difference away, so the short circuit never fired for this store. The read carried on, and projecting the given called `hydrate`, which failed with `TypeError: Cannot read properties of undefined (reading 'filter')` on the ancestor entry an absent fact does not have. `findFact` now reports `null`, and `hydrate` answers a reference it cannot find with `undefined`, as `MemoryStore.hydrate` does.

**A failed read left the database open.** `withDatabase` closed the connection after awaiting the action, so a failure skipped the close, and the next attempt to delete or upgrade the database blocked on the leaked connection indefinitely. That is what turned the TypeError above into a hung test file rather than a failing one. The close moves into a `finally`.

## Regression test, failing before and passing after

`test/indexeddb/indexeddbStoreReadSpec.ts`, at the level of `Storage` rather than through `Jinaga`, because both defects are in the store's own `FactSource` adapter.

Before the change, on `main`'s `src/indexeddb`:

```
✓ returns no results for a given it does not hold        (passes: the successor
                                                          query alone does not
                                                          reach hydrate)
✕ agrees with MemoryStore on a given it does not hold    TypeError: Cannot read
                                                          properties of undefined
                                                          (reading 'filter')
✕ closes the database when a read fails                  Received: "blocked"
● teardown                                               Database deletion blocked
Tests: 2 failed, 1 passed, 3 total
```

The first case is extended in this branch to read the given through both a successor query and an identity projection, which is what makes it fail before the fix as well.

After: all three pass, and `npm ci && npm run build && npm test` is green — 789 tests, 93 suites.

## `querySpec` is deliberately not migrated

Its 25 cases pass against `MemoryStore`. Against `IndexedDBStore`, 14 of 25 fail, and every failure is a permutation of the expected result rather than a different set: `MemoryStore` returns successors in save order, while `IndexedDBStore` reads them from the `predecessor` index of an object store keyed on `['successor', 'predecessor', 'role']`, and so returns them in hash order.

Migrating it would mean either relaxing assertions that have held since the suite was written, or asserting that one of the two stores is wrong. That is a contract question rather than a migration detail, and it blocks the rest of step 3 and step 5 alike, so it is raised on #252 rather than settled here.

## Notes beyond the scope of this change

- `IndexedDBStore.feed` throws `Method not implemented`, so the subscribe-driven suites cannot migrate until it exists. They are untouched here.
- The dependency-style `new MemoryStore()` uses — distribution engine, authorization rules, websocket handlers — stay as they are, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FWre7ETxBYA3w4eu9qWA3

---
_Generated by [Claude Code](https://claude.ai/code/session_013FWre7ETxBYA3w4eu9qWA3)_