### PR TITLE
Refresh night-shift-worker with the purposes section

### DIFF
--- a/.claude/skills/night-shift-worker/SKILL.md
+++ b/.claude/skills/night-shift-worker/SKILL.md
@@ -20,6 +20,18 @@ Your dispatch names an **issue**, and optionally a lower issue to stack on. If i
 
 ---
 
+## What these instructions serve
+
+Two purposes stand behind every rule in this skill and behind the dispatch that sent you.
+
+**Progress.** The run exists to move the repository forward. Ambiguity that has an obvious resolution is not a reason to stall.
+
+**Truthfulness.** What a run writes is checked against the real, current artifacts rather than assumed from prior wording. Read the released package, the merged diff, or the running system.
+
+**Where an instruction's literal wording would violate the purpose it was written to serve, follow the purpose.** Then say so plainly in the pull request, under its own heading, as a factual report rather than an apology. A deviation you reported is a finding the maintainer needs. A deviation you buried is a defect.
+
+---
+
 ## Before you start
 
 Read `.night-shift/config.md` at the repository root. It carries everything about this repository that the protocol does not fix: what to read first, how to reproduce, which commands must be green, which workflow gates the merge, and what happens after the pull request opens.
@@ -79,7 +91,15 @@ Record a blocking question when proceeding either way could produce the wrong pa
 
 Record one **also** at the far end of a run, when the work is finished and the issue still is not: the shape does not reproduce anywhere you can reach, and settling it needs a capture from a live system, a reproduction repo, or an answer from the reporter. Left in the queue, an issue like that draws a fresh claim check every night and re-derives a verification that is already complete.
 
-To record one:
+**A gap and a stale instruction are not the same thing, and only one of them is a question.**
+
+A **genuine gap** is something nobody has decided yet. The issue does not say, the code does not settle it, and either choice could be the wrong patch. Raise it here and do not resolve it alone.
+
+A **stale instruction** is something already decided, where the ground has since moved. A release now ships what the wording assumed absent, a dependency merged, or a measured fact changed. That is not a gap, and it does not need a maintainer to decide it again. Carry the decision out against current reality, and report the deviation from the literal wording in the pull request.
+
+What separates them is what you would be deciding. Reading a settled decision against today's artifacts is your job. Changing what was decided is the maintainer's, and where the config forbids a change outright, that prohibition holds and the question is the only move.
+
+To record a question:
 
 1. Comment on the issue. State what you found, why it blocks you, the candidate answers, and what you would do under each. Make it answerable in one reply. If a pull request already exists, post it there too and link it from the issue comment.
 2. Remove the queue label and add `question`.

--- a/.night-shift/skills.md
+++ b/.night-shift/skills.md
@@ -8,7 +8,7 @@ run wakes.
 
 | Skill | Upstream commit |
 |---|---|
-| `night-shift-worker` | `19ad2657e3bb4ad9ff3f1005021e1d1b2a629a66` |
+| `night-shift-worker` | `20a7f51914f8b10939c3a7b22c8c4b82a682ab0f` |
 
 To take an upstream change, re-copy the skill directory, update the commit
 above, and read the diff before you push. Local edits to an installed skill


### PR DESCRIPTION
Takes `factoryengineering/skills@20a7f51` into this repository's installed copy of the worker skill. Closes #284.

## The gap this fills

The skill told a run to record a blocking question rather than guess. That rule covers a **genuine gap**, meaning something nobody has decided yet.

It did not cover an instruction that is **already decided**, where the ground under it has since moved: a release now ships what the wording assumed absent, a dependency merged, or a measured fact changed. The literal wording and the purpose behind it then point in opposite directions, and a run had two of the skill's own rules to weigh against each other with no tiebreaker.

The precedent is a sweep of `jinaga/jinaga-worker` on a spec amendment whose instruction paired a known-gap bullet with a version reference. The only release satisfying the version half also closed the gap the bullet described. The worker verified that by unpacking both npm tarballs, dropped the bullet, and reported the deviation in jinaga/jinaga-worker#44. The outcome was right, and the skill offered no rule that said so, so it was filed as a transgression to confess.

## What the upstream change adds

A new section, `## What these instructions serve`, before the first procedural section, so a run reads it before the checklist and holds it through the work.

| Purpose | What it asks of a run |
|---|---|
| **Progress** | Move the repository forward. Ambiguity with an obvious resolution is not a reason to stall. |
| **Truthfulness** | Check what you write against the real, current artifacts. Read the released package, the merged diff, or the running system. |

Then one rule. Where an instruction's literal wording would violate the purpose it was written to serve, follow the purpose, and say so in the pull request under its own heading, as a factual report rather than an apology.

`## When to stop and ask instead` then draws the line. A gap is a question and stays one. A stale instruction is carried out against current reality and reported. What separates them is whether you would be reading a settled decision or changing one, and where a repository's config forbids a change outright, that prohibition holds and the question is the only move.

`To record one:` becomes `To record a question:`, because three paragraphs now sit between it and its referent.

## Verification

- `npm run build` — green.
- `npm test` — 807 passing across 94 suites. Unchanged.
- No source file changes. The diff is `.claude/skills/night-shift-worker/SKILL.md` and the provenance sha in `.night-shift/skills.md`.

The installed copy matched upstream `19ad265` byte for byte before this change, and matches `20a7f51` exactly after it. The same reinstall goes to `jinaga/jinaga-worker`, closing #48 there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhzwtrfMrKJb7qaN7sEqay
