### PR TITLE
Let a caller bound a subscription's start-up (#280)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export { validateSpecification, validateSpecificationOrThrow } from './specifica
 export { detectDisconnectedSpecification, DisconnectedSpecificationError } from "./specification/UnionFind";
 export { computeTupleSubsetHash, FactEnvelope, factEnvelopeEquals, FactFeed, FactRecord, FactReference, factReferenceEquals, FactSignature, FactTuple, PredecessorCollection, ProjectedResult, Queue, ReferencesByName, Storage, uniqueFactReferences, validateGiven } from './storage';
 export { UserIdentity } from './user-identity';
-export { ValidationError } from './util/errors';
+export { FeedTimeoutError, ValidationError } from './util/errors';
 export { delay } from './util/promise';
 export { ConsoleTracer, NoOpTracer, Trace, Tracer } from './util/trace';
 

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -468,13 +468,14 @@ export class Jinaga {
      * held feed and without a periodic `queryRows` sweep, a client observes
      * only what it saved itself.
      *
-     * This awaits the feed's first response, so a caller on a boot path should
-     * bound it with `feedTimeoutMs` or start it without awaiting. Unbounded, a
-     * replicator that accepts the connection and never answers holds the boot
-     * path open with no signal that anything is wrong (issue #280).
+     * This awaits the replicator -- registering the feeds, then their first
+     * response -- so a caller on a boot path should bound it with
+     * `feedTimeoutMs` or start it without awaiting. Unbounded, a replicator
+     * that accepts the connection and never answers holds the boot path open
+     * with no signal that anything is wrong (issue #280).
      *
      * @param specification Use Model.given().match() to create a specification
-     * @param args The fact or facts from which to begin, optionally followed by options; `capacity` sizes the queue of undelivered changes, and `feedTimeoutMs` bounds the wait for the feed's first response
+     * @param args The fact or facts from which to begin, optionally followed by options; `capacity` sizes the queue of undelivered changes, and `feedTimeoutMs` bounds the wait for the replicator, covering feed registration and the first response together
      * @returns A stream; iterate it, and call stop() to release the feed
      */
     async subscribeRows<T extends unknown[], U>(
@@ -488,11 +489,11 @@ export class Jinaga {
      * Subscribe to only the changes, with the feed held open: nothing is
      * delivered for a row that already matches.
      *
-     * Like `subscribeRows`, this awaits the feed's first response, and
-     * `feedTimeoutMs` bounds that wait.
+     * Like `subscribeRows`, this awaits the replicator, and `feedTimeoutMs`
+     * bounds that wait.
      *
      * @param specification Use Model.given().match() to create a specification
-     * @param args The fact or facts from which to begin, optionally followed by options; `capacity` sizes the queue of undelivered changes, and `feedTimeoutMs` bounds the wait for the feed's first response
+     * @param args The fact or facts from which to begin, optionally followed by options; `capacity` sizes the queue of undelivered changes, and `feedTimeoutMs` bounds the wait for the replicator, covering feed registration and the first response together
      * @returns A stream; iterate it, and call stop() to release the feed
      */
     async subscribeChanges<T extends unknown[], U>(

--- a/src/jinaga.ts
+++ b/src/jinaga.ts
@@ -468,8 +468,13 @@ export class Jinaga {
      * held feed and without a periodic `queryRows` sweep, a client observes
      * only what it saved itself.
      *
+     * This awaits the feed's first response, so a caller on a boot path should
+     * bound it with `feedTimeoutMs` or start it without awaiting. Unbounded, a
+     * replicator that accepts the connection and never answers holds the boot
+     * path open with no signal that anything is wrong (issue #280).
+     *
      * @param specification Use Model.given().match() to create a specification
-     * @param args The fact or facts from which to begin, optionally followed by options; `capacity` sizes the queue of undelivered changes
+     * @param args The fact or facts from which to begin, optionally followed by options; `capacity` sizes the queue of undelivered changes, and `feedTimeoutMs` bounds the wait for the feed's first response
      * @returns A stream; iterate it, and call stop() to release the feed
      */
     async subscribeRows<T extends unknown[], U>(
@@ -483,8 +488,11 @@ export class Jinaga {
      * Subscribe to only the changes, with the feed held open: nothing is
      * delivered for a row that already matches.
      *
+     * Like `subscribeRows`, this awaits the feed's first response, and
+     * `feedTimeoutMs` bounds that wait.
+     *
      * @param specification Use Model.given().match() to create a specification
-     * @param args The fact or facts from which to begin, optionally followed by options; `capacity` sizes the queue of undelivered changes
+     * @param args The fact or facts from which to begin, optionally followed by options; `capacity` sizes the queue of undelivered changes, and `feedTimeoutMs` bounds the wait for the feed's first response
      * @returns A stream; iterate it, and call stop() to release the feed
      */
     async subscribeChanges<T extends unknown[], U>(

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -7,6 +7,8 @@ import { FeedCache } from "../specification/feed-cache";
 import { Specification, reduceSpecification } from "../specification/specification";
 import { FactEnvelope, FactReference, ReferencesByName, Storage, factReferenceEquals } from "../storage";
 import { computeStringHash } from "../util/encoding";
+import { FeedTimeoutError } from "../util/errors";
+import { TIMED_OUT, withTimeout } from "../util/promise";
 import { Trace } from "../util/trace";
 
 export interface Network {
@@ -266,6 +268,17 @@ interface CachedFeedRegistration {
     specification: Specification;
 }
 
+/**
+ * One caller's bound on a subscription's start, carried as an absolute instant
+ * so the two round trips it covers share a budget rather than each taking the
+ * whole of it. `timeoutMs` rides along for the message and the error, which
+ * report what the caller asked for rather than what was left at that moment.
+ */
+interface FeedDeadline {
+    readonly at: number;
+    readonly timeoutMs: number;
+}
+
 export class NetworkManager {
     // Each entry carries the response *and* what it was registered from, so a
     // feed the replicator has forgotten can be registered again (issue #243).
@@ -377,9 +390,29 @@ export class NetworkManager {
         return [{ start, specification }];
     }
 
-    async subscribe(start: FactReference[], specification: Specification): Promise<CachedFeeds> {
+    /**
+     * Register the specification's feeds and hold them open, resolving when
+     * each has answered once.
+     *
+     * `feedTimeoutMs` bounds that wait (issue #280). It is opt-in because a
+     * cold start on a large candidate set can legitimately take minutes, and a
+     * default would turn a slow success into a retry loop. One deadline spans
+     * both round trips rather than one per phase, so a caller asking for five
+     * seconds waits five seconds rather than ten.
+     *
+     * Expiry takes the same cleanup path a failure takes: the feeds leave the
+     * cache and the subscribers are released. Without that, the subscriber
+     * created a moment ago would keep its connection open with a reference
+     * nobody holds, which is the leak an abandoned `await` hides.
+     */
+    async subscribe(start: FactReference[], specification: Specification, feedTimeoutMs?: number): Promise<CachedFeeds> {
         const reducedSpecification = reduceSpecification(specification);
-        const { feeds, decisions } = await this.getFeedsFromCache(start, reducedSpecification);
+        const deadline: FeedDeadline | undefined = feedTimeoutMs === undefined
+            ? undefined
+            : { at: Date.now() + feedTimeoutMs, timeoutMs: feedTimeoutMs };
+        const { feeds, decisions } = await this.withDeadline(
+            this.getFeedsFromCache(start, reducedSpecification), deadline,
+            "register the feeds for a subscription");
 
         const subscribers = feeds.map(feed => {
             let subscriber = this.subscribers.get(feed);
@@ -409,7 +442,8 @@ export class NetworkManager {
         });
 
         try {
-            await Promise.all(promises);
+            await this.withDeadline(Promise.all(promises), deadline,
+                "receive the first response from a subscribed feed");
         }
         catch (e) {
             // If any feed fails, then remove the specification from the cache.
@@ -421,6 +455,31 @@ export class NetworkManager {
         // can surface diagnostics (issue #207 W5/W6) while still using `feeds`
         // for its keep-alive/unsubscribe bookkeeping.
         return { feeds, decisions };
+    }
+
+    /**
+     * Await `promise` until the deadline, or without a bound when there is
+     * none. `action` completes "waiting to ...", so the message names the
+     * round trip that did not answer rather than the method that gave up.
+     */
+    private async withDeadline<T>(promise: Promise<T>, deadline: FeedDeadline | undefined, action: string): Promise<T> {
+        if (deadline === undefined) {
+            return await promise;
+        }
+        const remaining = deadline.at - Date.now();
+        const expired = () => new FeedTimeoutError(
+            `Timed out after ${deadline.timeoutMs} ms waiting to ${action}.`, deadline.timeoutMs);
+        // A budget the earlier phase already spent has to be reported here:
+        // withTimeout reads a non-positive bound as no bound at all, so racing
+        // on it would wait forever, which is what the caller asked not to do.
+        if (remaining <= 0) {
+            throw expired();
+        }
+        const result = await withTimeout(promise, remaining);
+        if (result === TIMED_OUT) {
+            throw expired();
+        }
+        return result as T;
     }
 
     unsubscribe(feeds: string[]) {

--- a/src/managers/NetworkManager.ts
+++ b/src/managers/NetworkManager.ts
@@ -7,7 +7,7 @@ import { FeedCache } from "../specification/feed-cache";
 import { Specification, reduceSpecification } from "../specification/specification";
 import { FactEnvelope, FactReference, ReferencesByName, Storage, factReferenceEquals } from "../storage";
 import { computeStringHash } from "../util/encoding";
-import { FeedTimeoutError } from "../util/errors";
+import { FeedTimeoutError, ValidationError } from "../util/errors";
 import { TIMED_OUT, withTimeout } from "../util/promise";
 import { Trace } from "../util/trace";
 
@@ -404,8 +404,18 @@ export class NetworkManager {
      * cache and the subscribers are released. Without that, the subscriber
      * created a moment ago would keep its connection open with a reference
      * nobody holds, which is the leak an abandoned `await` hides.
+     *
+     * A bound that is not a positive, finite number is refused rather than
+     * ignored. `NaN` and `Infinity` both arrive at `withTimeout`, which reads a
+     * non-finite bound as no bound at all, so accepting them would silently
+     * restore the unbounded wait this option exists to prevent -- in the one
+     * case where the caller believes they set a bound.
      */
     async subscribe(start: FactReference[], specification: Specification, feedTimeoutMs?: number): Promise<CachedFeeds> {
+        if (feedTimeoutMs !== undefined && !(Number.isFinite(feedTimeoutMs) && feedTimeoutMs > 0)) {
+            throw new ValidationError(
+                `A feed timeout must be a positive, finite number of milliseconds, but received ${feedTimeoutMs}.`);
+        }
         const reducedSpecification = reduceSpecification(specification);
         const deadline: FeedDeadline | undefined = feedTimeoutMs === undefined
             ? undefined

--- a/src/managers/factManager.ts
+++ b/src/managers/factManager.ts
@@ -122,9 +122,13 @@ export class FactManager {
         return await this.networkManager.fetch(start, specification);
     }
 
-    async subscribe(start: FactReference[], specification: Specification): Promise<CachedFeeds> {
+    /**
+     * Hold the specification's feeds open. `feedTimeoutMs`, when given, bounds
+     * the wait for the replicator's first response (issue #280).
+     */
+    async subscribe(start: FactReference[], specification: Specification, feedTimeoutMs?: number): Promise<CachedFeeds> {
         this.purgeManager.checkCompliance(specification);
-        return await this.networkManager.subscribe(start, specification);
+        return await this.networkManager.subscribe(start, specification, feedTimeoutMs);
     }
 
     async intersectForSubscribe(start: FactReference[], specification: Specification): Promise<DistributionIntersectionBranch[]> {

--- a/src/observer/row-stream.ts
+++ b/src/observer/row-stream.ts
@@ -33,6 +33,28 @@ export interface RowStreamOptions {
      * bounded.
      */
     capacity?: number;
+
+    /**
+     * Milliseconds to wait for the feed's first response before giving up,
+     * failing the start with a `FeedTimeoutError`.
+     *
+     * Opt-in, and deliberately without a default (issue #280). A cold start on
+     * a large candidate set can legitimately take minutes, so a default bound
+     * would turn a slow success into a retry loop; that trap has been sprung
+     * here before, in a supervisor that timed out first loads. Without this the
+     * wait has no bound at all, so a replicator that accepts the connection and
+     * never answers leaves the returned promise pending, and a service that
+     * awaits `subscribeRows` during boot never reaches its listener.
+     *
+     * Set it when a caller has somewhere better to be than the replicator's
+     * first response: a boot path, a health check, a supervisor that retries.
+     * Size it against a cold start rather than a warm one.
+     *
+     * It bounds the feed, so it applies to `subscribeRows` and
+     * `subscribeChanges`. `watchRows` and `watchChanges` hold no feed and
+     * ignore it.
+     */
+    feedTimeoutMs?: number;
 }
 
 export const DEFAULT_ROW_STREAM_CAPACITY = 1024;
@@ -84,6 +106,7 @@ interface StartOptions {
     from: RowOrigin;
     feed: FeedPolicy;
     capacity?: number;
+    feedTimeoutMs?: number;
 }
 
 /**
@@ -276,7 +299,7 @@ class RowObserver<U> {
         }
 
         if (options.feed === "held") {
-            await this.openFeeds();
+            await this.openFeeds(options.feedTimeoutMs);
         }
         if (options.from === "current") {
             await this.deliverStartingRows(options.feed);
@@ -344,11 +367,20 @@ class RowObserver<U> {
     /**
      * Hold each branch's feed open for the life of the stream, so facts arrive
      * from the replicator rather than only from this client's own writes.
+     *
+     * `feedTimeoutMs` bounds the wait for the replicator's first response
+     * (issue #280). It is the caller's, and there is no default: see
+     * `RowStreamOptions.feedTimeoutMs`. Every branch is given the same bound
+     * and they run concurrently, so it bounds the start rather than each
+     * branch in turn. On expiry the subscriptions are released before the
+     * error propagates, so nothing is left holding a connection: the ones that
+     * timed out by the cleanup inside `subscribe`, and any branch that answers
+     * afterwards by the `stopped` check below.
      */
-    private async openFeeds(): Promise<void> {
+    private async openFeeds(feedTimeoutMs?: number): Promise<void> {
         const decisions: FeedDecision[] = [];
         await Promise.all(this.branches.map(async branch => {
-            const { feeds, decisions: branchDecisions } = await this.factManager.subscribe(this.given, branch.specification);
+            const { feeds, decisions: branchDecisions } = await this.factManager.subscribe(this.given, branch.specification, feedTimeoutMs);
             if (this.stopped) {
                 // stop() ran while we were awaiting; do not leak the subscriber.
                 if (feeds.length > 0) {

--- a/src/observer/row-stream.ts
+++ b/src/observer/row-stream.ts
@@ -35,8 +35,15 @@ export interface RowStreamOptions {
     capacity?: number;
 
     /**
-     * Milliseconds to wait for the feed's first response before giving up,
-     * failing the start with a `FeedTimeoutError`.
+     * Milliseconds to wait for the replicator before giving up, failing the
+     * start with a `FeedTimeoutError`.
+     *
+     * It bounds the whole exchange the start waits on, not only its second
+     * half: registering the specification's feeds and then receiving the first
+     * response on each. A silent replicator hangs at either, and one budget
+     * covers both, so the bound is what the caller asked for rather than twice
+     * it. Must be a positive, finite number; anything else is refused rather
+     * than quietly ignored.
      *
      * Opt-in, and deliberately without a default (issue #280). A cold start on
      * a large candidate set can legitimately take minutes, so a default bound
@@ -46,9 +53,9 @@ export interface RowStreamOptions {
      * never answers leaves the returned promise pending, and a service that
      * awaits `subscribeRows` during boot never reaches its listener.
      *
-     * Set it when a caller has somewhere better to be than the replicator's
-     * first response: a boot path, a health check, a supervisor that retries.
-     * Size it against a cold start rather than a warm one.
+     * Set it when a caller has somewhere better to be than the replicator: a
+     * boot path, a health check, a supervisor that retries. Size it against a
+     * cold start rather than a warm one.
      *
      * It bounds the feed, so it applies to `subscribeRows` and
      * `subscribeChanges`. `watchRows` and `watchChanges` hold no feed and
@@ -368,11 +375,11 @@ class RowObserver<U> {
      * Hold each branch's feed open for the life of the stream, so facts arrive
      * from the replicator rather than only from this client's own writes.
      *
-     * `feedTimeoutMs` bounds the wait for the replicator's first response
-     * (issue #280). It is the caller's, and there is no default: see
-     * `RowStreamOptions.feedTimeoutMs`. Every branch is given the same bound
-     * and they run concurrently, so it bounds the start rather than each
-     * branch in turn. On expiry the subscriptions are released before the
+     * `feedTimeoutMs` bounds the wait for the replicator, registration and
+     * first response together (issue #280). It is the caller's, and there is
+     * no default: see `RowStreamOptions.feedTimeoutMs`. Every branch is given
+     * the same bound and they run concurrently, so it bounds the start rather
+     * than each branch in turn. On expiry the subscriptions are released before the
      * error propagates, so nothing is left holding a connection: the ones that
      * timed out by the cleanup inside `subscribe`, and any branch that answers
      * afterwards by the `stopped` check below.

--- a/src/util/errors.ts
+++ b/src/util/errors.ts
@@ -15,3 +15,21 @@ export class ValidationError extends Error {
         Object.setPrototypeOf(this, ValidationError.prototype);
     }
 }
+
+/**
+ * Thrown when a caller's opt-in bound on a feed's first response expires
+ * (issue #280). A replicator that accepts the connection and never answers
+ * leaves a subscription's start pending forever, which puts a service that
+ * awaits it during boot behind a machine it may never hear from.
+ *
+ * It is a distinct type rather than a `ValidationError` because it says
+ * nothing about the request: the same call may well succeed on the next
+ * attempt. Callers retry on this and give up on that.
+ */
+export class FeedTimeoutError extends Error {
+    constructor(message: string, public readonly timeoutMs: number) {
+        super(message);
+        this.name = 'FeedTimeoutError';
+        Object.setPrototypeOf(this, FeedTimeoutError.prototype);
+    }
+}

--- a/test/observable/rowStreamSpec.ts
+++ b/test/observable/rowStreamSpec.ts
@@ -1,7 +1,7 @@
 import {
     AuthenticationNoOp, FactEnvelope, FactManager, FactReference, FeedResponse, FeedTimeoutError,
     FeedsResponse, Jinaga, JinagaTest, MemoryStore, NoOpTracer, ObservableSource, PassThroughFork,
-    Specification, SyncStatusNotifier, Trace, Tracer, User, buildModel
+    Specification, SyncStatusNotifier, Trace, Tracer, User, ValidationError, buildModel
 } from "@src";
 import { Network } from "@src";
 
@@ -702,6 +702,22 @@ describe("subscribeRows start-up bound", () => {
 
         await expect(j.subscribeRows(outstandingTasks, project, { feedTimeoutMs: 50 }))
             .rejects.toThrow(FeedTimeoutError);
+        expect(network.opened).toEqual([]);
+    });
+
+    it("refuses a bound that is not a positive, finite number", async () => {
+        const network = new SilentNetwork();
+        const j = createWithNetwork(network);
+        const project = await projectOn(j);
+
+        // NaN and Infinity reach `withTimeout`, which reads a non-finite bound
+        // as no bound at all. Accepting either would silently restore the
+        // unbounded wait in the one case where the caller believes they set a
+        // bound, so they are refused where a malformed argument is refused.
+        for (const bad of [NaN, Infinity, 0, -1]) {
+            await expect(j.subscribeRows(outstandingTasks, project, { feedTimeoutMs: bad }))
+                .rejects.toThrow(ValidationError);
+        }
         expect(network.opened).toEqual([]);
     });
 

--- a/test/observable/rowStreamSpec.ts
+++ b/test/observable/rowStreamSpec.ts
@@ -1,7 +1,7 @@
 import {
-    AuthenticationNoOp, FactEnvelope, FactManager, FactReference, FeedResponse, FeedsResponse,
-    Jinaga, JinagaTest, MemoryStore, NoOpTracer, ObservableSource, PassThroughFork, Specification,
-    SyncStatusNotifier, Trace, Tracer, User, buildModel
+    AuthenticationNoOp, FactEnvelope, FactManager, FactReference, FeedResponse, FeedTimeoutError,
+    FeedsResponse, Jinaga, JinagaTest, MemoryStore, NoOpTracer, ObservableSource, PassThroughFork,
+    Specification, SyncStatusNotifier, Trace, Tracer, User, buildModel
 } from "@src";
 import { Network } from "@src";
 
@@ -568,6 +568,182 @@ describe("subscribeRows", () => {
         expect(network.opened).toEqual(["feed-one"]);
         expect(stream.pending).toEqual(0);
 
+        stream.stop();
+        expect(network.closed).toEqual(["feed-one"]);
+    });
+});
+
+describe("subscribeRows start-up bound", () => {
+    // Issue #280: subscribeRows awaits the feed's first response, so a
+    // replicator that accepts the connection and never answers holds the
+    // caller's boot path open with nothing it can set and no signal that
+    // anything is wrong. feedTimeoutMs is that bound, and it is opt-in
+    // because a cold start can legitimately take minutes.
+
+    /**
+     * A replicator that answers only when the test says so.
+     *
+     * `answer()` is what the real one does when it has nothing new. Until it
+     * is called the connection is open and silent, which is the shape the
+     * issue reports.
+     */
+    class SilentNetwork implements Network {
+        public opened: string[] = [];
+        public closed: string[] = [];
+        private responders: (() => void)[] = [];
+
+        constructor(public feedsAnswer: Promise<FeedsResponse> = Promise.resolve({ feeds: ["feed-one"] })) { }
+
+        feeds(start: FactReference[], specification: Specification): Promise<FeedsResponse> {
+            return this.feedsAnswer;
+        }
+
+        fetchFeed(feed: string, bookmark: string): Promise<FeedResponse> {
+            return Promise.resolve({ references: [], bookmark });
+        }
+
+        streamFeed(feed: string, bookmark: string, onResponse: (factReferences: FactReference[], nextBookmark: string) => Promise<void>, onError: (err: Error) => void): () => void {
+            this.opened.push(feed);
+            this.responders.push(() => { void onResponse([], bookmark); });
+            return () => { this.closed.push(feed); };
+        }
+
+        answer(): void {
+            const responders = this.responders;
+            this.responders = [];
+            for (const respond of responders) {
+                respond();
+            }
+        }
+
+        load(factReferences: FactReference[]): Promise<FactEnvelope[]> {
+            return Promise.resolve([]);
+        }
+
+        async intersectForSubscribe(start: FactReference[], specification: Specification) {
+            return [{ start, specification }];
+        }
+    }
+
+    function createWithNetwork(network: Network) {
+        const store = new MemoryStore();
+        const observableSource = new ObservableSource(store);
+        const factManager = new FactManager(new PassThroughFork(store), observableSource, store, network, []);
+        return new Jinaga(new AuthenticationNoOp(), factManager, new SyncStatusNotifier());
+    }
+
+    async function projectOn(j: Jinaga) {
+        const creator = await j.fact(new User("--- CREATOR ---"));
+        return await j.fact(new Project(creator, "one"));
+    }
+
+    // Yield to the macrotask queue, which drains every microtask behind it.
+    // Not a wait for async work: nothing here is scheduled on a timer, so a
+    // subscription that has settled has settled by the time this returns.
+    const flush = () => new Promise<void>(resolve => setImmediate(resolve));
+
+    it("fails the start when the replicator does not answer within the bound", async () => {
+        const network = new SilentNetwork();
+        const j = createWithNetwork(network);
+        const project = await projectOn(j);
+
+        // A real timer, because the timer is the feature. 50 ms is long enough
+        // that the connection is open before it fires and short enough to fail
+        // fast; the assertion is on which error arrives, not on when.
+        const start = j.subscribeRows(outstandingTasks, project, { feedTimeoutMs: 50 });
+
+        await expect(start).rejects.toThrow(FeedTimeoutError);
+        await expect(start).rejects.toThrow(/50 ms/);
+    });
+
+    it("releases the subscription when the bound expires", async () => {
+        const network = new SilentNetwork();
+        const j = createWithNetwork(network);
+        const project = await projectOn(j);
+
+        await expect(j.subscribeRows(outstandingTasks, project, { feedTimeoutMs: 50 }))
+            .rejects.toThrow(FeedTimeoutError);
+
+        // The connection the abandoned await left behind is closed rather than
+        // held open by a reference nobody has.
+        expect(network.opened).toEqual(["feed-one"]);
+        expect(network.closed).toEqual(["feed-one"]);
+    });
+
+    it("subscribes again after a bound expires", async () => {
+        const network = new SilentNetwork();
+        const j = createWithNetwork(network);
+        const project = await projectOn(j);
+        await j.fact(new Task(project, "backlog"));
+
+        await expect(j.subscribeRows(outstandingTasks, project, { feedTimeoutMs: 50 }))
+            .rejects.toThrow(FeedTimeoutError);
+
+        // The feed left the cache and the subscriber was released, so a retry
+        // registers from scratch rather than joining the abandoned one.
+        const retry = j.subscribeRows(outstandingTasks, project, { feedTimeoutMs: 50 });
+        await flush();
+        network.answer();
+        const stream = await retry;
+
+        expect(network.opened).toEqual(["feed-one", "feed-one"]);
+        const changes = stream[Symbol.asyncIterator]();
+        expect((await changes.next()).value.result.description).toEqual("backlog");
+
+        stream.stop();
+    });
+
+    it("bounds the feed registration, not only its first response", async () => {
+        // POST /feeds is the other half of the round trip a caller cannot
+        // bound. A replicator silent here never reaches streamFeed at all.
+        const network = new SilentNetwork(new Promise<FeedsResponse>(() => { }));
+        const j = createWithNetwork(network);
+        const project = await projectOn(j);
+
+        await expect(j.subscribeRows(outstandingTasks, project, { feedTimeoutMs: 50 }))
+            .rejects.toThrow(FeedTimeoutError);
+        expect(network.opened).toEqual([]);
+    });
+
+    it("leaves a slow feed alone when the caller sets no bound", async () => {
+        const network = new SilentNetwork();
+        const j = createWithNetwork(network);
+        const project = await projectOn(j);
+        await j.fact(new Task(project, "backlog"));
+
+        let settled = false;
+        const start = j.subscribeRows(outstandingTasks, project);
+        void start.then(() => { settled = true; }, () => { settled = true; });
+
+        await flush();
+        expect(settled).toBe(false);
+
+        // The default is no bound at all, so the slow start succeeds rather
+        // than becoming a retry loop.
+        network.answer();
+        const stream = await start;
+        const changes = stream[Symbol.asyncIterator]();
+        expect((await changes.next()).value.result.description).toEqual("backlog");
+
+        stream.stop();
+    });
+
+    it("does not disturb a feed that answers within the bound", async () => {
+        const network = new SilentNetwork();
+        const j = createWithNetwork(network);
+        const project = await projectOn(j);
+        await j.fact(new Task(project, "backlog"));
+
+        const start = j.subscribeRows(outstandingTasks, project, { feedTimeoutMs: 60_000 });
+        await flush();
+        network.answer();
+        const stream = await start;
+
+        const changes = stream[Symbol.asyncIterator]();
+        expect((await changes.next()).value.result.description).toEqual("backlog");
+
+        // A bound that did not fire leaves nothing behind: the feed is open,
+        // and stop() releases it as it does without one.
         stream.stop();
         expect(network.closed).toEqual(["feed-one"]);
     });


### PR DESCRIPTION
Fixes #280.

Stacked on #281 (issue #279). Its commit is the base of this branch.

## The shape

`subscribeRows` awaits the replicator with no bound the caller can set. A replicator that accepts the connection and never answers therefore leaves the returned promise pending, with no signal that anything is wrong, and a service that awaits `start()` during boot puts its HTTP listener behind a machine it may never hear from.

Reproduced before changing anything, with a `Network` whose `streamFeed` accepts the connection and never calls `onResponse`: `await j.subscribeRows(...)` never settles, and the process stays open afterward because the subscriber it created is still holding a connection nobody has a reference to.

## The change

`RowStreamOptions` gains `feedTimeoutMs`. It is opt-in and has no default, as the issue asks: a cold start on a large candidate set can legitimately take minutes, so a default bound would turn a slow success into a retry loop.

The bound lives in `NetworkManager.subscribe`, because that is where the cleanup lives:

- **One deadline spans both round trips** — registering the feeds with `POST /feeds`, then the first response on each — so a caller asking for five seconds waits five seconds rather than ten. A silent replicator hangs at either, and only bounding the second would leave the first unbounded.
- **Expiry takes the same path a failure takes.** The feeds leave the cache and the subscribers are released, through the `catch` that was already there. A timeout that merely abandoned the `await` would leave the connection open with a reference nobody holds — the leak the reproduction shows.
- It reuses the existing `withTimeout` helper in `src/util/promise.ts`, which already handles the late settle of an abandoned promise.
- A bound that is not a positive, finite number is refused as a `ValidationError`. `NaN` and `Infinity` both reach `withTimeout`, which reads a non-finite bound as no bound at all, so accepting them would silently restore the unbounded wait in the one case where the caller believes they set a bound.

Failure to answer in time arrives as `FeedTimeoutError` (exported), distinct from `ValidationError` because it says nothing about the request: the same call may well succeed on the next attempt. Callers retry on this and give up on that.

`watchRows` and `watchChanges` hold no feed and ignore the option; that is stated on the option itself.

## Regression tests

Seven, in `test/observable/rowStreamSpec.ts`, against a network that answers only when the test says so.

**Before** (the deadline neutralized at its source, types kept so the suite compiles), four fail by hanging past the test timeout, which is the reported symptom:

```
● subscribeRows start-up bound › fails the start when the replicator does not answer within the bound
● subscribeRows start-up bound › releases the subscription when the bound expires
● subscribeRows start-up bound › subscribes again after a bound expires
● subscribeRows start-up bound › bounds the feed registration, not only its first response
    thrown: "Exceeded timeout of 8000 ms for a test."
✔ 2 passing  ✘ 4 failing
```

The two that pass either way pin what must not change: a slow feed with no bound still succeeds, and a bound that does not fire leaves the stream exactly as it was. The seventh, added from the review below, covers the malformed bounds (`NaN`, `Infinity`, `0`, `-1`) and would hang the same way without the validation.

**After**: `npm ci && npm run build && npm test` green on this branch — 804 passing, 94 suites, including the seven here and the six from the layer below.

The one real timer in these tests is the bound itself, which is the feature under test rather than a wait for async work; everything else yields through `setImmediate`, which drains the microtasks behind it. Both are commented in place.

## Review round

Copilot raised three findings, all verified against the code and all addressed in the second commit: the `NaN` hole above, and two places where the documentation claimed the bound covered only the first response while the implementation also covers registration. The docs now say what the code does.

## Noted, not fixed

`watchRows`'s one-time `fetch` is the same unbounded wait on a different call, and `NetworkManager.fetch` shares its in-flight promise across callers through `activeFeeds`, so bounding it means deciding what an abandoned share does to the others. Out of scope here; recorded rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012N5KDUUechBwiQLZ3EBWcs