### PR TITLE
Apply distribution-rule intersection to held row-stream feeds (#279)

### DIFF
--- a/src/observer/row-stream.ts
+++ b/src/observer/row-stream.ts
@@ -214,9 +214,11 @@ class RowObserver<U> {
         private readonly onFeedDecisions: (decisions: FeedDecision[]) => void
     ) {
         // Row identity stays pre-intersection. An intersected branch keeps the
-        // caller's given labels, match unknowns and projection, and only adds
-        // the synthetic auth labels ahead of them, so this subset identifies
-        // the same row on every branch and matches what `queryRows` produces.
+        // caller's given labels, match unknowns and projection, and adds only
+        // the synthetic auth labels: the `distributionUser` given appended
+        // after the caller's givens, and the lifted auth matches prepended
+        // before the caller's matches. So this subset identifies the same row
+        // on every branch, and matches what `queryRows` produces.
         this.rowIdentityLabels = rowIdentityLabels(specification);
 
         // A single passthrough branch until `applySubscribeIntersection`

--- a/src/observer/row-stream.ts
+++ b/src/observer/row-stream.ts
@@ -176,11 +176,23 @@ class RowQueue<U> {
     }
 }
 
+/**
+ * One distribution-rule intersection of the stream's specification.
+ *
+ * A stream that holds a feed open has one branch per rule that authorizes it,
+ * exactly as `ObserverImpl` does, and one passthrough branch carrying the
+ * caller's own specification when no intersection occurred.
+ */
+interface RowBranch {
+    specification: Specification;
+    listeners: SpecificationListener[];
+    feeds: string[];
+}
+
 class RowObserver<U> {
     private readonly rowIdentityLabels: string[];
-    private readonly givenHash: string;
-    private listeners: SpecificationListener[] = [];
-    private feeds: string[] = [];
+    private givenHash: string;
+    private branches: RowBranch[];
     private stopped = false;
 
     /**
@@ -197,18 +209,30 @@ class RowObserver<U> {
     constructor(
         private readonly factManager: FactManager,
         private readonly specification: Specification,
-        private readonly given: FactReference[],
+        private given: FactReference[],
         private readonly queue: RowQueue<U>,
         private readonly onFeedDecisions: (decisions: FeedDecision[]) => void
     ) {
+        // Row identity stays pre-intersection. An intersected branch keeps the
+        // caller's given labels, match unknowns and projection, and only adds
+        // the synthetic auth labels ahead of them, so this subset identifies
+        // the same row on every branch and matches what `queryRows` produces.
         this.rowIdentityLabels = rowIdentityLabels(specification);
 
+        // A single passthrough branch until `applySubscribeIntersection`
+        // replaces it with one branch per authorizing distribution rule.
+        this.branches = [{ specification, listeners: [], feeds: [] }];
+
+        this.givenHash = this.computeGivenHash(specification);
+    }
+
+    private computeGivenHash(specification: Specification): string {
         const givenSubset = specification.given.map(g => g.label.name);
         const tuple: ReferencesByName = specification.given.reduce((t, label, index) => ({
             ...t,
-            [label.label.name]: given[index]
+            [label.label.name]: this.given[index]
         }), {} as ReferencesByName);
-        this.givenHash = computeTupleSubsetHash(tuple, givenSubset);
+        return computeTupleSubsetHash(tuple, givenSubset);
     }
 
     /**
@@ -222,18 +246,35 @@ class RowObserver<U> {
      * produced one. There is no longer an assembly to get wrong.
      */
     public async start(options: StartOptions): Promise<void> {
-        const inverses = invertSpecification(this.specification)
-            .filter(inverse => inverse.path === "");
+        // Intersect before the listeners are installed, so they are built from
+        // the branch specifications the feed will actually carry. The
+        // intersection itself reads nothing and notifies nothing, so it does
+        // not reopen the window the listener ordering below closes.
+        if (options.feed === "held") {
+            await this.applySubscribeIntersection();
+            if (this.stopped) {
+                return;
+            }
+        }
 
-        Trace.info(`[RowStream] START - From: ${options.from}, Feed: ${options.feed}, Root inverses: ${inverses.length}, Given hash: ${this.givenHash.substring(0, 8)}...`);
+        const rootInverses = this.branches.map(branch => ({
+            branch,
+            inverses: invertSpecification(branch.specification)
+                .filter(inverse => inverse.path === "")
+        }));
+        const inverseCount = rootInverses.reduce((sum, b) => sum + b.inverses.length, 0);
 
-        this.listeners = inverses.map(inverse => this.factManager.addSpecificationListener(
-            inverse.inverseSpecification,
-            results => this.onResult(inverse, results)
-        ));
+        Trace.info(`[RowStream] START - From: ${options.from}, Feed: ${options.feed}, Branches: ${this.branches.length}, Root inverses: ${inverseCount}, Given hash: ${this.givenHash.substring(0, 8)}...`);
+
+        for (const { branch, inverses } of rootInverses) {
+            branch.listeners = inverses.map(inverse => this.factManager.addSpecificationListener(
+                inverse.inverseSpecification,
+                results => this.onResult(inverse, results)
+            ));
+        }
 
         if (options.feed === "held") {
-            await this.openFeed();
+            await this.openFeeds();
         }
         if (options.from === "current") {
             await this.deliverStartingRows(options.feed);
@@ -246,13 +287,15 @@ class RowObserver<U> {
             return;
         }
         this.stopped = true;
-        for (const listener of this.listeners) {
-            this.factManager.removeSpecificationListener(listener);
-        }
-        this.listeners = [];
-        if (this.feeds.length > 0) {
-            this.factManager.unsubscribe(this.feeds);
-            this.feeds = [];
+        for (const branch of this.branches) {
+            for (const listener of branch.listeners) {
+                this.factManager.removeSpecificationListener(listener);
+            }
+            branch.listeners = [];
+            if (branch.feeds.length > 0) {
+                this.factManager.unsubscribe(branch.feeds);
+                branch.feeds = [];
+            }
         }
         this.startupBuffer = null;
         this.startingRowHashes = null;
@@ -261,26 +304,62 @@ class RowObserver<U> {
     }
 
     /**
-     * Hold the specification's feed open for the life of the stream, so facts
-     * arrive from the replicator rather than only from this client's own
-     * writes.
+     * Compose the specification with any distribution rule that authorizes it,
+     * exactly as `ObserverImpl` does before it subscribes.
      *
-     * KNOWN GAP: this does not apply the distribution-rule intersection that
-     * `j.subscribe` performs, so a specification authorized only through an
-     * intersected rule reports `reactive` and delivers nothing. That surfaces
-     * through the diagnostics rather than silently, and closing it means
-     * lifting the branch fan-out out of `ObserverImpl`.
+     * Without this a specification authorized only through an intersected rule
+     * reports `reactive` and delivers nothing (issue #279), or is refused
+     * outright by the in-process engine. With it the authorization pattern
+     * becomes part of the specification, so the stream starts empty and the
+     * inverse engine delivers the backlog when the authorizing fact arrives.
+     *
+     * Each rule that applies becomes its own branch, and the branches are ORed:
+     * a row authorized by any of them is delivered. A row authorized by more
+     * than one arrives once per branch; the stream's contract already has the
+     * consumer deduplicating on `rowHash`, which is stable across branches.
      */
-    private async openFeed(): Promise<void> {
-        const { feeds, decisions } = await this.factManager.subscribe(this.given, this.specification);
-        if (this.stopped) {
-            // stop() ran while we were awaiting; do not leak the subscriber.
-            if (feeds.length > 0) {
-                this.factManager.unsubscribe(feeds);
-            }
+    private async applySubscribeIntersection(): Promise<void> {
+        const branches = await this.factManager.intersectForSubscribe(this.given, this.specification);
+        const passthrough = branches.length === 1
+            && branches[0].specification === this.specification
+            && branches[0].start === this.given;
+        if (passthrough) {
             return;
         }
-        this.feeds = feeds;
+        // Every branch's intersected spec appends the same synthetic
+        // `distributionUser` given, bound to the same user, so one
+        // observer-level `given` and `givenHash` covers them all.
+        this.given = branches[0].start;
+        this.givenHash = this.computeGivenHash(branches[0].specification);
+        this.branches = branches.map(b => ({
+            specification: b.specification,
+            listeners: [],
+            feeds: []
+        }));
+        Trace.info(`[RowStream] INTERSECTED - Branches: ${this.branches.length}, Given hash: ${this.givenHash.substring(0, 8)}...`);
+    }
+
+    /**
+     * Hold each branch's feed open for the life of the stream, so facts arrive
+     * from the replicator rather than only from this client's own writes.
+     */
+    private async openFeeds(): Promise<void> {
+        const decisions: FeedDecision[] = [];
+        await Promise.all(this.branches.map(async branch => {
+            const { feeds, decisions: branchDecisions } = await this.factManager.subscribe(this.given, branch.specification);
+            if (this.stopped) {
+                // stop() ran while we were awaiting; do not leak the subscriber.
+                if (feeds.length > 0) {
+                    this.factManager.unsubscribe(feeds);
+                }
+                return;
+            }
+            branch.feeds = feeds;
+            decisions.push(...branchDecisions);
+        }));
+        if (this.stopped) {
+            return;
+        }
         this.onFeedDecisions(decisions);
     }
 
@@ -305,13 +384,27 @@ class RowObserver<U> {
         if (this.stopped) {
             return;
         }
-        const projectedResults = await this.factManager.read(this.given, this.specification);
+        // One read per branch: each authorizes an independently filtered set,
+        // and a row that more than one branch authorizes is delivered once.
+        const branchResults = await Promise.all(this.branches.map(branch =>
+            this.factManager.read(this.given, branch.specification)));
         if (this.stopped) {
             return;
         }
-        const { rows, totalCount } = toRows<U>(projectedResults, this.specification, this.rowIdentityLabels);
-        Trace.counter("facts_loaded", totalCount);
-        this.startingRowHashes = new Set(rows.map(row => row.rowHash));
+        const rows: SpecificationRow<U>[] = [];
+        const rowHashes = new Set<string>();
+        for (const projectedResults of branchResults) {
+            const branchRows = toRows<U>(projectedResults, this.specification, this.rowIdentityLabels);
+            Trace.counter("facts_loaded", branchRows.totalCount);
+            for (const row of branchRows.rows) {
+                if (rowHashes.has(row.rowHash)) {
+                    continue;
+                }
+                rowHashes.add(row.rowHash);
+                rows.push(row);
+            }
+        }
+        this.startingRowHashes = rowHashes;
         Trace.info(`[RowStream] STARTING ROWS - Rows: ${rows.length}`);
         this.queue.pushStarting(rows);
     }

--- a/test/distribution/rowStreamIntersectionSpec.ts
+++ b/test/distribution/rowStreamIntersectionSpec.ts
@@ -1,0 +1,190 @@
+import { DistributionRules, JinagaTest, Trace, User } from "@src";
+import { Administrator, Company, Office, President, model } from "../companyModel";
+
+// Issue #279: `subscribeRows` resolved its feed without the distribution-rule
+// intersection that `j.subscribe` performs, so a specification authorized only
+// through an intersected rule delivered nothing — reported as `reactive` by the
+// replicator, and refused outright by the in-process engine. The workaround was
+// a distribution rule per consumer matching the consumer's own specification
+// character for character.
+describe("subscribeRows with distribution-rule intersection (#279)", () => {
+    Trace.off();
+
+    const creator = new User("creator");
+    const subscriber = new User("subscriber");
+    const otherUser = new User("other");
+    const company = new Company(creator, "Co");
+
+    const officesOfCompany = model.given(Company).match((c, facts) =>
+        facts.ofType(Office)
+            .join(o => o.company, c)
+    );
+
+    // Share Company → Office with the company's administrators. The subscriber
+    // is not an administrator when the stream starts.
+    const distribution = (r: DistributionRules) => r
+        .share(model.given(Company).match((c, facts) =>
+            facts.ofType(Office)
+                .join(o => o.company, c)
+        ))
+        .with(model.given(Company).match((c, facts) =>
+            facts.ofType(Administrator)
+                .join(a => a.company, c)
+                .selectMany(a => facts.ofType(User).join(u => u, a.user))
+        ));
+
+    it("delivers the backlog when the authorizing fact arrives", async () => {
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution
+        });
+
+        const stream = await j.subscribeRows(officesOfCompany, company);
+        const changes = stream[Symbol.asyncIterator]();
+
+        // Not yet authorized: the stream starts, and starts empty.
+        expect(stream.pending).toEqual(0);
+
+        await j.fact(new Administrator(company, subscriber, new Date("2026-05-26")));
+
+        const first = await changes.next();
+        expect(first.value.operation).toEqual("added");
+        expect(j.hash(first.value.result)).toEqual(j.hash(office));
+
+        stream.stop();
+    });
+
+    it("delivers the rows that already match when the user is already authorized", async () => {
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [
+                creator, subscriber, company, office,
+                new Administrator(company, subscriber, new Date("2026-05-26"))
+            ],
+            distribution
+        });
+
+        const stream = await j.subscribeRows(officesOfCompany, company);
+        const changes = stream[Symbol.asyncIterator]();
+
+        const first = await changes.next();
+        expect(j.hash(first.value.result)).toEqual(j.hash(office));
+
+        stream.stop();
+    });
+
+    it("gives an intersected row the same rowHash that queryRows gives it", async () => {
+        // Intersection appends synthetic auth labels to the specification. Row
+        // identity must stay pre-intersection, or a consumer could not
+        // deduplicate its periodic sweep against the stream.
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [
+                creator, subscriber, company, office,
+                new Administrator(company, subscriber, new Date("2026-05-26"))
+            ],
+            distribution
+        });
+
+        const stream = await j.subscribeRows(officesOfCompany, company);
+        const changes = stream[Symbol.asyncIterator]();
+        const streamed = await changes.next();
+
+        const queried = await j.queryRows(officesOfCompany, company);
+        expect(queried).toHaveLength(1);
+        expect(streamed.value.rowHash).toEqual(queried[0].rowHash);
+
+        stream.stop();
+    });
+
+    it("stays empty when the authorizing fact names a different user", async () => {
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, otherUser, company, office],
+            distribution
+        });
+
+        const stream = await j.subscribeRows(officesOfCompany, company);
+
+        await j.fact(new Administrator(company, otherUser, new Date("2026-05-26")));
+
+        expect(stream.pending).toEqual(0);
+
+        stream.stop();
+    });
+
+    it("delivers a row once when two rules authorize it", async () => {
+        // Two rules over the same share-spec are ORed into two branches. A row
+        // both branches authorize must reach the read's starting rows once.
+        const office = new Office(company, "Office1");
+        const twoRules = (r: DistributionRules) => r
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(Administrator)
+                    .join(a => a.company, c)
+                    .selectMany(a => facts.ofType(User).join(u => u, a.user))
+            ))
+            .share(model.given(Company).match((c, facts) =>
+                facts.ofType(Office).join(o => o.company, c)
+            ))
+            .with(model.given(Company).match((c, facts) =>
+                facts.ofType(President)
+                    .join(p => p.office.company, c)
+                    .selectMany(p => facts.ofType(User).join(u => u, p.user))
+            ));
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution: twoRules
+        });
+
+        const stream = await j.subscribeRows(officesOfCompany, company);
+        const changes = stream[Symbol.asyncIterator]();
+
+        // Neither auth fact exists yet, so the read that starts the stream
+        // finds nothing on either branch.
+        expect(stream.pending).toEqual(0);
+
+        // The President branch alone authorizes the row.
+        await j.fact(new President(office, subscriber));
+        const first = await changes.next();
+        expect(j.hash(first.value.result)).toEqual(j.hash(office));
+
+        stream.stop();
+    });
+
+    it("holds a feed for every branch, and releases them all on stop", async () => {
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [
+                creator, subscriber, company, office,
+                new Administrator(company, subscriber, new Date("2026-05-26"))
+            ],
+            distribution
+        });
+
+        const stream = await j.subscribeRows(officesOfCompany, company);
+        // A second stream over the same specification proves the first
+        // released its feeds: a leaked subscriber would keep them registered.
+        stream.stop();
+
+        const second = await j.subscribeRows(officesOfCompany, company);
+        const changes = second[Symbol.asyncIterator]();
+        expect(j.hash((await changes.next()).value.result)).toEqual(j.hash(office));
+        second.stop();
+    });
+});

--- a/test/distribution/rowStreamIntersectionSpec.ts
+++ b/test/distribution/rowStreamIntersectionSpec.ts
@@ -1,4 +1,8 @@
-import { DistributionRules, JinagaTest, Trace, User } from "@src";
+import {
+    AuthenticationNoOp, DistributionRules, FactEnvelope, FactManager, FactReference, FeedResponse,
+    FeedsResponse, Jinaga, JinagaTest, MemoryStore, Network, NoOpTracer, ObservableSource,
+    PassThroughFork, Specification, SyncStatusNotifier, Trace, Tracer, User
+} from "@src";
 import { Administrator, Company, Office, President, model } from "../companyModel";
 
 // Issue #279: `subscribeRows` resolved its feed without the distribution-rule
@@ -122,11 +126,8 @@ describe("subscribeRows with distribution-rule intersection (#279)", () => {
         stream.stop();
     });
 
-    it("delivers a row once when two rules authorize it", async () => {
-        // Two rules over the same share-spec are ORed into two branches. A row
-        // both branches authorize must reach the read's starting rows once.
-        const office = new Office(company, "Office1");
-        const twoRules = (r: DistributionRules) => r
+    // Two rules over the same share-spec are ORed into two branches.
+    const twoRules = (r: DistributionRules) => r
             .share(model.given(Company).match((c, facts) =>
                 facts.ofType(Office).join(o => o.company, c)
             ))
@@ -143,6 +144,49 @@ describe("subscribeRows with distribution-rule intersection (#279)", () => {
                     .join(p => p.office.company, c)
                     .selectMany(p => facts.ofType(User).join(u => u, p.user))
             ));
+
+    /**
+     * The branch count the stream actually fanned out to, read from the trace
+     * the start emits. Two rules in the rule set do not imply two branches:
+     * `intersectForSubscribe` intersects only when the user is not already
+     * authorized, so what a test needs to pin is the fan-out, not the rules.
+     */
+    async function branchesOnStart(start: () => Promise<{ stop(): void }>): Promise<number> {
+        const lines: string[] = [];
+        Trace.configure(new class extends NoOpTracer implements Tracer {
+            info(message: string): void {
+                if (message.includes("[RowStream] START")) {
+                    lines.push(message);
+                }
+            }
+        }());
+        let stream;
+        try {
+            stream = await start();
+        }
+        finally {
+            Trace.configure(new NoOpTracer());
+        }
+        stream.stop();
+        const match = /Branches: (\d+)/.exec(lines[0]);
+        return Number(match![1]);
+    }
+
+    it("fans out to one branch per rule when the user is not yet authorized", async () => {
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [creator, subscriber, company, office],
+            distribution: twoRules
+        });
+
+        expect(await branchesOnStart(() => j.subscribeRows(officesOfCompany, company)))
+            .toEqual(2);
+    });
+
+    it("starts on whichever of two ORed rules authorizes the user", async () => {
+        const office = new Office(company, "Office1");
         const j = JinagaTest.create({
             model,
             user: subscriber,
@@ -163,6 +207,91 @@ describe("subscribeRows with distribution-rule intersection (#279)", () => {
         expect(j.hash(first.value.result)).toEqual(j.hash(office));
 
         stream.stop();
+    });
+
+    it("does not fan out when the user is already authorized outright", async () => {
+        // Both auth facts present: `canDistributeToAll` succeeds, so the
+        // intersection is a passthrough and the rule count is irrelevant.
+        // This is why holding both auth facts does NOT exercise the
+        // cross-branch read — that needs the stub below.
+        const office = new Office(company, "Office1");
+        const j = JinagaTest.create({
+            model,
+            user: subscriber,
+            initialState: [
+                creator, subscriber, company, office,
+                new Administrator(company, subscriber, new Date("2026-05-26")),
+                new President(office, subscriber)
+            ],
+            distribution: twoRules
+        });
+
+        expect(await branchesOnStart(() => j.subscribeRows(officesOfCompany, company)))
+            .toEqual(1);
+    });
+
+    it("delivers a row once when two branches both match it", async () => {
+        // The cross-branch dedup in `deliverStartingRows`, at the level of the
+        // mechanism rather than end to end. A network that hands back two
+        // branches matching the same rows is what an OR over two rules looks
+        // like to the row stream; the in-process engine cannot produce that
+        // state deterministically, because a rule whose auth fact is present
+        // authorizes the user outright and collapses the fan-out (above).
+        //
+        // Without the dedup this office arrives twice.
+        class TwoBranchNetwork implements Network {
+            feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse> {
+                return Promise.resolve({ feeds: ["feed-one"] });
+            }
+
+            fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
+                return Promise.resolve({ references: [], bookmark });
+            }
+
+            streamFeed(feed: string, bookmark: string, onResponse: (factReferences: FactReference[], nextBookmark: string) => Promise<void>): () => void {
+                void onResponse([], bookmark);
+                return () => { };
+            }
+
+            load(factReferences: FactReference[]): Promise<FactEnvelope[]> {
+                return Promise.resolve([]);
+            }
+
+            async intersectForSubscribe(start: FactReference[], specification: Specification) {
+                return [
+                    { start, specification },
+                    { start, specification }
+                ];
+            }
+        }
+
+        const store = new MemoryStore();
+        const factManager = new FactManager(
+            new PassThroughFork(store), new ObservableSource(store), store, new TwoBranchNetwork(), []);
+        const j = new Jinaga(new AuthenticationNoOp(), factManager, new SyncStatusNotifier());
+
+        const persistedCreator = await j.fact(creator);
+        const persistedCompany = await j.fact(new Company(persistedCreator, "Co"));
+        const office = await j.fact(new Office(persistedCompany, "Office1"));
+
+        const stream = await j.subscribeRows(officesOfCompany, persistedCompany);
+        try {
+            // `pending` is exact, and nothing has been consumed yet, so this is
+            // the whole starting set: the second branch's copy of the same row
+            // was collapsed rather than queued. Read before consuming, so a
+            // regression fails this assertion rather than parking a consumer
+            // on a `next()` that never resolves.
+            expect(stream.pending).toEqual(1);
+
+            const changes = stream[Symbol.asyncIterator]();
+            const first = await changes.next();
+            expect(j.hash(first.value.result)).toEqual(j.hash(office));
+        }
+        finally {
+            // Release the held feed even when an assertion above fails, so a
+            // failure is reported rather than hanging the run on an open feed.
+            stream.stop();
+        }
     });
 
     it("holds a feed for every branch, and releases them all on stop", async () => {


### PR DESCRIPTION
Fixes #279.

## Reproduced first

A `JinagaTest` client whose only authorization for `Company → Office` comes through a `share().with()` rule, subscribing with `subscribeRows`:

```
Not authorized: Cannot distribute to (p1: Company) { u1: Office [ u1->company: Company = p1 ] }
The user does not match ... => u2
```

The in-process engine refuses outright; against the real replicator the same missing intersection surfaces as the `reactive` decision the issue describes, and the stream silently delivers nothing. `j.subscribe` on the identical specification succeeds and pushes the backlog when the authorizing fact arrives — the gap was that the row-stream path never called `intersectForSubscribe`.

## The change

`RowObserver` now fans out into branches the way `ObserverImpl` does, and only when the stream holds a feed (`subscribeRows` / `subscribeChanges`); `watchRows` and `watchChanges` are untouched.

- Intersect **before** installing listeners, so the listeners are built from the branch specifications the feed actually carries. The intersection reads nothing and notifies nothing, so it does not reopen the T2–T3 window the listener-before-read ordering closes.
- One feed per branch, all released on `stop()`. Per-branch feed decisions are collected and reported through the existing `onFeedDecisions` sink in one call, so diagnostics still name the caller's specification.
- One read per branch, with the starting rows deduplicated on `rowHash`. Multiple branches are the OR across matching rules; a row that more than one branch authorizes is delivered once from the read.

Row identity stays pre-intersection. An intersected branch keeps the caller's given labels, match unknowns and projection, and adds only the synthetic auth labels — the `distributionUser` given **appended after** the caller's givens, and the lifted auth matches **prepended before** the caller's matches. So a row keeps the hash `queryRows` gives it, which is what lets a durable consumer deduplicate its periodic sweep against the stream. A test pins that.

The `KNOWN GAP` comment at `src/observer/row-stream.ts:268` is replaced by the doc comment for the new step.

## Tests

New: `test/distribution/rowStreamIntersectionSpec.ts`, nine cases — backlog delivered when the authorizing fact arrives; rows delivered when already authorized; the intersected row's `rowHash` equals `queryRows`'; nothing delivered when the auth fact names a different user; the branch fan-out itself (two branches when not yet authorized, one when the rules authorize outright); either of two ORed rules starting the stream; a row delivered once when two branches both match it; feeds released on stop.

Two rules in the rule set do not imply two branches — `intersectForSubscribe` intersects only when the user is not already authorized, so holding every auth fact collapses the fan-out to a passthrough. The cross-branch dedup is therefore pinned at the level of the mechanism, with a `Network` stub returning two branches over the same rows, and verified by mutation: deleting the `rowHashes.has` guard fails it with `Expected: 1, Received: 2`.

- **Against `origin/main`'s `row-stream.ts`**: 5 of the 9 fail. The 4 that pass are guards on paths this change must not alter.
- **After the change**: 9 passing.

Full suite: `npm ci && npm run build && npm test` green — 800 tests, up from 792.

## Note beyond the diff

Change notifications, unlike the starting rows, are not deduplicated across branches: a row authorized by two rules can arrive twice, and a `removed` from one branch does not check whether another branch still authorizes the row. `ObserverImpl` handles that with per-row vote counting, which the row stream deliberately cannot do — holding a delivered-row set for the life of the stream is the unbounded growth its design avoids, and its contract already has the consumer deduplicating on `rowHash` with a periodic `queryRows` sweep as the source of truth. Recorded as a comment rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbZpokAMiNsAbFaGHnjR2t